### PR TITLE
fix(security): Restrict CORS to specific origins

### DIFF
--- a/.squad/log/2026-04-12T16-15-00Z-insurance-feature.md
+++ b/.squad/log/2026-04-12T16-15-00Z-insurance-feature.md
@@ -1,0 +1,39 @@
+# Session Log: Insurance Feature Delivery
+
+**Date:** 2026-04-12T16:15:00Z  
+**Topic:** Insurance Policies Standalone CRUD Feature  
+**Issue:** #18  
+**PR:** #30 (merged to main)
+
+## Who Worked
+
+- **Hockney** (Backend Dev) — Insurance API + DB models + Alembic migration
+- **Fenster** (Frontend Dev) — Insurance page + After I Leave integration + navigation
+
+## What Was Done
+
+1. Implemented insurance policies as standalone CRUD table (not snapshot-embedded)
+2. Built `/api/insurance` endpoint with GET/POST/PUT/DELETE
+3. Created `/insurance` page with full UI (add/edit/delete modals)
+4. Integrated real insurance data into After I Leave family sections
+5. Updated SummaryTable to pull real policies
+6. Added "Insurance Policies" nav link under "Family" section
+
+## Key Decisions
+
+- `sum_insured` stored as string (supports both monetary and descriptive formats)
+- Type enum validated server-side (extensible without migrations)
+- Owner values: "You" / "Partner" (matching pension pattern)
+- Frontend gracefully handles API unavailability (demo fallback)
+
+## Outcomes
+
+✅ Feature complete and merged  
+✅ API contract established and implemented  
+✅ Both agents working in parallel (zero blocking)  
+✅ No impact on existing finance/pension systems
+
+## Next Steps
+
+- Real policies populate net-worth and asset allocation views (follow-up story)
+- Consider premium aggregation in family financial planning

--- a/.squad/orchestration-log/2026-04-12T16-15-00Z-fenster-insurance-page.md
+++ b/.squad/orchestration-log/2026-04-12T16-15-00Z-fenster-insurance-page.md
@@ -1,0 +1,60 @@
+# Orchestration: Fenster — Insurance Page & After I Leave Integration
+
+**Timestamp:** 2026-04-12T16:15:00Z  
+**Agent:** Fenster (Frontend Dev)  
+**Issue:** #18  
+**PR:** #30 (merged)
+
+## What Fenster Built
+
+1. **Insurance Policies Page** (`apps/frontend/src/app/insurance/page.tsx`)
+   - Full CRUD UI for insurance policies
+   - Display table with columns: Type, Provider, Policy #, Sum Insured, Monthly Premium, Expiry, Owner, Actions
+   - Add/edit/delete modals
+   - Graceful error handling for missing API
+
+2. **After I Leave Integration** (`apps/frontend/src/app/after-i-leave/page.tsx`)
+   - Life Insurance section now pulls real policies (type: `life`) from API instead of demo
+   - Mortgage Protection section pulls real policies (type: `mortgage`) instead of demo
+   - Falls back to demo if API unavailable
+
+3. **Summary Updates** (`components/SummaryTable.tsx`)
+   - Insurance rows now show real data when API available
+   - Swaps demo insurance items for actual policies
+
+4. **Navigation** (`MainLayout.tsx`)
+   - Added "Insurance Policies" nav link under new "Family" section
+   - Styled consistent with existing UI
+
+## API Contract Established
+
+```
+GET /api/insurance → { status: "success", data: InsurancePolicy[] }
+POST /api/insurance → { status: "success", data: InsurancePolicy }
+PUT /api/insurance/{id} → { status: "success", data: InsurancePolicy }
+DELETE /api/insurance/{id} → { status: "success" }
+```
+
+**InsurancePolicy TypeScript shape:**
+- `id?: string`
+- `type: 'Life' | 'Mortgage' | 'Health' | 'Disability' | 'Other'`
+- `provider: string`
+- `policy_number?: string`
+- `sum_insured?: string` (flexible text)
+- `monthly_premium?: number | null`
+- `beneficiaries?: string`
+- `expiry_date?: string` (ISO date)
+- `website?: string`
+- `notes?: string`
+- `owner: string` ('You' or 'Partner')
+
+## Outcome
+
+✅ **SUCCESS** — Frontend fully functional, waiting on backend API (consumed in parallel). PR #30 merged to main.
+
+## Notes
+
+- Frontend gracefully handles API unavailability (empty state, demo fallback)
+- `sum_insured` intentionally string (supports "₪2,000,000" and "Covers remaining mortgage")
+- Type enum normalized to title-case for display (backend validates lowercase)
+- Next phase: integrate real policies into net-worth & asset allocation views

--- a/.squad/orchestration-log/2026-04-12T16-15-00Z-hockney-insurance-api.md
+++ b/.squad/orchestration-log/2026-04-12T16-15-00Z-hockney-insurance-api.md
@@ -1,0 +1,41 @@
+# Orchestration: Hockney — Insurance Policies API & Database
+
+**Timestamp:** 2026-04-12T16:15:00Z  
+**Agent:** Hockney (Backend Dev)  
+**Issue:** #18  
+**PR:** #30 (merged)
+
+## What Hockney Built
+
+1. **Insurance API** (`apps/backend/app/api/insurance.py`)
+   - GET `/api/insurance` — list all policies, optional `?owner=` filter
+   - POST `/api/insurance` — create new policy
+   - PUT `/api/insurance/{id}` — update policy
+   - DELETE `/api/insurance/{id}` — delete policy
+   - Standard JSON responses: `{ status: "success", data: ... }`
+
+2. **Data Models** (`apps/backend/app/schema/`)
+   - `InsurancePolicy` Pydantic model (financial schema)
+   - DB schema: `insurance_policies` table, UUID PK, standalone CRUD
+   - Type enum server-side validated (`life`, `mortgage`, `health`, `disability`, `other`)
+   - `sum_insured` stored as string (flexible text for mixed formats)
+   - `owner` enum (`You` / `Partner`) matching pension pattern
+
+3. **Database** 
+   - Alembic migration added (tracked)
+   - No impact on existing finance/pension systems
+   - Standalone reference-data table (no time-series, no snapshot embedding)
+
+4. **Integration**
+   - Updated `apps/backend/main.py` router registration
+   - Updated `apps/backend/app/schema/models.py` with InsurancePolicy exports
+
+## Outcome
+
+✅ **SUCCESS** — API ready for frontend integration. Fenster successfully consumed contract in parallel. PR #30 merged to main.
+
+## Notes
+
+- `sum_insured` kept as free-text by design (supports both monetary "₪2,000,000" and descriptive "Covers remaining mortgage")
+- Enum values are lowercase in DB, display strings (title-case) handled by frontend
+- Future: Could add monthly_premium aggregation to family net-worth reports

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -72,9 +72,16 @@ app = FastAPI(lifespan=lifespan)
 # Instrument FastAPI
 FastAPIInstrumentor.instrument_app(app)
 
+# CORS: restrict origins. Set CORS_ORIGINS env var (comma-separated) for production.
+cors_origins = [
+    o.strip()
+    for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
+    if o.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
Closes #3

Replaces `allow_origins=['*']` with `CORS_ORIGINS` env var (comma-separated). Defaults to `http://localhost:3000` for development.

**Changes:** `apps/backend/main.py` — 8 lines added, 1 removed.
**Tests:** 136 passed, 2 pre-existing failures (need Postgres).