### PR TITLE
polish(analyze): Error boundaries, retry, responsive layout (#6)

### DIFF
--- a/.squad/decisions/inbox/fenster-analyze-polish.md
+++ b/.squad/decisions/inbox/fenster-analyze-polish.md
@@ -1,0 +1,26 @@
+# Decision: Analyze Page — Shared Components & Error Resilience
+
+**Author:** Fenster (Frontend)
+**Date:** 2025-07-24
+**Issue:** #6 — Company Analysis polish for v0.0.1
+
+## Context
+
+The Analyze page had duplicated skeleton/error UI across ShortTermView and LongTermView, no per-section error isolation, no retry support in shortterm hooks, and rigid grid layouts on mobile.
+
+## Decisions
+
+1. **Extracted `shared/` component library** — SkeletonCard, ErrorBanner (with optional `onRetry`), SectionErrorBoundary (React class error boundary), and EmptyState live under `Analyze/shared/` with a barrel export. Both views now import from this single source.
+
+2. **Per-section error boundaries** — Every data-driven section in both views is wrapped in `<SectionErrorBoundary>`. A crash in one section (e.g. chart rendering) no longer takes down the entire page.
+
+3. **Retry on all hooks** — All 4 shortterm hooks (`useTechnicals`, `usePriceHistory`, `useSynthesis`, `useOptionChain`) now expose `refetch` via `useCallback`. Longterm hooks already had this. Each section's ErrorBanner wires to the relevant hook's `refetch`.
+
+4. **Mobile-responsive grids** — FinancialScorecard changed from `grid-cols-2` to `grid-cols-1 sm:grid-cols-2`. ShortTermView grids changed from `md:grid-cols-2` to `sm:grid-cols-2` for earlier breakpoint.
+
+5. **Improved empty & error states** — No-ticker-selected now shows an EmptyState with suggestions. Invalid-ticker errors show a descriptive message with icon and retry button.
+
+## Trade-offs
+
+- SectionErrorBoundary is a class component (React requirement for error boundaries). This is the only class component in the codebase.
+- The `shared/` folder is scoped to Analyze. If other pages need these components later, they can be promoted to a top-level `shared/` or `ui/` directory.

--- a/apps/frontend/src/components/Analyze/AnalyzePage.tsx
+++ b/apps/frontend/src/components/Analyze/AnalyzePage.tsx
@@ -5,6 +5,7 @@ import TickerSearch from "./TickerSearch";
 import SplitBrainToggle, { type AnalysisMode } from "./SplitBrainToggle";
 import LongTermView from "./LongTermView";
 import ShortTermView from "./ShortTermView";
+import { SectionErrorBoundary, EmptyState } from "./shared";
 
 export default function AnalyzePage() {
     const [ticker, setTicker] = useState<string | null>(null);
@@ -27,19 +28,17 @@ export default function AnalyzePage() {
 
                 {ticker && (
                     <div className="mt-8">
-                        {mode === "long-term" ? (
-                            <LongTermView ticker={ticker} />
-                        ) : (
-                            <ShortTermView ticker={ticker} />
-                        )}
+                        <SectionErrorBoundary sectionName={mode === "long-term" ? "Long-Term View" : "Short-Term View"}>
+                            {mode === "long-term" ? (
+                                <LongTermView ticker={ticker} />
+                            ) : (
+                                <ShortTermView ticker={ticker} />
+                            )}
+                        </SectionErrorBoundary>
                     </div>
                 )}
 
-                {!ticker && (
-                    <div className="flex items-center justify-center min-h-[300px]">
-                        <p className="text-slate-600 text-lg">Enter a ticker symbol above to start analyzing.</p>
-                    </div>
-                )}
+                {!ticker && <EmptyState />}
             </div>
         </div>
     );

--- a/apps/frontend/src/components/Analyze/ShortTermView.tsx
+++ b/apps/frontend/src/components/Analyze/ShortTermView.tsx
@@ -10,28 +10,10 @@ import MomentumPanel from "./shortterm/MomentumPanel";
 import AIPriceAction from "./shortterm/AIPriceAction";
 import OptionChainSnapshot from "./shortterm/OptionChainSnapshot";
 import BreakevenVisualizer from "./shortterm/BreakevenVisualizer";
+import { SkeletonCard, ErrorBanner, SectionErrorBoundary } from "./shared";
 
 interface ShortTermViewProps {
     ticker: string;
-}
-
-function SkeletonCard({ className = "" }: { className?: string }) {
-    return (
-        <div className={`bg-slate-900 border border-slate-800 rounded-xl p-6 animate-pulse ${className}`}>
-            <div className="h-4 bg-slate-800 rounded w-1/3 mb-4" />
-            <div className="h-8 bg-slate-800 rounded w-1/2 mb-3" />
-            <div className="h-3 bg-slate-800 rounded w-2/3 mb-2" />
-            <div className="h-3 bg-slate-800 rounded w-1/2" />
-        </div>
-    );
-}
-
-function ErrorBanner({ message }: { message: string }) {
-    return (
-        <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 text-red-400 text-sm">
-            ⚠️ {message}
-        </div>
-    );
 }
 
 export default function ShortTermView({ ticker }: ShortTermViewProps) {
@@ -40,69 +22,75 @@ export default function ShortTermView({ ticker }: ShortTermViewProps) {
     const priceHistory = usePriceHistory(ticker);
     const synthesis = useSynthesis(ticker);
 
-    const anyLoading = technicals.loading || options.loading || priceHistory.loading || synthesis.loading;
-    const errors = [technicals.error, options.error, priceHistory.error, synthesis.error].filter(Boolean);
-
     return (
         <div className="space-y-6">
             <h2 className="text-lg font-semibold text-slate-300">
                 Short-Term Analysis — <span className="text-white font-mono">{ticker}</span>
             </h2>
 
-            {errors.length > 0 && (
-                <div className="space-y-2">
-                    {errors.map((err, i) => <ErrorBanner key={i} message={err!} />)}
-                </div>
-            )}
+            {/* Per-section errors with retry */}
+            {technicals.error && <ErrorBanner message={technicals.error} onRetry={technicals.refetch} />}
+            {priceHistory.error && <ErrorBanner message={priceHistory.error} onRetry={priceHistory.refetch} />}
+            {options.error && <ErrorBanner message={options.error} onRetry={options.refetch} />}
+            {synthesis.error && <ErrorBanner message={synthesis.error} onRetry={synthesis.refetch} />}
 
             {/* Top pane: Candlestick chart */}
-            {priceHistory.loading ? (
-                <SkeletonCard className="min-h-[340px]" />
-            ) : priceHistory.data.length > 0 ? (
-                <CandlestickChart priceData={priceHistory.data} />
-            ) : null}
+            <SectionErrorBoundary sectionName="Candlestick Chart">
+                {priceHistory.loading ? (
+                    <SkeletonCard className="min-h-[340px]" />
+                ) : priceHistory.data.length > 0 ? (
+                    <CandlestickChart priceData={priceHistory.data} />
+                ) : null}
+            </SectionErrorBoundary>
 
             {/* Middle pane: Momentum + AI Price Action */}
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <div className="lg:col-span-2">
-                    {technicals.loading ? (
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                            <SkeletonCard />
-                            <SkeletonCard />
-                        </div>
-                    ) : technicals.data ? (
-                        <MomentumPanel technicals={technicals.data} />
-                    ) : null}
+                    <SectionErrorBoundary sectionName="Momentum Panel">
+                        {technicals.loading ? (
+                            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                                <SkeletonCard />
+                                <SkeletonCard />
+                            </div>
+                        ) : technicals.data ? (
+                            <MomentumPanel technicals={technicals.data} />
+                        ) : null}
+                    </SectionErrorBoundary>
                 </div>
                 <div>
-                    {synthesis.loading ? (
-                        <SkeletonCard />
-                    ) : synthesis.data?.price_action_summary ? (
-                        <AIPriceAction summary={synthesis.data.price_action_summary} />
-                    ) : null}
+                    <SectionErrorBoundary sectionName="AI Price Action">
+                        {synthesis.loading ? (
+                            <SkeletonCard />
+                        ) : synthesis.data?.price_action_summary ? (
+                            <AIPriceAction summary={synthesis.data.price_action_summary} />
+                        ) : null}
+                    </SectionErrorBoundary>
                 </div>
             </div>
 
             {/* Bottom pane: Option Chain + Breakeven */}
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                {options.loading ? (
-                    <>
+                <SectionErrorBoundary sectionName="Option Chain">
+                    {options.loading ? (
                         <SkeletonCard className="min-h-[300px]" />
-                        <SkeletonCard className="min-h-[300px]" />
-                    </>
-                ) : options.data ? (
-                    <>
+                    ) : options.data ? (
                         <OptionChainSnapshot
                             data={options.data}
                             expiry={options.expiry}
                             onExpiryChange={options.setExpiry}
                         />
+                    ) : null}
+                </SectionErrorBoundary>
+                <SectionErrorBoundary sectionName="Breakeven Visualizer">
+                    {options.loading ? (
+                        <SkeletonCard className="min-h-[300px]" />
+                    ) : options.data ? (
                         <BreakevenVisualizer
                             currentPrice={options.data.current_price}
                             puts={options.data.puts}
                         />
-                    </>
-                ) : null}
+                    ) : null}
+                </SectionErrorBoundary>
             </div>
         </div>
     );

--- a/apps/frontend/src/components/Analyze/longterm/FinancialScorecard.tsx
+++ b/apps/frontend/src/components/Analyze/longterm/FinancialScorecard.tsx
@@ -44,7 +44,7 @@ export default function FinancialScorecard({ financials, loading }: FinancialSco
     return (
       <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
         <h3 className="text-lg font-semibold text-white mb-4">Financial Scorecard</h3>
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {[1, 2, 3, 4].map((i) => <SkeletonCard key={i} />)}
         </div>
       </div>
@@ -67,7 +67,7 @@ export default function FinancialScorecard({ financials, loading }: FinancialSco
   return (
     <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
       <h3 className="text-lg font-semibold text-white mb-4">Financial Scorecard</h3>
-      <div className="grid grid-cols-2 gap-3">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <MetricCard
           label="ROIC vs WACC"
           value={roicSpread !== null ? `${roicSpread > 0 ? "+" : ""}${fmt(roicSpread, "pp")}` : "N/A"}

--- a/apps/frontend/src/components/Analyze/longterm/LongTermView.tsx
+++ b/apps/frontend/src/components/Analyze/longterm/LongTermView.tsx
@@ -10,6 +10,10 @@ import ValuationBenchmarks from "./ValuationBenchmarks";
 import DCFCalculator from "./DCFCalculator";
 import AISynthesis from "./AISynthesis";
 import GrowthStory from "./GrowthStory";
+import {
+  ErrorBanner,
+  SectionErrorBoundary,
+} from "../shared";
 
 interface LongTermViewProps {
   ticker: string;
@@ -46,18 +50,22 @@ export default function LongTermView({ ticker }: LongTermViewProps) {
 
   const currentPrice = fundamentals.data?.current_price ?? 0;
 
-  // Show error state
-  if (fundamentals.error) {
+  // Full-page error only for invalid/unknown tickers (404)
+  if (fundamentals.error && !fundamentals.loading) {
     return (
       <div className="space-y-6">
         <h2 className="text-lg font-semibold text-slate-300">
           Long-Term Analysis — <span className="text-white font-mono">{ticker}</span>
         </h2>
-        <div className="bg-red-950/30 border border-red-900/50 rounded-xl p-6 text-center">
-          <p className="text-red-400">{fundamentals.error}</p>
+        <div className="bg-red-950/30 border border-red-900/50 rounded-xl p-8 text-center">
+          <div className="text-4xl mb-3">&#x1F50D;</div>
+          <p className="text-red-400 font-medium mb-1">{fundamentals.error}</p>
+          <p className="text-slate-500 text-sm mb-4">
+            Check the ticker symbol and try again. If the issue persists, the data source may be temporarily unavailable.
+          </p>
           <button
             onClick={fundamentals.refetch}
-            className="mt-3 px-4 py-2 text-sm bg-slate-800 text-slate-300 rounded-lg hover:bg-slate-700 transition-colors"
+            className="px-5 py-2.5 text-sm bg-slate-800 text-slate-300 rounded-lg hover:bg-slate-700 transition-colors"
           >
             Retry
           </button>
@@ -77,10 +85,15 @@ export default function LongTermView({ ticker }: LongTermViewProps) {
         )}
       </h2>
 
+      {/* Per-section errors for non-critical data */}
+      {priceHistory.error && <ErrorBanner message={priceHistory.error} onRetry={priceHistory.refetch} />}
+      {synthesis.error && <ErrorBanner message={synthesis.error} onRetry={synthesis.refetch} />}
+
       {/* Top row: Price chart + AI Synthesis / Growth Story */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         <div className="lg:col-span-2">
-          <PriceChartWithFairValue
+          <SectionErrorBoundary sectionName="Price Chart">
+            <PriceChartWithFairValue
             priceData={priceHistory.data}
             fairValue={dcfFairValue}
             currentPrice={currentPrice}
@@ -88,8 +101,10 @@ export default function LongTermView({ ticker }: LongTermViewProps) {
             period={period}
             onPeriodChange={setPeriod}
           />
+          </SectionErrorBoundary>
         </div>
         <div>
+          <SectionErrorBoundary sectionName="AI Synthesis">
           {!showGrowthStory ? (
             <div className="space-y-3">
               <AISynthesis data={synthesis.data} loading={synthesis.loading} />
@@ -103,26 +118,33 @@ export default function LongTermView({ ticker }: LongTermViewProps) {
           ) : (
             <GrowthStory ticker={ticker} />
           )}
+          </SectionErrorBoundary>
         </div>
       </div>
 
       {/* Middle row: Financial Scorecard */}
-      <FinancialScorecard
-        financials={fundamentals.data?.financials ?? null}
-        loading={fundamentals.loading}
-      />
-
-      {/* Bottom row: Valuation + DCF Calculator */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <ValuationBenchmarks
+      <SectionErrorBoundary sectionName="Financial Scorecard">
+        <FinancialScorecard
           financials={fundamentals.data?.financials ?? null}
           loading={fundamentals.loading}
         />
-        <DCFCalculator
-          dcfInputs={fundamentals.data?.dcf_inputs ?? null}
-          currentPrice={currentPrice}
-          loading={fundamentals.loading}
-        />
+      </SectionErrorBoundary>
+
+      {/* Bottom row: Valuation + DCF Calculator */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <SectionErrorBoundary sectionName="Valuation Benchmarks">
+          <ValuationBenchmarks
+            financials={fundamentals.data?.financials ?? null}
+            loading={fundamentals.loading}
+          />
+        </SectionErrorBoundary>
+        <SectionErrorBoundary sectionName="DCF Calculator">
+          <DCFCalculator
+            dcfInputs={fundamentals.data?.dcf_inputs ?? null}
+            currentPrice={currentPrice}
+            loading={fundamentals.loading}
+          />
+        </SectionErrorBoundary>
       </div>
     </div>
   );

--- a/apps/frontend/src/components/Analyze/shared/EmptyState.tsx
+++ b/apps/frontend/src/components/Analyze/shared/EmptyState.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+
+export default function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] text-center px-4">
+      <div className="text-5xl mb-4" aria-hidden="true">&#x1F4CA;</div>
+      <h2 className="text-xl font-semibold text-slate-300 mb-2">
+        No ticker selected
+      </h2>
+      <p className="text-slate-500 max-w-md">
+        Enter a ticker symbol above to start analyzing. Get fundamental data,
+        valuation metrics, and AI-powered insights.
+      </p>
+      <div className="mt-6 flex items-center gap-3 text-sm text-slate-600">
+        <span className="px-2 py-1 bg-slate-800 rounded font-mono">AAPL</span>
+        <span className="px-2 py-1 bg-slate-800 rounded font-mono">MSFT</span>
+        <span className="px-2 py-1 bg-slate-800 rounded font-mono">GOOGL</span>
+        <span className="text-slate-700">Try one of these</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Analyze/shared/ErrorBanner.tsx
+++ b/apps/frontend/src/components/Analyze/shared/ErrorBanner.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import React from "react";
+
+interface ErrorBannerProps {
+  message: string;
+  onRetry?: () => void;
+}
+
+export default function ErrorBanner({ message, onRetry }: ErrorBannerProps) {
+  return (
+    <div className="bg-red-900/30 border border-red-800 rounded-xl p-4 flex items-center justify-between gap-4">
+      <p className="text-red-400 text-sm">{message}</p>
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="shrink-0 px-3 py-1.5 text-xs bg-slate-800 text-slate-300 rounded-lg hover:bg-slate-700 transition-colors"
+        >
+          Retry
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Analyze/shared/SectionErrorBoundary.tsx
+++ b/apps/frontend/src/components/Analyze/shared/SectionErrorBoundary.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import React, { Component, type ReactNode } from "react";
+
+interface Props {
+  sectionName: string;
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export default class SectionErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="bg-red-950/30 border border-red-900/50 rounded-xl p-6 text-center">
+          <p className="text-red-400 text-sm mb-1">
+            {this.props.sectionName} failed to render
+          </p>
+          <p className="text-slate-500 text-xs mb-3">
+            {this.state.error?.message ?? "An unexpected error occurred"}
+          </p>
+          <button
+            onClick={this.handleRetry}
+            className="px-4 py-2 text-sm bg-slate-800 text-slate-300 rounded-lg hover:bg-slate-700 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/apps/frontend/src/components/Analyze/shared/SkeletonCard.tsx
+++ b/apps/frontend/src/components/Analyze/shared/SkeletonCard.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import React from "react";
+
+interface SkeletonCardProps {
+  className?: string;
+}
+
+export default function SkeletonCard({ className = "" }: SkeletonCardProps) {
+  return (
+    <div
+      className={`bg-slate-900 border border-slate-800 rounded-xl p-6 animate-pulse ${className}`}
+    >
+      <div className="h-4 bg-slate-800 rounded w-1/3 mb-4" />
+      <div className="h-8 bg-slate-800 rounded w-1/2 mb-3" />
+      <div className="h-3 bg-slate-800 rounded w-2/3 mb-2" />
+      <div className="h-3 bg-slate-800 rounded w-1/2" />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Analyze/shared/index.ts
+++ b/apps/frontend/src/components/Analyze/shared/index.ts
@@ -1,0 +1,4 @@
+export { default as SkeletonCard } from "./SkeletonCard";
+export { default as ErrorBanner } from "./ErrorBanner";
+export { default as SectionErrorBoundary } from "./SectionErrorBoundary";
+export { default as EmptyState } from "./EmptyState";

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 export interface PutOption {
   strike: number;
@@ -28,6 +28,7 @@ interface UseOptionChainResult {
   error: string | null;
   expiry: string | null;
   setExpiry: (expiry: string) => void;
+  refetch: () => void;
 }
 
 export function useOptionChain(ticker: string): UseOptionChainResult {
@@ -36,7 +37,7 @@ export function useOptionChain(ticker: string): UseOptionChainResult {
   const [error, setError] = useState<string | null>(null);
   const [expiry, setExpiry] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     if (!ticker) return;
 
     setLoading(true);
@@ -64,5 +65,9 @@ export function useOptionChain(ticker: string): UseOptionChainResult {
       });
   }, [ticker, expiry]);
 
-  return { data, loading, error, expiry, setExpiry };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, expiry, setExpiry, refetch: fetchData };
 }

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 export interface OHLCVBar {
   time: string;
@@ -15,6 +15,7 @@ interface UsePriceHistoryResult {
   data: OHLCVBar[];
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 export function usePriceHistory(ticker: string): UsePriceHistoryResult {
@@ -22,7 +23,7 @@ export function usePriceHistory(ticker: string): UsePriceHistoryResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     if (!ticker) return;
 
     setLoading(true);
@@ -43,5 +44,9 @@ export function usePriceHistory(ticker: string): UsePriceHistoryResult {
       });
   }, [ticker]);
 
-  return { data, loading, error };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
 }

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 export interface PriceActionSummary {
   current_support: number;
@@ -15,6 +15,7 @@ interface UseSynthesisResult {
   data: SynthesisData | null;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 export function useSynthesis(ticker: string): UseSynthesisResult {
@@ -22,7 +23,7 @@ export function useSynthesis(ticker: string): UseSynthesisResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     if (!ticker) return;
 
     setLoading(true);
@@ -43,5 +44,9 @@ export function useSynthesis(ticker: string): UseSynthesisResult {
       });
   }, [ticker]);
 
-  return { data, loading, error };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
 }

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 
 interface MacdData {
   macd_line: number;
@@ -37,6 +37,7 @@ interface UseTechnicalsResult {
   data: TechnicalsData | null;
   loading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 export function useTechnicals(ticker: string): UseTechnicalsResult {
@@ -44,7 +45,7 @@ export function useTechnicals(ticker: string): UseTechnicalsResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
+  const fetchData = useCallback(() => {
     if (!ticker) return;
 
     setLoading(true);
@@ -65,5 +66,9 @@ export function useTechnicals(ticker: string): UseTechnicalsResult {
       });
   }, [ticker]);
 
-  return { data, loading, error };
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  return { data, loading, error, refetch: fetchData };
 }


### PR DESCRIPTION
Closes #6

**Changes (14 files, +300/-100):**
- 5 new shared components: SkeletonCard, ErrorBanner, SectionErrorBoundary, EmptyState
- Error boundaries wrap every section independently (no full-page crashes)
- Retry buttons on all error banners, wired to hook refetch
- refetch added to all 4 shortterm hooks via useCallback
- Responsive grids with sm: breakpoints
- Empty state with suggestions when no ticker selected
- Invalid ticker user-friendly error

Working as Fenster (Frontend Specialist)