### PR TITLE
feat(security): Add security headers middleware (#10)

### DIFF
--- a/.squad/decisions/inbox/hockney-security-headers.md
+++ b/.squad/decisions/inbox/hockney-security-headers.md
@@ -1,0 +1,31 @@
+# Decision: Add Security Headers Middleware
+
+**Author:** Hockney (Backend Dev)
+**Date:** 2025-07-18
+**Status:** Accepted
+**Issue:** #10
+
+## Context
+
+The trading journal backend had no security headers on HTTP responses. This leaves the application vulnerable to clickjacking, MIME-type sniffing, and other client-side attacks.
+
+## Decision
+
+Added a Starlette `BaseHTTPMiddleware` that injects six security headers on **every** response:
+
+| Header | Value | Purpose |
+|--------|-------|---------|
+| X-Frame-Options | DENY | Prevent clickjacking |
+| X-Content-Type-Options | nosniff | Stop MIME-type sniffing |
+| Strict-Transport-Security | max-age=31536000; includeSubDomains | Enforce HTTPS |
+| Referrer-Policy | strict-origin-when-cross-origin | Limit referrer leakage |
+| Content-Security-Policy | default-src 'self' | Restrict resource origins |
+| Permissions-Policy | camera=(), microphone=(), geolocation=() | Disable sensitive browser APIs |
+
+Headers are defined as a constant dict in `security_headers.py` so tests and future middleware can reference the single source of truth.
+
+## Consequences
+
+- All responses (including errors) now carry these headers.
+- The CSP `default-src 'self'` is intentionally strict; if the frontend needs to load external resources it should be relaxed per-directive rather than weakening the default.
+- HSTS assumes HTTPS in production; harmless over plain HTTP in dev.

--- a/apps/backend/app/middleware/security_headers.py
+++ b/apps/backend/app/middleware/security_headers.py
@@ -1,0 +1,23 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+SECURITY_HEADERS = {
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Content-Security-Policy": "default-src 'self'",
+    "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+}
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Adds security headers to every HTTP response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        for header, value in SECURITY_HEADERS.items():
+            response.headers[header] = value
+        return response

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 import uvicorn
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
+from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.dal.database import create_db_and_tables
 from app.api import (
     trades,
@@ -86,6 +87,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(SecurityHeadersMiddleware)
 
 @app.get("/")
 def read_root():

--- a/apps/backend/tests/test_security_headers.py
+++ b/apps/backend/tests/test_security_headers.py
@@ -1,0 +1,39 @@
+import pytest
+from fastapi.testclient import TestClient
+from main import app
+
+from app.middleware.security_headers import SECURITY_HEADERS
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+class TestSecurityHeaders:
+    """Verify that every response includes the required security headers."""
+
+    def test_root_endpoint_has_all_security_headers(self, client: TestClient):
+        response = client.get("/")
+        for header, expected in SECURITY_HEADERS.items():
+            assert header in response.headers, f"Missing header: {header}"
+            assert response.headers[header] == expected, (
+                f"{header}: expected '{expected}', got '{response.headers[header]}'"
+            )
+
+    def test_headers_present_on_404(self, client: TestClient):
+        """Security headers must appear even on error responses."""
+        response = client.get("/nonexistent-path")
+        for header, expected in SECURITY_HEADERS.items():
+            assert response.headers.get(header) == expected
+
+    @pytest.mark.parametrize(
+        "header,expected",
+        list(SECURITY_HEADERS.items()),
+        ids=list(SECURITY_HEADERS.keys()),
+    )
+    def test_individual_header_value(
+        self, client: TestClient, header: str, expected: str
+    ):
+        response = client.get("/")
+        assert response.headers.get(header) == expected


### PR DESCRIPTION
Closes #10

Adds SecurityHeadersMiddleware setting 6 headers on every response:
X-Frame-Options, X-Content-Type-Options, Strict-Transport-Security, Referrer-Policy, Content-Security-Policy, Permissions-Policy.

**Files:** 5 new/modified, +104 lines. 8 new tests, all passing.