### PR TITLE
ci: Add GitHub Actions CI pipeline (#8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+      - run: uv sync
+      - run: uv run python -m pytest --tb=short -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Personal Options Trading Journal
 
+[![CI](https://github.com/cohenjo/trading-journal/actions/workflows/ci.yml/badge.svg)](https://github.com/cohenjo/trading-journal/actions/workflows/ci.yml)
+
 This project is a personal trading journal designed to help users track their options trades, analyze performance, and visualize their profit and loss over time.
 
 ## Getting Started


### PR DESCRIPTION
Closes #8

Adds `.github/workflows/ci.yml` with two parallel jobs:
- **backend**: uv sync → pytest
- **frontend**: npm ci → lint → build → test

Runs on PRs to main and pushes to main. CI badge added to README.