### PR TITLE
feat(pension): historical report browser with snapshot comparison (#13)

### DIFF
--- a/.squad/decisions/inbox/fenster-pension-browser.md
+++ b/.squad/decisions/inbox/fenster-pension-browser.md
@@ -1,0 +1,32 @@
+# Decision: Pension Historical Report Browser
+
+**Author:** Fenster (Frontend Dev)
+**Date:** 2025-07-22
+**Issue:** #13
+
+## Context
+
+The pension page only showed the latest uploaded report. Users need to browse historical reports to track retirement progress over time and compare changes between periods.
+
+## Decision
+
+### Backend
+- Added `GET /api/pension/reports` endpoint that returns:
+  - List of uploaded PDF files with metadata (filename, owner, upload timestamp, size)
+  - Per-snapshot pension totals derived from `FinanceSnapshot` records, including per-account breakdowns
+
+### Frontend
+- **ReportHistory** component: timeline sidebar showing all pension snapshots with total values, delta badges comparing to previous snapshot, expandable per-account details, and a collapsible uploaded files list
+- **SnapshotDetail** component: full-width detail view when a snapshot is clicked, showing per-account table with value, deposits, earnings, fees, and delta vs previous period
+- Layout changed from 2-col to 3-col grid (lg breakpoint) to accommodate history panel alongside upload + results
+
+### Architecture Notes
+- No new DB models — reports endpoint reads existing `FinanceSnapshot` records and scans the `reports/` directory for file metadata
+- No i18n added (pension page doesn't use i18n patterns)
+- Currency formatting follows existing `he-IL` / `ILS` convention
+- All new components are `'use client'` to match existing pension page pattern
+
+## Alternatives Considered
+
+1. **Store reports in DB**: Adds model complexity; filesystem scan is sufficient for MVP since files are already saved on upload
+2. **Separate page for history**: Rejected — inline panel provides faster context switching without losing dashboard view

--- a/apps/backend/app/api/pension.py
+++ b/apps/backend/app/api/pension.py
@@ -680,6 +680,75 @@ async def upload_pension_report(
         raise HTTPException(status_code=500, detail=str(exc))
 
 
+@router.get("/reports")
+def list_pension_reports(db: Session = Depends(get_session)):
+    """Return a list of uploaded pension report files with metadata and snapshot totals."""
+    try:
+        root_dir = Path(__file__).parent.parent.parent.parent.parent
+        reports_root = root_dir / "reports"
+        report_files: list[dict[str, Any]] = []
+
+        for owner_dir in sorted(reports_root.iterdir()) if reports_root.exists() else []:
+            if not owner_dir.is_dir() or owner_dir.name.startswith("."):
+                continue
+            owner = owner_dir.name
+            for pdf in sorted(owner_dir.glob("*.pdf"), key=lambda p: p.stat().st_mtime, reverse=True):
+                stat = pdf.stat()
+                report_files.append({
+                    "filename": pdf.name,
+                    "owner": owner,
+                    "uploaded_at": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                    "size_bytes": stat.st_size,
+                })
+
+        # Compute per-snapshot pension totals for delta comparison
+        snapshots = db.exec(
+            select(FinanceSnapshot).order_by(FinanceSnapshot.date.asc())
+        ).all()
+
+        snapshot_totals: list[dict[str, Any]] = []
+        for snapshot in snapshots:
+            pension_items = [
+                item for item in snapshot.data.get("items", [])
+                if item.get("type") == "Pension"
+            ]
+            if not pension_items:
+                continue
+            total_value = sum(_safe_float(item.get("value")) for item in pension_items)
+            accounts = []
+            for item in pension_items:
+                details = item.get("details") or {}
+                accounts.append({
+                    "id": get_pension_identity(item) or item.get("id", ""),
+                    "owner": _safe_text(item.get("owner")) or "Unknown",
+                    "name": _safe_text(details.get("pension_display_name"))
+                    or _safe_text(item.get("name"))
+                    or "Unknown",
+                    "value": _safe_float(item.get("value")),
+                    "deposits": _safe_float(details.get("deposits")),
+                    "earnings": _safe_float(details.get("earnings")),
+                    "fees": _safe_float(details.get("fees")),
+                    "insurance_fees": _safe_float(details.get("insurance_fees")),
+                })
+            snapshot_totals.append({
+                "date": snapshot.date.isoformat(),
+                "total_value": total_value,
+                "account_count": len(pension_items),
+                "accounts": accounts,
+            })
+
+        return {
+            "status": "success",
+            "reports": report_files,
+            "snapshots": snapshot_totals,
+        }
+    except Exception as exc:
+        import traceback
+
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
 @router.get("/dashboard")
 def get_pension_dashboard(db: Session = Depends(get_session)):
     """Return aggregated pension dashboard with history and plan data."""

--- a/apps/frontend/src/app/pension/page.tsx
+++ b/apps/frontend/src/app/pension/page.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PensionChart from '@/components/Pension/PensionChart';
 import PensionTable from '@/components/Pension/PensionTable';
+import ReportHistory from '@/components/Pension/ReportHistory';
+import SnapshotDetail from '@/components/Pension/SnapshotDetail';
+import type { PensionSnapshotSummary } from '@/components/Pension/pensionTypes';
 
 interface PensionUploadResponse {
     status: string;
@@ -18,6 +21,10 @@ export default function PensionPage() {
     const [result, setResult] = useState<PensionUploadResponse | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [dashboardData, setDashboardData] = useState<any>(null);
+    const [selectedSnapshot, setSelectedSnapshot] = useState<PensionSnapshotSummary | null>(null);
+    const [previousSnapshot, setPreviousSnapshot] = useState<PensionSnapshotSummary | null>(null);
+    const [allSnapshots, setAllSnapshots] = useState<PensionSnapshotSummary[]>([]);
+    const [refreshKey, setRefreshKey] = useState(0);
 
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -38,6 +45,28 @@ export default function PensionPage() {
     useEffect(() => {
         fetchDashboard();
     }, []);
+
+    const handleSelectSnapshot = useCallback((snapshot: PensionSnapshotSummary | null) => {
+        setSelectedSnapshot(snapshot);
+        if (snapshot && allSnapshots.length > 0) {
+            const idx = allSnapshots.findIndex((s) => s.date === snapshot.date);
+            setPreviousSnapshot(idx > 0 ? allSnapshots[idx - 1] : null);
+        } else {
+            setPreviousSnapshot(null);
+        }
+    }, [allSnapshots]);
+
+    // Keep allSnapshots in sync by fetching from reports endpoint
+    useEffect(() => {
+        fetch('/api/pension/reports')
+            .then((res) => res.ok ? res.json() : null)
+            .then((json) => {
+                if (json?.snapshots) {
+                    setAllSnapshots(json.snapshots);
+                }
+            })
+            .catch(() => {});
+    }, [refreshKey]);
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         if (e.target.files && e.target.files.length > 0) {
@@ -87,8 +116,9 @@ export default function PensionPage() {
             const data = await response.json();
             setResult(data);
 
-            // Refresh dashboard after successful upload
+            // Refresh dashboard and report history after successful upload
             await fetchDashboard();
+            setRefreshKey((k) => k + 1);
         } catch (err: unknown) {
             console.error(err);
             if (err instanceof Error) {
@@ -144,7 +174,26 @@ export default function PensionPage() {
                     </div>
                 )}
 
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                {/* Historical Snapshot Detail */}
+                {selectedSnapshot && (
+                    <SnapshotDetail
+                        snapshot={selectedSnapshot}
+                        previousSnapshot={previousSnapshot}
+                        onClose={() => handleSelectSnapshot(null)}
+                    />
+                )}
+
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                    {/* Report History Panel */}
+                    <div className="lg:col-span-1 lg:order-last">
+                        <ReportHistory
+                            onSelectSnapshot={handleSelectSnapshot}
+                            selectedDate={selectedSnapshot?.date ?? null}
+                            refreshKey={refreshKey}
+                        />
+                    </div>
+
+                    <div className="lg:col-span-2 grid grid-cols-1 md:grid-cols-2 gap-8">
                     {/* Upload Form */}
                     <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
                         <h2 className="text-xl font-semibold mb-4 text-white">Upload Report</h2>
@@ -342,6 +391,7 @@ export default function PensionPage() {
                                 </div>
                             </div>
                         )}
+                    </div>
                     </div>
                 </div>
             </div>

--- a/apps/frontend/src/components/Pension/ReportHistory.tsx
+++ b/apps/frontend/src/components/Pension/ReportHistory.tsx
@@ -1,0 +1,295 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import type {
+  PensionReportsResponse,
+  PensionSnapshotSummary,
+  PensionSnapshotAccount,
+} from './pensionTypes';
+
+type Props = {
+  /** Called when the user selects a snapshot to view its details */
+  onSelectSnapshot: (snapshot: PensionSnapshotSummary | null) => void;
+  /** Currently selected snapshot date, kept in sync with parent */
+  selectedDate: string | null;
+  /** Trigger refetch when a new upload completes */
+  refreshKey: number;
+};
+
+const formatCurrency = (val: number) =>
+  new Intl.NumberFormat('he-IL', {
+    style: 'currency',
+    currency: 'ILS',
+    maximumFractionDigits: 0,
+  }).format(val);
+
+const formatDate = (iso: string) => {
+  try {
+    return new Date(iso).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+};
+
+const formatFileSize = (bytes: number) => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+};
+
+function DeltaBadge({ current, previous }: { current: number; previous: number }) {
+  const diff = current - previous;
+  if (diff === 0 || previous === 0) return null;
+  const pct = ((diff / previous) * 100).toFixed(1);
+  const isPositive = diff > 0;
+  return (
+    <span
+      className={`inline-flex items-center text-xs font-medium px-1.5 py-0.5 rounded ${
+        isPositive
+          ? 'bg-emerald-500/20 text-emerald-400'
+          : 'bg-rose-500/20 text-rose-400'
+      }`}
+    >
+      {isPositive ? '▲' : '▼'} {formatCurrency(Math.abs(diff))} ({isPositive ? '+' : ''}{pct}%)
+    </span>
+  );
+}
+
+export default function ReportHistory({ onSelectSnapshot, selectedDate, refreshKey }: Props) {
+  const [data, setData] = useState<PensionReportsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [expandedDate, setExpandedDate] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+
+    fetch('/api/pension/reports')
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((json: PensionReportsResponse) => {
+        if (!cancelled) {
+          setData(json);
+          setError(null);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err.message);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [refreshKey]);
+
+  if (loading) {
+    return (
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 animate-pulse">
+        <div className="h-5 bg-slate-800 rounded w-40 mb-4" />
+        <div className="space-y-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 bg-slate-800/50 rounded" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Report History</h2>
+        <p className="text-red-400 text-sm">Failed to load reports: {error}</p>
+      </div>
+    );
+  }
+
+  const snapshots = data?.snapshots ?? [];
+  const reports = data?.reports ?? [];
+
+  if (snapshots.length === 0 && reports.length === 0) {
+    return (
+      <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
+        <h2 className="text-lg font-semibold text-white mb-2">Report History</h2>
+        <p className="text-slate-500 text-sm italic">
+          No historical reports yet. Upload your first pension report above.
+        </p>
+      </div>
+    );
+  }
+
+  const handleSnapshotClick = (snapshot: PensionSnapshotSummary) => {
+    if (selectedDate === snapshot.date) {
+      onSelectSnapshot(null);
+    } else {
+      onSelectSnapshot(snapshot);
+    }
+  };
+
+  const toggleExpand = (date: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setExpandedDate(expandedDate === date ? null : date);
+  };
+
+  return (
+    <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
+      <h2 className="text-lg font-semibold text-white mb-1">Report History</h2>
+      <p className="text-slate-500 text-xs mb-4">
+        {snapshots.length} snapshot{snapshots.length !== 1 ? 's' : ''} · {reports.length} file{reports.length !== 1 ? 's' : ''}
+      </p>
+
+      {/* Snapshot timeline */}
+      <div className="space-y-2">
+        {snapshots.map((snapshot, idx) => {
+          const prevSnapshot = idx > 0 ? snapshots[idx - 1] : null;
+          const isSelected = selectedDate === snapshot.date;
+          const isExpanded = expandedDate === snapshot.date;
+
+          return (
+            <div key={snapshot.date}>
+              <button
+                onClick={() => handleSnapshotClick(snapshot)}
+                className={`w-full text-left px-4 py-3 rounded-lg border transition-all ${
+                  isSelected
+                    ? 'border-blue-500 bg-blue-500/10'
+                    : 'border-slate-800 bg-slate-800/30 hover:border-slate-700 hover:bg-slate-800/60'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3">
+                    <div
+                      className={`w-2 h-2 rounded-full ${
+                        idx === snapshots.length - 1
+                          ? 'bg-emerald-400'
+                          : 'bg-slate-600'
+                      }`}
+                    />
+                    <div>
+                      <span className="text-sm font-medium text-slate-200">
+                        {formatDate(snapshot.date)}
+                      </span>
+                      {idx === snapshots.length - 1 && (
+                        <span className="ml-2 text-xs text-emerald-400 font-medium">Latest</span>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <span className="text-sm font-semibold text-emerald-400">
+                      {formatCurrency(snapshot.total_value)}
+                    </span>
+                    {prevSnapshot && (
+                      <DeltaBadge
+                        current={snapshot.total_value}
+                        previous={prevSnapshot.total_value}
+                      />
+                    )}
+                    <button
+                      onClick={(e) => toggleExpand(snapshot.date, e)}
+                      className="p-1 text-slate-500 hover:text-slate-300 transition-colors"
+                      title="Show accounts"
+                    >
+                      <svg
+                        className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-2 mt-1 ml-5">
+                  <span className="text-xs text-slate-500">
+                    {snapshot.account_count} account{snapshot.account_count !== 1 ? 's' : ''}
+                  </span>
+                </div>
+              </button>
+
+              {/* Expanded account details */}
+              {isExpanded && (
+                <div className="ml-5 mt-1 mb-2 border-l-2 border-slate-800 pl-4 space-y-2">
+                  {snapshot.accounts.map((acc: PensionSnapshotAccount) => {
+                    const prevAcc = prevSnapshot?.accounts.find((a) => a.id === acc.id);
+                    return (
+                      <div
+                        key={acc.id}
+                        className="flex items-center justify-between text-xs py-1"
+                      >
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${
+                              acc.owner === 'You'
+                                ? 'bg-blue-500/20 text-blue-400'
+                                : 'bg-purple-500/20 text-purple-400'
+                            }`}
+                          >
+                            {acc.owner}
+                          </span>
+                          <span className="text-slate-300">{acc.name}</span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span className="text-emerald-400 font-medium">
+                            {formatCurrency(acc.value)}
+                          </span>
+                          {prevAcc && (
+                            <DeltaBadge current={acc.value} previous={prevAcc.value} />
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Uploaded files section */}
+      {reports.length > 0 && (
+        <details className="mt-4">
+          <summary className="text-xs text-slate-500 cursor-pointer hover:text-slate-400 transition-colors">
+            Uploaded files ({reports.length})
+          </summary>
+          <div className="mt-2 space-y-1 max-h-48 overflow-y-auto">
+            {reports.map((r, i) => (
+              <div
+                key={`${r.filename}-${i}`}
+                className="flex items-center justify-between text-xs py-1.5 px-2 rounded bg-slate-800/30"
+              >
+                <div className="flex items-center gap-2 truncate">
+                  <svg className="w-3.5 h-3.5 text-slate-500 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                  </svg>
+                  <span className="text-slate-400 truncate">{r.filename}</span>
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span
+                    className={`px-1 py-0.5 rounded text-[10px] font-medium ${
+                      r.owner === 'You'
+                        ? 'bg-blue-500/20 text-blue-400'
+                        : 'bg-purple-500/20 text-purple-400'
+                    }`}
+                  >
+                    {r.owner}
+                  </span>
+                  <span className="text-slate-600">{formatFileSize(r.size_bytes)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Pension/SnapshotDetail.tsx
+++ b/apps/frontend/src/components/Pension/SnapshotDetail.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import React from 'react';
+import type { PensionSnapshotSummary, PensionSnapshotAccount } from './pensionTypes';
+
+type Props = {
+  snapshot: PensionSnapshotSummary;
+  previousSnapshot: PensionSnapshotSummary | null;
+  onClose: () => void;
+};
+
+const formatCurrency = (val: number) =>
+  new Intl.NumberFormat('he-IL', {
+    style: 'currency',
+    currency: 'ILS',
+    maximumFractionDigits: 0,
+  }).format(val);
+
+const formatDate = (iso: string) => {
+  try {
+    return new Date(iso).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    });
+  } catch {
+    return iso;
+  }
+};
+
+function DeltaCell({ current, previous }: { current: number; previous?: number }) {
+  if (previous === undefined || previous === 0) return null;
+  const diff = current - previous;
+  const pct = ((diff / previous) * 100).toFixed(1);
+  const isPositive = diff > 0;
+  return (
+    <div
+      className={`text-xs ${isPositive ? 'text-emerald-400' : 'text-rose-400'}`}
+    >
+      {isPositive ? '+' : ''}
+      {formatCurrency(diff)} ({isPositive ? '+' : ''}{pct}%)
+    </div>
+  );
+}
+
+export default function SnapshotDetail({ snapshot, previousSnapshot, onClose }: Props) {
+  const totalDelta = previousSnapshot
+    ? snapshot.total_value - previousSnapshot.total_value
+    : null;
+
+  return (
+    <div className="bg-slate-900 border border-blue-500/30 rounded-xl p-6 relative">
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 p-1 text-slate-500 hover:text-slate-300 transition-colors"
+        title="Close"
+      >
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+        </svg>
+      </button>
+
+      {/* Header */}
+      <div className="mb-4">
+        <div className="flex items-center gap-2 mb-1">
+          <h2 className="text-lg font-semibold text-white">
+            Snapshot — {formatDate(snapshot.date)}
+          </h2>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="text-2xl font-bold text-emerald-400">
+            {formatCurrency(snapshot.total_value)}
+          </span>
+          {totalDelta !== null && previousSnapshot && (
+            <div className="flex flex-col">
+              <span
+                className={`text-sm font-semibold ${totalDelta >= 0 ? 'text-emerald-400' : 'text-rose-400'}`}
+              >
+                {totalDelta >= 0 ? '▲' : '▼'} {formatCurrency(Math.abs(totalDelta))}
+              </span>
+              <span className="text-xs text-slate-500">
+                vs {formatDate(previousSnapshot.date)}
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Account details table */}
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm text-left text-slate-300">
+          <thead className="text-xs text-slate-400 uppercase bg-slate-800/50">
+            <tr>
+              <th className="px-4 py-3 font-semibold">Owner</th>
+              <th className="px-4 py-3 font-semibold">Account</th>
+              <th className="px-4 py-3 font-semibold text-right">Value</th>
+              <th className="px-4 py-3 font-semibold text-right">Change</th>
+              <th className="px-4 py-3 font-semibold text-right">Deposits</th>
+              <th className="px-4 py-3 font-semibold text-right">Earnings</th>
+              <th className="px-4 py-3 font-semibold text-right">Fees</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-800">
+            {snapshot.accounts.map((acc: PensionSnapshotAccount) => {
+              const prevAcc = previousSnapshot?.accounts.find((a) => a.id === acc.id);
+              return (
+                <tr key={acc.id} className="hover:bg-slate-800/50 transition-colors">
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                        acc.owner === 'You'
+                          ? 'bg-blue-500/20 text-blue-400'
+                          : 'bg-purple-500/20 text-purple-400'
+                      }`}
+                    >
+                      {acc.owner}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-200 font-medium">{acc.name}</td>
+                  <td className="px-4 py-3 text-right text-emerald-400 font-medium">
+                    {formatCurrency(acc.value)}
+                  </td>
+                  <td className="px-4 py-3 text-right">
+                    <DeltaCell current={acc.value} previous={prevAcc?.value} />
+                  </td>
+                  <td className="px-4 py-3 text-right text-slate-400">
+                    {acc.deposits ? formatCurrency(acc.deposits) : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-emerald-400/80">
+                    {acc.earnings ? formatCurrency(acc.earnings) : '-'}
+                  </td>
+                  <td className="px-4 py-3 text-right text-rose-400/80">
+                    {(acc.fees || acc.insurance_fees)
+                      ? formatCurrency((acc.fees || 0) + (acc.insurance_fees || 0))
+                      : '-'}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Pension/pensionTypes.ts
+++ b/apps/frontend/src/components/Pension/pensionTypes.ts
@@ -63,3 +63,36 @@ export const getPensionFundName = (account: PensionAccount): string | null => {
 
 export const getPensionDisplayName = (account: PensionAccount): string =>
   account.display_name || getPensionProductName(account) || account.name;
+
+// --- Report History Types ---
+
+export type PensionReportFile = {
+  filename: string;
+  owner: string;
+  uploaded_at: string;
+  size_bytes: number;
+};
+
+export type PensionSnapshotAccount = {
+  id: string;
+  owner: string;
+  name: string;
+  value: number;
+  deposits: number;
+  earnings: number;
+  fees: number;
+  insurance_fees: number;
+};
+
+export type PensionSnapshotSummary = {
+  date: string;
+  total_value: number;
+  account_count: number;
+  accounts: PensionSnapshotAccount[];
+};
+
+export type PensionReportsResponse = {
+  status: string;
+  reports: PensionReportFile[];
+  snapshots: PensionSnapshotSummary[];
+};


### PR DESCRIPTION
Closes #13

## Changes
- **Backend**: `GET /api/pension/reports` endpoint — lists uploaded PDFs + per-snapshot pension totals with account breakdowns
- **Frontend**: `ReportHistory` sidebar with timeline, delta badges, and expandable per-account details
- **Frontend**: `SnapshotDetail` panel with full account table (value, deposits, earnings, fees) + delta vs previous
- **Pension page**: Refactored to 3-column layout with history panel
- **Types**: Added `PensionSnapshotSummary`, `PensionSnapshotAccount` types

Working as Fenster (Frontend Specialist)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>