### PR TITLE
feat: migrate all monetary float fields to Decimal (Numeric 18,6) (#9)

### DIFF
--- a/.squad/decisions/inbox/mcmanus-decimal-migration.md
+++ b/.squad/decisions/inbox/mcmanus-decimal-migration.md
@@ -1,0 +1,46 @@
+# Decision: Migrate monetary float fields to Decimal
+
+**Author:** McManus (Data/Finance)  
+**Date:** 2025-07-25  
+**Status:** Accepted  
+**Issue:** #9
+
+## Context
+
+All monetary fields across the trading-journal backend were stored as Python `float`
+(IEEE 754 double-precision). This introduces rounding errors in financial calculations
+(e.g., `0.1 + 0.2 != 0.3`), which is unacceptable for a trading journal tracking
+real P&L, commissions, and portfolio values.
+
+## Decision
+
+Migrate every monetary `float` field to `decimal.Decimal` in Python and
+`Numeric(18, 6)` in PostgreSQL. This covers ~80+ fields across 9 schema files.
+
+### Key design choices
+
+| Choice | Rationale |
+|--------|-----------|
+| `Numeric(18,6)` precision | 18 digits total, 6 fractional — sufficient for equity/options prices and large portfolio values |
+| `sa_column=Column(Numeric(18,6))` for table fields | SQLModel requires explicit SQLAlchemy column for Numeric mapping |
+| Plain `Decimal` for Pydantic-only models | No database column needed; Pydantic validates the type |
+| `ENCODERS_BY_TYPE[Decimal] = float` in FastAPI | Ensures JSON responses emit numbers, not strings — backward compatible with frontend |
+| `DecimalSafeJSONResponse` as default | Belt-and-suspenders for any Decimal that bypasses `jsonable_encoder` |
+| Manual Alembic migration | Autogenerate requires live DB; hand-written migration is safer and reviewable |
+
+## Scope
+
+- **Migrated:** All SQLModel table fields, Pydantic API models, and dataclass models
+  with monetary semantics across models.py, trading_models.py, finance_models.py,
+  dividend_models.py, plan_models.py, insurance_models.py, options_models.py,
+  backtest_models.py, ladder_models.py
+- **Not migrated:** `plan_service.py` and `plan_components.py` simulation engine
+  (uses dict-based float arithmetic — separate refactor)
+- **Intentionally kept as float:** `Ndx1mChartData.time` (Unix timestamp)
+
+## Consequences
+
+- Financial calculations gain exact decimal precision
+- Frontend receives numbers (not strings) — no breaking change
+- Alembic migration safely casts existing float data via `::numeric(18,6)`
+- Test assertions updated to use `float()` wrapper for `pytest.approx` compatibility

--- a/apps/backend/alembic/versions/4d9a58ecd93b_migrate_monetary_fields_to_decimal.py
+++ b/apps/backend/alembic/versions/4d9a58ecd93b_migrate_monetary_fields_to_decimal.py
@@ -1,0 +1,133 @@
+"""Migrate monetary float fields to Decimal (Numeric(18,6))
+
+Revision ID: 4d9a58ecd93b
+Revises: acadd4bc6806
+Create Date: 2025-07-25
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "4d9a58ecd93b"
+down_revision = "acadd4bc6806"
+branch_labels = None
+depends_on = None
+
+# (table, column) pairs to migrate
+COLUMNS = [
+    # manual_trades
+    ("manual_trades", "size"),
+    ("manual_trades", "entry_price"),
+    ("manual_trades", "exit_price"),
+    ("manual_trades", "pnl"),
+    # trades
+    ("trades", "fxRateToBase"),
+    ("trades", "quantity"),
+    ("trades", "tradePrice"),
+    ("trades", "tradeMoney"),
+    ("trades", "proceeds"),
+    ("trades", "taxes"),
+    ("trades", "ibCommission"),
+    ("trades", "netCash"),
+    ("trades", "closePrice"),
+    ("trades", "cost"),
+    ("trades", "fifoPnlRealized"),
+    ("trades", "mtmPnl"),
+    ("trades", "origTradePrice"),
+    ("trades", "changeInPrice"),
+    ("trades", "changeInQuantity"),
+    ("trades", "accruedInt"),
+    ("trades", "fineness"),
+    ("trades", "weight"),
+    # daily_summaries
+    ("daily_summaries", "total_pnl"),
+    ("daily_summaries", "win_rate"),
+    ("daily_summaries", "avg_win"),
+    ("daily_summaries", "avg_loss"),
+    # ndx1m
+    ("ndx1m", "open"),
+    ("ndx1m", "high"),
+    ("ndx1m", "low"),
+    ("ndx1m", "close"),
+    # daily_bars
+    ("daily_bars", "open"),
+    ("daily_bars", "high"),
+    ("daily_bars", "low"),
+    ("daily_bars", "close"),
+    # executions
+    ("executions", "shares"),
+    ("executions", "price"),
+    ("executions", "avgPrice"),
+    ("executions", "cumQty"),
+    ("executions", "commission"),
+    ("executions", "realizedPNL"),
+    # matched_trades
+    ("matched_trades", "open_price"),
+    ("matched_trades", "close_price"),
+    ("matched_trades", "pnl"),
+    # trading_account_summaries
+    ("trading_account_summaries", "net_liquidation"),
+    ("trading_account_summaries", "total_cash"),
+    # trading_positions
+    ("trading_positions", "amount"),
+    ("trading_positions", "avg_cost"),
+    # finance_snapshots
+    ("finance_snapshots", "net_worth"),
+    ("finance_snapshots", "total_assets"),
+    ("finance_snapshots", "total_liabilities"),
+    # dividend_positions
+    ("dividend_positions", "shares"),
+    # dividend_ticker_data
+    ("dividend_ticker_data", "price"),
+    ("dividend_ticker_data", "dividend_yield"),
+    ("dividend_ticker_data", "dividend_rate"),
+    ("dividend_ticker_data", "dgr_3y"),
+    ("dividend_ticker_data", "dgr_5y"),
+    ("dividend_ticker_data", "previous_close"),
+    # insurance_policies
+    ("insurance_policies", "monthly_premium"),
+    # option_contracts
+    ("option_contracts", "strike"),
+    # historical_option_bars
+    ("historical_option_bars", "open"),
+    ("historical_option_bars", "high"),
+    ("historical_option_bars", "low"),
+    ("historical_option_bars", "close"),
+    ("historical_option_bars", "implied_vol"),
+    ("historical_option_bars", "delta"),
+    ("historical_option_bars", "gamma"),
+    ("historical_option_bars", "theta"),
+    ("historical_option_bars", "vega"),
+    ("historical_option_bars", "underlying_price"),
+    # backtest_runs
+    ("backtest_runs", "initial_capital"),
+    ("backtest_runs", "final_equity"),
+    ("backtest_runs", "total_realized_pnl"),
+    ("backtest_runs", "total_unrealized_pnl"),
+    # backtest_trades
+    ("backtest_trades", "quantity"),
+    ("backtest_trades", "price"),
+    ("backtest_trades", "commission"),
+]
+
+
+def upgrade() -> None:
+    for table, col in COLUMNS:
+        op.alter_column(
+            table,
+            col,
+            type_=sa.Numeric(18, 6),
+            existing_type=sa.Float(),
+            postgresql_using=f"{col}::numeric(18,6)",
+        )
+
+
+def downgrade() -> None:
+    for table, col in COLUMNS:
+        op.alter_column(
+            table,
+            col,
+            type_=sa.Float(),
+            existing_type=sa.Numeric(18, 6),
+            postgresql_using=f"{col}::double precision",
+        )

--- a/apps/backend/app/schema/backtest_models.py
+++ b/apps/backend/app/schema/backtest_models.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date
+from decimal import Decimal
 from typing import Optional
-from sqlalchemy import BigInteger, Column, ForeignKey
+from sqlalchemy import BigInteger, Column, ForeignKey, Numeric
 from sqlmodel import Field, SQLModel
 
 class OptionContract(SQLModel, table=True):
@@ -8,7 +9,7 @@ class OptionContract(SQLModel, table=True):
     conid: int = Field(sa_column=Column(BigInteger, primary_key=True))  # IBKR Contract ID
     symbol: str = Field(index=True)       # e.g., "NDX"
     expiration: date = Field(index=True)
-    strike: float
+    strike: Decimal = Field(sa_column=Column("strike", Numeric(18, 6)))
     right: str = Field(max_length=1)      # "C" or "P"
     multiplier: str = Field(default="100")
 
@@ -19,34 +20,34 @@ class HistoricalOptionBar(SQLModel, table=True):
     date: datetime = Field(index=True)
     
     # Price Data
-    open: float
-    high: float
-    low: float
-    close: float
+    open: Decimal = Field(sa_column=Column("open", Numeric(18, 6)))
+    high: Decimal = Field(sa_column=Column("high", Numeric(18, 6)))
+    low: Decimal = Field(sa_column=Column("low", Numeric(18, 6)))
+    close: Decimal = Field(sa_column=Column("close", Numeric(18, 6)))
     volume: int
     
     # Greeks (Snapshot at close)
-    implied_vol: Optional[float] = None
-    delta: Optional[float] = None
-    gamma: Optional[float] = None
-    theta: Optional[float] = None
-    vega: Optional[float] = None
+    implied_vol: Optional[Decimal] = Field(default=None, sa_column=Column("implied_vol", Numeric(18, 6)))
+    delta: Optional[Decimal] = Field(default=None, sa_column=Column("delta", Numeric(18, 6)))
+    gamma: Optional[Decimal] = Field(default=None, sa_column=Column("gamma", Numeric(18, 6)))
+    theta: Optional[Decimal] = Field(default=None, sa_column=Column("theta", Numeric(18, 6)))
+    vega: Optional[Decimal] = Field(default=None, sa_column=Column("vega", Numeric(18, 6)))
     
     # Underlying Price (for convenience/speed)
-    underlying_price: float
+    underlying_price: Decimal = Field(sa_column=Column("underlying_price", Numeric(18, 6)))
 
 class BacktestRun(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     created_at: datetime = Field(default_factory=datetime.utcnow)
     start_date: date
     end_date: date
-    initial_capital: float
+    initial_capital: Decimal = Field(sa_column=Column("initial_capital", Numeric(18, 6)))
     parameters: str  # JSON string of strategy params (budget, delta, etc.)
     
     # Results
-    final_equity: float
-    total_realized_pnl: float
-    total_unrealized_pnl: float
+    final_equity: Decimal = Field(sa_column=Column("final_equity", Numeric(18, 6)))
+    total_realized_pnl: Decimal = Field(sa_column=Column("total_realized_pnl", Numeric(18, 6)))
+    total_unrealized_pnl: Decimal = Field(sa_column=Column("total_unrealized_pnl", Numeric(18, 6)))
 
 class BacktestTrade(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
@@ -54,7 +55,7 @@ class BacktestTrade(SQLModel, table=True):
     date: datetime
     action: str  # "BUY", "SELL", "EXPIRE"
     conid: int = Field(sa_column=Column(BigInteger))
-    quantity: float
-    price: float
-    commission: float
+    quantity: Decimal = Field(sa_column=Column("quantity", Numeric(18, 6)))
+    price: Decimal = Field(sa_column=Column("price", Numeric(18, 6)))
+    commission: Decimal = Field(sa_column=Column("commission", Numeric(18, 6)))
     notes: Optional[str] = None

--- a/apps/backend/app/schema/dividend_models.py
+++ b/apps/backend/app/schema/dividend_models.py
@@ -1,6 +1,8 @@
+from decimal import Decimal
 from typing import List, Literal, Optional
 from datetime import datetime
 from pydantic import BaseModel
+from sqlalchemy import Column, Numeric
 from sqlmodel import SQLModel, Field
 
 # --- Database Models ---
@@ -11,7 +13,7 @@ class DividendPosition(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     account: str = Field(index=True) # e.g. ABKR, IRS, RSU
     ticker: str
-    shares: float
+    shares: Decimal = Field(sa_column=Column(Numeric(18, 6)))
 
 class DividendAccount(SQLModel, table=True):
     __tablename__ = "dividend_accounts"
@@ -22,58 +24,58 @@ class DividendTickerData(SQLModel, table=True):
     __tablename__ = "dividend_ticker_data"
     ticker: str = Field(primary_key=True)
     last_updated: datetime
-    price: float
+    price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     currency: str
-    dividend_yield: float
-    dividend_rate: float
-    dgr_3y: float
-    dgr_5y: float
-    previous_close: float = 0.0
+    dividend_yield: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    dividend_rate: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    dgr_3y: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    dgr_5y: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    previous_close: Decimal = Field(default=Decimal("0"), sa_column=Column(Numeric(18, 6)))
 
 # --- Pydantic Schemas for API ---
 
 class DividendPositionCreate(BaseModel):
     account: str
     ticker: str
-    shares: float
+    shares: Decimal
 
 class DividendPositionRead(BaseModel):
     id: int
     account: str
     ticker: str
-    shares: float
+    shares: Decimal
 
 # Data enriched with yfinance stats
 class DividendPositionStats(DividendPositionRead):
-    price: float
-    dividend_yield: float
-    annual_income: float
+    price: Decimal
+    dividend_yield: Decimal
+    annual_income: Decimal
     currency: str
-    dgr_3y: float
-    dgr_5y: float
+    dgr_3y: Decimal
+    dgr_5y: Decimal
 
 class DividendDashboardStats(BaseModel):
-    portfolio_yield: float
-    annual_income: float
-    dgr_5y: float
+    portfolio_yield: Decimal
+    annual_income: Decimal
+    dgr_5y: Decimal
     currency: str = "USD"
 
 # --- Legacy / Projection Models (kept for backward compatibility if needed, or migration) ---
 
 class DividendRecord(BaseModel):
     year: int
-    amount: float
+    amount: Decimal
 
 class DividendProjectionParams(BaseModel):
-    yield_rate: float
-    growth_rate: float
-    reinvest_rate: float
+    yield_rate: Decimal
+    growth_rate: Decimal
+    reinvest_rate: Decimal
     cutoff_year: int
     final_year: int
 
 class DividendProjectionPoint(BaseModel):
     year: int
-    amount: float
+    amount: Decimal
     type: Literal['historical', 'projected']
 
 class DividendProjectionResponse(BaseModel):

--- a/apps/backend/app/schema/finance_models.py
+++ b/apps/backend/app/schema/finance_models.py
@@ -1,7 +1,9 @@
 from datetime import date
+from decimal import Decimal
 from typing import List, Dict, Union, Optional, Any
 from pydantic import BaseModel
-from sqlmodel import SQLModel, Field, Column, JSON
+from sqlalchemy import Column, Numeric
+from sqlmodel import SQLModel, Field, Column as SMColumn, JSON
 from datetime import date as date_type
 
 # --- Pydantic Schemas for JSON Validation ---
@@ -10,22 +12,22 @@ class FinanceItem(BaseModel):
     id: str
     category: str # 'Savings', 'Investments', 'Assets', 'Liabilities'
     name: str
-    value: float
+    value: Decimal
     type: str
     owner: str
 class FinanceItem(BaseModel):
     id: str
     category: str # 'Savings', 'Investments', 'Assets', 'Liabilities'
     name: str
-    value: float
+    value: Decimal
     type: str
     owner: str
     # Priorities for Cash Flow
     inflow_priority: Optional[int] = 100 # Lower number = Higher priority
     withdrawal_priority: Optional[int] = 100
     # Withdrawal Limits
-    max_withdrawal_rate: Optional[float] = None # Percentage (0-100)
-    max_withdrawal_cap: Optional[float] = None # Fixed amount (e.g. 200000 for RSU)
+    max_withdrawal_rate: Optional[Decimal] = None # Percentage (0-100)
+    max_withdrawal_cap: Optional[Decimal] = None # Fixed amount (e.g. 200000 for RSU)
     currency: Optional[str] = 'ILS' # Default to ILS
     details: Optional[Dict[str, Any]] = None
 
@@ -33,11 +35,11 @@ class SnapshotData(BaseModel):
     items: List[FinanceItem] = []
     # We can add computed totals here or compute them on retrieval.
     # Storing them makes history queries faster/easier (e.g. "Select net_worth from snapshots")
-    total_savings: float
-    total_investments: float
-    total_assets: float
-    total_liabilities: float
-    net_worth: float
+    total_savings: Decimal
+    total_investments: Decimal
+    total_assets: Decimal
+    total_liabilities: Decimal
+    net_worth: Decimal
     date: Optional[date_type] = None
 
 # --- SQLModel Database Table ---
@@ -48,10 +50,10 @@ class FinanceSnapshot(SQLModel, table=True):
     date: date_type = Field(primary_key=True)
     
     # Store the entire snapshot as a JSON document
-    data: Dict = Field(sa_column=Column(JSON, nullable=False))
+    data: Dict = Field(sa_column=SMColumn(JSON, nullable=False))
     
     # We can also store top-level metrics as columns for easy SQL aggregation/graphing
     # without needing JSON extraction syntax in every query.
-    net_worth: float
-    total_assets: float
-    total_liabilities: float
+    net_worth: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    total_assets: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    total_liabilities: Decimal = Field(sa_column=Column(Numeric(18, 6)))

--- a/apps/backend/app/schema/insurance_models.py
+++ b/apps/backend/app/schema/insurance_models.py
@@ -1,7 +1,9 @@
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional
 
+from sqlalchemy import Column, Numeric
 from sqlmodel import Field, SQLModel
 
 
@@ -17,7 +19,7 @@ class InsurancePolicy(SQLModel, table=True):
     provider: str
     policy_number: Optional[str] = None
     sum_insured: str  # Free-text for display flexibility
-    monthly_premium: Optional[float] = None
+    monthly_premium: Optional[Decimal] = Field(default=None, sa_column=Column(Numeric(18, 6)))
     beneficiaries: Optional[str] = None
     expiry_date: Optional[str] = None  # ISO date string
     website: Optional[str] = None

--- a/apps/backend/app/schema/ladder_models.py
+++ b/apps/backend/app/schema/ladder_models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from decimal import Decimal
 from typing import List, Literal, Optional
 
 
@@ -11,8 +12,8 @@ class LadderRung:
     year: int
     start_date: date
     end_date: date
-    target_amount: float
-    current_amount: float
+    target_amount: Decimal
+    current_amount: Decimal
 
 
 @dataclass
@@ -21,8 +22,8 @@ class LadderBond:
     ticker: Optional[str] | None
     issuer: str
     currency: str
-    face_value: float
-    coupon_rate: float
+    face_value: Decimal
+    coupon_rate: Decimal
     coupon_frequency: str
     maturity_date: date
     rung_id: str
@@ -33,7 +34,7 @@ class BondCashflow:
     id: str
     bond_id: str
     date: date
-    amount: float
+    amount: Decimal
     currency: str
     type: Literal["COUPON", "PRINCIPAL"]
     rung_id: str
@@ -42,14 +43,14 @@ class BondCashflow:
 @dataclass
 class IncomePoint:
     date: date
-    value: float
+    value: Decimal
 
 
 @dataclass
 class DistributionRow:
     id: str
     date: date
-    amount: float
+    amount: Decimal
     currency: str
     type: Literal["COUPON", "PRINCIPAL"]
     bond_id: str

--- a/apps/backend/app/schema/models.py
+++ b/apps/backend/app/schema/models.py
@@ -1,7 +1,8 @@
 from datetime import datetime, date as date_type
+from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import BigInteger, Column
+from sqlalchemy import BigInteger, Column, Numeric
 from sqlmodel import Field, SQLModel
 
 
@@ -10,10 +11,10 @@ class ManualTrade(SQLModel, table=True):
     timestamp: datetime
     symbol: str
     side: str
-    size: float
-    entry_price: float
-    exit_price: float
-    pnl: float
+    size: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    entry_price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    exit_price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    pnl: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     notes: Optional[str] = None
 
 
@@ -23,7 +24,7 @@ class Trade(SQLModel, table=True):
     acctAlias: Optional[str] = None
     model: Optional[str] = None
     currency: str
-    fxRateToBase: float
+    fxRateToBase: Decimal = Field(sa_column=Column("fxRateToBase", Numeric(18, 6)))
     assetCategory: str
     subCategory: Optional[str] = None
     symbol: str
@@ -53,21 +54,21 @@ class Trade(SQLModel, table=True):
     settleDateTarget: Optional[date_type] = None
     transactionType: Optional[str] = None
     exchange: Optional[str] = None
-    quantity: float
-    tradePrice: float
-    tradeMoney: float
-    proceeds: float
-    taxes: float
-    ibCommission: float
+    quantity: Decimal = Field(sa_column=Column("quantity", Numeric(18, 6)))
+    tradePrice: Decimal = Field(sa_column=Column("tradePrice", Numeric(18, 6)))
+    tradeMoney: Decimal = Field(sa_column=Column("tradeMoney", Numeric(18, 6)))
+    proceeds: Decimal = Field(sa_column=Column("proceeds", Numeric(18, 6)))
+    taxes: Decimal = Field(sa_column=Column("taxes", Numeric(18, 6)))
+    ibCommission: Decimal = Field(sa_column=Column("ibCommission", Numeric(18, 6)))
     ibCommissionCurrency: Optional[str] = None
-    netCash: float
-    closePrice: float
+    netCash: Decimal = Field(sa_column=Column("netCash", Numeric(18, 6)))
+    closePrice: Decimal = Field(sa_column=Column("closePrice", Numeric(18, 6)))
     openCloseIndicator: Optional[str] = None
     notes: Optional[str] = None
-    cost: float
-    fifoPnlRealized: float
-    mtmPnl: float
-    origTradePrice: Optional[float] = None
+    cost: Decimal = Field(sa_column=Column("cost", Numeric(18, 6)))
+    fifoPnlRealized: Decimal = Field(sa_column=Column("fifoPnlRealized", Numeric(18, 6)))
+    mtmPnl: Decimal = Field(sa_column=Column("mtmPnl", Numeric(18, 6)))
+    origTradePrice: Optional[Decimal] = Field(default=None, sa_column=Column("origTradePrice", Numeric(18, 6)))
     origTradeDate: Optional[str] = None
     origTradeID: Optional[str] = None
     origOrderID: Optional[int] = Field(default=None, sa_column=Column(BigInteger))
@@ -90,28 +91,28 @@ class Trade(SQLModel, table=True):
     whenRealized: Optional[str] = None
     whenReopened: Optional[str] = None
     levelOfDetail: Optional[str] = None
-    changeInPrice: Optional[float] = None
-    changeInQuantity: Optional[float] = None
+    changeInPrice: Optional[Decimal] = Field(default=None, sa_column=Column("changeInPrice", Numeric(18, 6)))
+    changeInQuantity: Optional[Decimal] = Field(default=None, sa_column=Column("changeInQuantity", Numeric(18, 6)))
     orderType: Optional[str] = None
     traderID: Optional[str] = None
     isAPIOrder: Optional[str] = None
-    accruedInt: Optional[float] = None
+    accruedInt: Optional[Decimal] = Field(default=None, sa_column=Column("accruedInt", Numeric(18, 6)))
     initialInvestment: Optional[str] = None
     serialNumber: Optional[str] = None
     deliveryType: Optional[str] = None
     commodityType: Optional[str] = None
-    fineness: Optional[float] = None
-    weight: Optional[float] = None
+    fineness: Optional[Decimal] = Field(default=None, sa_column=Column("fineness", Numeric(18, 6)))
+    weight: Optional[Decimal] = Field(default=None, sa_column=Column("weight", Numeric(18, 6)))
 
 
 class DailySummary(SQLModel, table=True):
     date: date_type = Field(primary_key=True)
-    total_pnl: float
+    total_pnl: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     winning_trades: int
     losing_trades: int
-    win_rate: float
-    avg_win: float
-    avg_loss: float
+    win_rate: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    avg_win: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    avg_loss: Decimal = Field(sa_column=Column(Numeric(18, 6)))
 
 
 class Note(SQLModel, table=True):
@@ -121,28 +122,28 @@ class Note(SQLModel, table=True):
 
 class Ndx1m(SQLModel, table=True):
     timestamp: datetime = Field(primary_key=True)
-    open: float
-    high: float
-    low: float
-    close: float
+    open: Decimal = Field(sa_column=Column("open", Numeric(18, 6)))
+    high: Decimal = Field(sa_column=Column("high", Numeric(18, 6)))
+    low: Decimal = Field(sa_column=Column("low", Numeric(18, 6)))
+    close: Decimal = Field(sa_column=Column("close", Numeric(18, 6)))
     volume: int
 
 
 class Ndx1mChartData(SQLModel):
     time: float
-    open: float
-    high: float
-    low: float
-    close: float
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
 
 
 class DailyBar(SQLModel, table=True):
     symbol: str = Field(primary_key=True)
     date: date_type = Field(primary_key=True)
-    open: float
-    high: float
-    low: float
-    close: float
+    open: Decimal = Field(sa_column=Column("open", Numeric(18, 6)))
+    high: Decimal = Field(sa_column=Column("high", Numeric(18, 6)))
+    low: Decimal = Field(sa_column=Column("low", Numeric(18, 6)))
+    close: Decimal = Field(sa_column=Column("close", Numeric(18, 6)))
     volume: int
 
 
@@ -155,14 +156,14 @@ class Execution(SQLModel, table=True):
     acctNumber: str
     exchange: str
     side: str
-    shares: float
-    price: float
-    avgPrice: float
-    cumQty: float
+    shares: Decimal = Field(sa_column=Column("shares", Numeric(18, 6)))
+    price: Decimal = Field(sa_column=Column("price", Numeric(18, 6)))
+    avgPrice: Decimal = Field(sa_column=Column("avgPrice", Numeric(18, 6)))
+    cumQty: Decimal = Field(sa_column=Column("cumQty", Numeric(18, 6)))
     symbol: str
-    commission: float
+    commission: Decimal = Field(sa_column=Column("commission", Numeric(18, 6)))
     currency: str
-    realizedPNL: float | None = Field(default=None)
+    realizedPNL: Optional[Decimal] = Field(default=None, sa_column=Column("realizedPNL", Numeric(18, 6)))
 
 
 class MatchedTrade(SQLModel, table=True):
@@ -172,9 +173,9 @@ class MatchedTrade(SQLModel, table=True):
     open_date: datetime
     close_transaction_id: int = Field(sa_column=Column(BigInteger))
     close_date: datetime
-    open_price: float
-    close_price: float
-    pnl: float
+    open_price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    close_price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    pnl: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     notes: Optional[str] = None
 
 # Import backtest models to register them with SQLModel.metadata

--- a/apps/backend/app/schema/options_models.py
+++ b/apps/backend/app/schema/options_models.py
@@ -1,22 +1,23 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from pydantic import BaseModel
 
 
 class OptionsRecord(BaseModel):
     year: int
-    amount: float
+    amount: Decimal
 
 
 class OptionsProjectionParams(BaseModel):
-    growth_rate: float
+    growth_rate: Decimal
     cutoff_year: int
     final_year: int
 
 
 class OptionsProjectionPoint(BaseModel):
     year: int
-    amount: float
+    amount: Decimal
     type: str  # "historical" or "projected"
 
 

--- a/apps/backend/app/schema/plan_models.py
+++ b/apps/backend/app/schema/plan_models.py
@@ -1,4 +1,5 @@
 from datetime import datetime, date as date_type
+from decimal import Decimal
 from typing import List, Dict, Optional, Union
 from pydantic import BaseModel
 from sqlmodel import SQLModel, Field, Column, JSON
@@ -14,8 +15,8 @@ class PlanItem(BaseModel):
     currency: str = "ILS" # "USD", "ILS", "EUR"
     
     # Financials
-    value: float = 0.0 # Annual Amount or Current Value
-    growth_rate: float = 0.0 # Percentage
+    value: Decimal = Decimal("0") # Annual Amount or Current Value
+    growth_rate: Decimal = Decimal("0") # Percentage
     
     # Timing
     start_date: Optional[Union[date_type, str]] = None # specific date or "Today"
@@ -23,7 +24,7 @@ class PlanItem(BaseModel):
     frequency: str = "Yearly" # "Monthly", "Yearly", "OneTime"
     
     # New Fields matching Frontend types.ts
-    tax_rate: Optional[float] = 0.0
+    tax_rate: Optional[Decimal] = Decimal("0")
     start_condition: Optional[str] = None
     start_reference: Optional[str] = None
     end_condition: Optional[str] = None

--- a/apps/backend/app/schema/trading_models.py
+++ b/apps/backend/app/schema/trading_models.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional
+from sqlalchemy import Column, Numeric
 from sqlmodel import SQLModel, Field
 
 class TradingAccountType(str, Enum):
@@ -37,8 +39,8 @@ class TradingAccountSummary(SQLModel, table=True):
     
     id: Optional[int] = Field(default=None, primary_key=True)
     account_config_id: Optional[int] = Field(default=None, foreign_key="trading_account_config.id")
-    net_liquidation: float
-    total_cash: float
+    net_liquidation: Decimal = Field(sa_column=Column(Numeric(18, 6)))
+    total_cash: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     currency: str = Field(default="USD")
     timestamp: datetime = Field(default_factory=datetime.utcnow)
 
@@ -48,8 +50,8 @@ class TradingPosition(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     account_config_id: Optional[int] = Field(default=None, foreign_key="trading_account_config.id")
     symbol: str
-    amount: float
+    amount: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     sec_type: str
-    avg_cost: float
+    avg_cost: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     con_id: Optional[int] = Field(default=None) # Optional for non-IBKR
     timestamp: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/backend/app/utils/decimal_encoder.py
+++ b/apps/backend/app/utils/decimal_encoder.py
@@ -1,0 +1,21 @@
+"""Custom JSON encoding for Decimal types in FastAPI responses.
+
+Converts Decimal values to float so API consumers receive numbers (not strings),
+preserving backward compatibility with existing frontend code.
+"""
+from decimal import Decimal
+from typing import Any
+
+from fastapi.encoders import ENCODERS_BY_TYPE
+
+
+def decimal_default(obj: Any) -> Any:
+    """JSON serializer fallback that converts Decimal -> float."""
+    if isinstance(obj, Decimal):
+        return float(obj)
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+# Register Decimal -> float with FastAPI's jsonable_encoder so that
+# response models containing Decimal fields are serialized as numbers.
+ENCODERS_BY_TYPE[Decimal] = float

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,9 +1,14 @@
+import json
+from decimal import Decimal
+
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 import uvicorn
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.dal.database import create_db_and_tables
+from app.utils.decimal_encoder import decimal_default
 from app.api import (
     trades,
     day,
@@ -62,6 +67,20 @@ metrics.set_meter_provider(meter_provider)
 
 LoggingInstrumentor().instrument(set_logging_format=True)
 
+
+class DecimalSafeJSONResponse(JSONResponse):
+    """JSONResponse that serializes Decimal values as numbers (float)."""
+    def render(self, content) -> bytes:
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            indent=None,
+            separators=(",", ":"),
+            default=decimal_default,
+        ).encode("utf-8")
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     print("Creating tables..")
@@ -75,6 +94,7 @@ app = FastAPI(
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=lifespan,
+    default_response_class=DecimalSafeJSONResponse,
 )
 
 # Instrument FastAPI

--- a/apps/backend/tests/test_dividend_projection.py
+++ b/apps/backend/tests/test_dividend_projection.py
@@ -140,7 +140,7 @@ class TestDividendProjectionCompounding:
         projected = [p for p in result.data if p.type == "projected"]
         assert len(projected) == 3
         expected = 1000.0 * (1.08 ** 3)
-        assert projected[-1].amount == pytest.approx(expected, rel=1e-6)
+        assert float(projected[-1].amount) == pytest.approx(expected, rel=1e-6)
 
     def test_zero_growth_rate(self):
         """With zero growth, only reinvest yield applies."""

--- a/apps/backend/tests/test_dividend_service_enrich.py
+++ b/apps/backend/tests/test_dividend_service_enrich.py
@@ -129,8 +129,8 @@ class TestEnrichPositions:
         result = enrich_positions(positions, mock_db, target_currency="USD")
 
         # Total value = 2000, total income = 80
-        assert result["stats"].portfolio_yield == pytest.approx(0.04)
-        assert result["stats"].annual_income == pytest.approx(80.0)
+        assert float(result["stats"].portfolio_yield) == pytest.approx(0.04)
+        assert float(result["stats"].annual_income) == pytest.approx(80.0)
 
     @patch("app.services.dividend_service.get_market_data_batch")
     @patch("app.services.dividend_service.convert_currency")
@@ -169,7 +169,7 @@ class TestEnrichPositions:
         result = enrich_positions(positions, mock_db, target_currency="USD")
 
         # Only X(0.10) and Y(0.06) count: avg = 0.08
-        assert result["stats"].dgr_5y == pytest.approx(0.08)
+        assert float(result["stats"].dgr_5y) == pytest.approx(0.08)
 
 
 # ===================================================================

--- a/apps/backend/tests/test_options_projection.py
+++ b/apps/backend/tests/test_options_projection.py
@@ -115,7 +115,7 @@ class TestOptionsProjectionGrowth:
         projected = [p for p in result.data if p.type == "projected"]
         assert len(projected) == 3
         expected = 5000.0 * (1.10 ** 3)
-        assert projected[-1].amount == pytest.approx(expected, rel=1e-6)
+        assert float(projected[-1].amount) == pytest.approx(expected, rel=1e-6)
 
     def test_base_is_average_of_historical(self):
         """Base amount = average(2000, 4000, 6000) = 4000."""


### PR DESCRIPTION
Closes #9

## Changes
- **9 schema files**: All ~80+ monetary `float` → `Decimal` with `sa_column=Column(Numeric(18,6))`
- **Alembic migration**: Safe PostgreSQL column type conversion (`ALTER COLUMN TYPE NUMERIC(18,6)`)
- **JSON serialization**: `DecimalSafeJSONResponse` + FastAPI `ENCODERS_BY_TYPE` registration
- **Test fixes**: 4 assertions updated for Decimal compatibility
- **Decision doc**: Written to `.squad/decisions/inbox/`

## Testing
- 238 tests pass (2 pre-existing DB failures unchanged)
- plan_service.py simulation engine deferred to separate refactor

Working as McManus (Data/Finance Specialist)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>