### PR TITLE
feat: Add JWT authentication to all API endpoints

### DIFF
--- a/.squad/decisions/inbox/rabin-auth.md
+++ b/.squad/decisions/inbox/rabin-auth.md
@@ -1,0 +1,43 @@
+# Decision: JWT Authentication for API Endpoints
+
+**Author:** Rabin (Security Specialist)  
+**Date:** 2025-07-26  
+**Status:** Implemented  
+**Issue:** #1 — Add authentication to API endpoints
+
+## Context
+
+All 18+ API endpoints lacked authentication. Anyone with network access could view, modify, or delete financial data. This was the #1 blocker for non-localhost deployment.
+
+## Decision
+
+Implement JWT-based authentication using `python-jose` + `passlib[bcrypt]`.
+
+### Key choices:
+
+| Decision | Rationale |
+|----------|-----------|
+| JWT Bearer tokens | Stateless, no server-side session storage needed |
+| bcrypt password hashing | Industry standard, resistant to brute-force |
+| Router-level `dependencies=` | Clean separation — auth applied per router include in main.py |
+| Public paths: `/`, `/api/auth/register`, `/api/auth/login` | Minimum surface area for unauthenticated access |
+| No roles/permissions | Single-user personal app — authenticated = authorized |
+| `JWT_SECRET_KEY` env var with dev default | Safe for local dev, forces explicit config for production |
+| 60-minute token expiry | Balance between convenience and security |
+| bcrypt < 4.1 pinned | passlib incompatible with bcrypt 5.x |
+
+## Files Changed
+
+- `app/schema/user_models.py` — User model + Pydantic schemas
+- `app/auth/security.py` — JWT + bcrypt helpers
+- `app/auth/dependencies.py` — `get_current_user` FastAPI dependency
+- `app/api/auth.py` — Register, login, me endpoints
+- `main.py` — Auth router + `dependencies=auth_dep` on all data routers
+- `alembic/versions/acfa0cdeaae7_add_users_table.py` — Migration
+- `tests/conftest.py` — Auth-aware test fixtures
+- `tests/test_auth.py` — 13 auth-specific tests
+
+## Risks
+
+- `passlib` is unmaintained; may need replacement if Python 3.13+ drops `crypt` module
+- Dev default secret key must never reach production — document in deployment guide

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,0 +1,13 @@
+# Database
+DATABASE_URL=postgresql://user:password@localhost/trading_journal
+
+# JWT Authentication
+JWT_SECRET_KEY=change-me-to-a-random-secret
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+# CORS
+CORS_ORIGINS=http://localhost:3000
+
+# OpenTelemetry
+OTEL_SERVICE_NAME=trading-journal-backend
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/apps/backend/alembic/env.py
+++ b/apps/backend/alembic/env.py
@@ -23,6 +23,7 @@ if config.config_file_name is not None:
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
 from app.schema.models import SQLModel
+from app.schema.user_models import User  # noqa: F401 — ensure User table is registered
 # from app.dal.database import DATABASE_URL
 # config.set_main_option('sqlalchemy.url', DATABASE_URL)
 target_metadata = SQLModel.metadata

--- a/apps/backend/alembic/versions/acfa0cdeaae7_add_users_table.py
+++ b/apps/backend/alembic/versions/acfa0cdeaae7_add_users_table.py
@@ -1,0 +1,35 @@
+"""add users table
+
+Revision ID: acfa0cdeaae7
+Revises: 4d9a58ecd93b
+Create Date: 2025-07-26
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+import sqlmodel
+
+
+revision: str = "acfa0cdeaae7"
+down_revision: Union[str, None] = "4d9a58ecd93b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("username", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("hashed_password", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("true")),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_user_username"), "user", ["username"], unique=True)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_user_username"), table_name="user")
+    op.drop_table("user")

--- a/apps/backend/app/api/auth.py
+++ b/apps/backend/app/api/auth.py
@@ -1,0 +1,56 @@
+"""Authentication router — register, login, me."""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, select
+
+from app.auth.dependencies import get_current_user
+from app.auth.security import create_access_token, hash_password, verify_password
+from app.dal.database import get_session
+from app.schema.user_models import Token, User, UserCreate, UserResponse
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserResponse)
+def register(user_in: UserCreate, session: Session = Depends(get_session)):
+    """Create a new user account."""
+    existing = session.exec(
+        select(User).where(User.username == user_in.username)
+    ).first()
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already taken",
+        )
+
+    user = User(
+        username=user_in.username,
+        hashed_password=hash_password(user_in.password),
+    )
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+@router.post("/login", response_model=Token)
+def login(user_in: UserCreate, session: Session = Depends(get_session)):
+    """Authenticate and return a JWT access token."""
+    user = session.exec(
+        select(User).where(User.username == user_in.username)
+    ).first()
+    if not user or not verify_password(user_in.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid username or password",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    token = create_access_token(data={"sub": user.username})
+    return Token(access_token=token)
+
+
+@router.get("/me", response_model=UserResponse)
+def me(current_user: User = Depends(get_current_user)):
+    """Return current authenticated user info."""
+    return current_user

--- a/apps/backend/app/auth/dependencies.py
+++ b/apps/backend/app/auth/dependencies.py
@@ -1,0 +1,46 @@
+"""FastAPI dependencies for authentication."""
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlmodel import Session, select
+
+from app.auth.security import verify_token
+from app.dal.database import get_session
+from app.schema.user_models import User
+
+bearer_scheme = HTTPBearer()
+
+
+def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+    session: Session = Depends(get_session),
+) -> User:
+    """Extract and validate JWT from Authorization header.
+
+    Returns the authenticated User or raises 401.
+    """
+    payload = verify_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    username: str = payload.get("sub")
+    if username is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token payload",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    user = session.exec(select(User).where(User.username == username)).first()
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found or inactive",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    return user

--- a/apps/backend/app/auth/security.py
+++ b/apps/backend/app/auth/security.py
@@ -1,0 +1,47 @@
+"""JWT token creation/verification and password hashing."""
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from jose import JWTError, jwt
+from passlib.context import CryptContext
+
+SECRET_KEY = os.getenv("JWT_SECRET_KEY", "dev-secret-change-in-production")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = int(
+    os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+)
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password using bcrypt."""
+    return pwd_context.hash(password)
+
+
+def verify_password(plain_password: str, hashed_password: str) -> bool:
+    """Verify a plaintext password against a bcrypt hash."""
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(
+    data: dict, expires_delta: Optional[timedelta] = None
+) -> str:
+    """Create a signed JWT access token."""
+    to_encode = data.copy()
+    expire = datetime.now(timezone.utc) + (
+        expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def verify_token(token: str) -> Optional[dict]:
+    """Decode and verify a JWT token. Returns payload or None."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        return payload
+    except JWTError:
+        return None

--- a/apps/backend/app/schema/user_models.py
+++ b/apps/backend/app/schema/user_models.py
@@ -1,0 +1,32 @@
+"""User models for authentication."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel
+from sqlmodel import Field, SQLModel
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True, unique=True)
+    hashed_password: str
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class UserCreate(BaseModel):
+    username: str
+    password: str
+
+
+class UserResponse(BaseModel):
+    id: int
+    username: str
+    is_active: bool
+    created_at: datetime
+
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str = "bearer"

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,7 +1,7 @@
 import json
 from decimal import Decimal
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
 import uvicorn
 from contextlib import asynccontextmanager
@@ -9,7 +9,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.dal.database import create_db_and_tables
 from app.utils.decimal_encoder import decimal_default
+from app.auth.dependencies import get_current_user
 from app.api import (
+    auth as auth_router_module,
     trades,
     day,
     summary,
@@ -117,31 +119,41 @@ app.add_middleware(
 
 app.add_middleware(SecurityHeadersMiddleware)
 
+# Public paths that skip JWT authentication
+PUBLIC_PATHS = {"/", "/docs", "/redoc", "/openapi.json", "/api/auth/register", "/api/auth/login"}
+
+
 @app.get("/")
 def read_root():
     """Health-check root endpoint."""
     return {"Hello": "World"}
 
+# Auth router (public endpoints — registered first, no auth dependency)
+app.include_router(auth_router_module.router)
+
+# All remaining routers require authentication
+auth_dep = [Depends(get_current_user)]
+
 # Include routers
-app.include_router(trades.router, prefix="/api", tags=["trades"])
-app.include_router(day.router, prefix="/api", tags=["day"])
-app.include_router(summary.router, prefix="/api", tags=["summary"])
-app.include_router(ndx.router, prefix="/api", tags=["ndx"])
-app.include_router(ladder.router, prefix="/api", tags=["ladder"])
-app.include_router(holdings.router, prefix="/api", tags=["holdings"])
-app.include_router(bonds.router, prefix="/api", tags=["bonds"])
-app.include_router(dividends.router, prefix="/api", tags=["dividends"])
-app.include_router(dividend_accounts.router)
-app.include_router(options.router, prefix="/api", tags=["options"])
-app.include_router(tax_condor.router, prefix="/api/tax-condor", tags=["tax-condor"])
-app.include_router(backtest.router, prefix="/api/backtest", tags=["backtest"])
-app.include_router(finances.router)
-app.include_router(plans.router)
-app.include_router(trading.router)
-app.include_router(pension.router)
-app.include_router(analyze.router)
-app.include_router(insurance.router)
-app.include_router(telemetry_metrics.router)
+app.include_router(trades.router, prefix="/api", tags=["trades"], dependencies=auth_dep)
+app.include_router(day.router, prefix="/api", tags=["day"], dependencies=auth_dep)
+app.include_router(summary.router, prefix="/api", tags=["summary"], dependencies=auth_dep)
+app.include_router(ndx.router, prefix="/api", tags=["ndx"], dependencies=auth_dep)
+app.include_router(ladder.router, prefix="/api", tags=["ladder"], dependencies=auth_dep)
+app.include_router(holdings.router, prefix="/api", tags=["holdings"], dependencies=auth_dep)
+app.include_router(bonds.router, prefix="/api", tags=["bonds"], dependencies=auth_dep)
+app.include_router(dividends.router, prefix="/api", tags=["dividends"], dependencies=auth_dep)
+app.include_router(dividend_accounts.router, dependencies=auth_dep)
+app.include_router(options.router, prefix="/api", tags=["options"], dependencies=auth_dep)
+app.include_router(tax_condor.router, prefix="/api/tax-condor", tags=["tax-condor"], dependencies=auth_dep)
+app.include_router(backtest.router, prefix="/api/backtest", tags=["backtest"], dependencies=auth_dep)
+app.include_router(finances.router, dependencies=auth_dep)
+app.include_router(plans.router, dependencies=auth_dep)
+app.include_router(trading.router, dependencies=auth_dep)
+app.include_router(pension.router, dependencies=auth_dep)
+app.include_router(analyze.router, dependencies=auth_dep)
+app.include_router(insurance.router, dependencies=auth_dep)
+app.include_router(telemetry_metrics.router, dependencies=auth_dep)
 
 if __name__ == "__main__":
     uvicorn.run("main:app", host="0.0.0.0", port=8001, reload=True)

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "pypdf>=6.10.0",
     "python-multipart>=0.0.22",
     "cachetools>=7.0.5",
+    "python-jose[cryptography]>=3.5.0",
+    "passlib[bcrypt]>=1.7.4",
+    "bcrypt<4.1",
 ]
 requires-python = ">=3.10"
 

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -12,6 +12,8 @@ from fastapi.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
 
 from app.dal.database import get_session
+from app.auth.dependencies import get_current_user
+from app.schema.user_models import User
 
 
 @pytest.fixture(name="engine")
@@ -50,26 +52,25 @@ def session_fixture(engine) -> Generator[Session, None, None]:
         yield session
 
 
+def _fake_current_user():
+    """Return a stub user for tests that bypass real auth."""
+    return User(id=1, username="testuser", hashed_password="x", is_active=True)
+
+
 @pytest.fixture(name="client")
 def client_fixture(session: Session) -> Generator[TestClient, None, None]:
     """Create a FastAPI TestClient with dependency overrides.
     
-    This fixture creates a synchronous test client that uses the test
-    database session instead of the production database.
-    
-    Args:
-        session: The test database session fixture
-        
-    Yields:
-        TestClient: FastAPI test client for API endpoint testing
+    Provides an authenticated test client by default — all protected
+    endpoints are accessible without a real JWT.
     """
-    # Import app here to avoid circular imports and instrumentation issues
     from main import app
     
     def get_session_override():
         return session
     
     app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_current_user] = _fake_current_user
     
     with TestClient(app) as client:
         yield client
@@ -77,26 +78,39 @@ def client_fixture(session: Session) -> Generator[TestClient, None, None]:
     app.dependency_overrides.clear()
 
 
+@pytest.fixture(name="unauth_client")
+def unauth_client_fixture(session: Session) -> Generator[TestClient, None, None]:
+    """Create a FastAPI TestClient WITHOUT auth override.
+
+    Useful for testing that endpoints properly reject unauthenticated requests.
+    """
+    from main import app
+
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    # Do NOT override get_current_user — real auth is enforced
+
+    with TestClient(app) as client:
+        yield client
+
+    app.dependency_overrides.clear()
+
+
 @pytest.fixture(name="async_client")
 async def async_client_fixture(session: Session) -> Generator[AsyncClient, None, None]:
     """Create an async HTTPX client for testing async API endpoints.
     
-    This fixture creates an asynchronous test client that uses the test
-    database session and can handle async operations.
-    
-    Args:
-        session: The test database session fixture
-        
-    Yields:
-        AsyncClient: HTTPX async client for testing
+    Provides an authenticated async client by default.
     """
-    # Import app here to avoid circular imports and instrumentation issues
     from main import app
     
     def get_session_override():
         return session
     
     app.dependency_overrides[get_session] = get_session_override
+    app.dependency_overrides[get_current_user] = _fake_current_user
     
     async with AsyncClient(
         transport=ASGITransport(app=app),

--- a/apps/backend/tests/test_auth.py
+++ b/apps/backend/tests/test_auth.py
@@ -1,0 +1,122 @@
+"""Tests for authentication endpoints and JWT protection."""
+
+import pytest
+from app.auth.security import hash_password, verify_password, create_access_token, verify_token
+from app.schema.user_models import User
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for security helpers
+# ---------------------------------------------------------------------------
+
+class TestPasswordHashing:
+    def test_hash_and_verify(self):
+        hashed = hash_password("secret123")
+        assert verify_password("secret123", hashed)
+
+    def test_wrong_password(self):
+        hashed = hash_password("secret123")
+        assert not verify_password("wrong", hashed)
+
+
+class TestJWT:
+    def test_create_and_verify(self):
+        token = create_access_token(data={"sub": "alice"})
+        payload = verify_token(token)
+        assert payload is not None
+        assert payload["sub"] == "alice"
+
+    def test_invalid_token(self):
+        assert verify_token("not.a.token") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests for auth endpoints
+# ---------------------------------------------------------------------------
+
+class TestRegister:
+    def test_register_success(self, unauth_client):
+        resp = unauth_client.post(
+            "/api/auth/register",
+            json={"username": "newuser", "password": "pass1234"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["username"] == "newuser"
+        assert "hashed_password" not in data
+
+    def test_register_duplicate(self, unauth_client):
+        unauth_client.post(
+            "/api/auth/register",
+            json={"username": "dup", "password": "pass"},
+        )
+        resp = unauth_client.post(
+            "/api/auth/register",
+            json={"username": "dup", "password": "pass"},
+        )
+        assert resp.status_code == 409
+
+
+class TestLogin:
+    def test_login_success(self, unauth_client):
+        unauth_client.post(
+            "/api/auth/register",
+            json={"username": "loginuser", "password": "secret"},
+        )
+        resp = unauth_client.post(
+            "/api/auth/login",
+            json={"username": "loginuser", "password": "secret"},
+        )
+        assert resp.status_code == 200
+        assert "access_token" in resp.json()
+
+    def test_login_bad_password(self, unauth_client):
+        unauth_client.post(
+            "/api/auth/register",
+            json={"username": "user2", "password": "right"},
+        )
+        resp = unauth_client.post(
+            "/api/auth/login",
+            json={"username": "user2", "password": "wrong"},
+        )
+        assert resp.status_code == 401
+
+
+class TestMe:
+    def test_me_authenticated(self, unauth_client):
+        unauth_client.post(
+            "/api/auth/register",
+            json={"username": "meuser", "password": "pw"},
+        )
+        login_resp = unauth_client.post(
+            "/api/auth/login",
+            json={"username": "meuser", "password": "pw"},
+        )
+        token = login_resp.json()["access_token"]
+        resp = unauth_client.get(
+            "/api/auth/me",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["username"] == "meuser"
+
+    def test_me_no_token(self, unauth_client):
+        resp = unauth_client.get("/api/auth/me")
+        assert resp.status_code == 403  # HTTPBearer returns 403 when missing
+
+
+class TestProtectedRoutes:
+    def test_protected_route_rejects_no_auth(self, unauth_client):
+        """Any data endpoint should reject unauthenticated requests."""
+        resp = unauth_client.get("/api/holdings")
+        assert resp.status_code == 403
+
+    def test_health_check_public(self, unauth_client):
+        """Root health-check must remain public."""
+        resp = unauth_client.get("/")
+        assert resp.status_code == 200
+
+    def test_protected_route_accepts_auth(self, client):
+        """Client fixture has auth override, so data endpoints work."""
+        resp = client.get("/")
+        assert resp.status_code == 200

--- a/apps/backend/tests/test_performance.py
+++ b/apps/backend/tests/test_performance.py
@@ -6,8 +6,13 @@ import time
 from fastapi.testclient import TestClient
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app.auth.dependencies import get_current_user
+from app.schema.user_models import User
 from main import app
 
+app.dependency_overrides[get_current_user] = lambda: User(
+    id=1, username="testuser", hashed_password="x", is_active=True
+)
 client = TestClient(app)
 
 SIMULATION_BUDGET_MS = float(os.getenv("PERF_SIMULATION_BUDGET_MS", "1200"))

--- a/apps/backend/tests/test_simulation.py
+++ b/apps/backend/tests/test_simulation.py
@@ -1,8 +1,13 @@
 
 from fastapi.testclient import TestClient
 from app.services.plan_service import PlanService
+from app.auth.dependencies import get_current_user
+from app.schema.user_models import User
 from main import app
 
+app.dependency_overrides[get_current_user] = lambda: User(
+    id=1, username="testuser", hashed_password="x", is_active=True
+)
 client = TestClient(app)
 
 def test_plan_simulation_structure():

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -103,6 +103,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "bcrypt" },
     { name = "cachetools" },
     { name = "fastapi" },
     { name = "github-copilot-sdk" },
@@ -115,11 +116,13 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "passlib", extra = ["bcrypt"] },
     { name = "pdfplumber" },
     { name = "psycopg2-binary" },
     { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "schwab-py" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -142,6 +145,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic" },
+    { name = "bcrypt", specifier = "<4.1" },
     { name = "cachetools", specifier = ">=7.0.5" },
     { name = "fastapi" },
     { name = "github-copilot-sdk", specifier = ">=0.1.25" },
@@ -153,11 +157,13 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
+    { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pdfplumber", specifier = ">=0.11.9" },
     { name = "psycopg2-binary" },
     { name = "pypdf", specifier = ">=6.10.0" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.5.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
     { name = "schwab-py" },
     { name = "scipy", specifier = ">=1.15.3" },
@@ -183,6 +189,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313 },
+]
+
+[[package]]
+name = "bcrypt"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz", hash = "sha256:27d375903ac8261cfe4047f6709d16f7d18d39b1ec92aaf72af989552a650ebd", size = 25498 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/d4/3b2657bd58ef02b23a07729b0df26f21af97169dbd0b5797afa9e97ebb49/bcrypt-4.0.1-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:b1023030aec778185a6c16cf70f359cbb6e0c289fd564a7cfa29e727a1c38f8f", size = 473446 },
+    { url = "https://files.pythonhosted.org/packages/ec/0a/1582790232fef6c2aa201f345577306b8bfe465c2c665dec04c86a016879/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:08d2947c490093a11416df18043c27abe3921558d2c03e2076ccb28a116cb6d0", size = 583044 },
+    { url = "https://files.pythonhosted.org/packages/41/16/49ff5146fb815742ad58cafb5034907aa7f166b1344d0ddd7fd1c818bd17/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0eaa47d4661c326bfc9d08d16debbc4edf78778e6aaba29c1bc7ce67214d4410", size = 583189 },
+    { url = "https://files.pythonhosted.org/packages/aa/48/fd2b197a9741fa790ba0b88a9b10b5e88e62ff5cf3e1bc96d8354d7ce613/bcrypt-4.0.1-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae88eca3024bb34bb3430f964beab71226e761f51b912de5133470b649d82344", size = 593473 },
+    { url = "https://files.pythonhosted.org/packages/7d/50/e683d8418974a602ba40899c8a5c38b3decaf5a4d36c32fc65dce454d8a8/bcrypt-4.0.1-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:a522427293d77e1c29e303fc282e2d71864579527a04ddcfda6d4f8396c6c36a", size = 593249 },
+    { url = "https://files.pythonhosted.org/packages/fb/a7/ee4561fd9b78ca23c8e5591c150cc58626a5dfb169345ab18e1c2c664ee0/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:fbdaec13c5105f0c4e5c52614d04f0bca5f5af007910daa8b6b12095edaa67b3", size = 583586 },
+    { url = "https://files.pythonhosted.org/packages/64/fe/da28a5916128d541da0993328dc5cf4b43dfbf6655f2c7a2abe26ca2dc88/bcrypt-4.0.1-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ca3204d00d3cb2dfed07f2d74a25f12fc12f73e606fcaa6975d1f7ae69cacbb2", size = 593659 },
+    { url = "https://files.pythonhosted.org/packages/dd/4f/3632a69ce344c1551f7c9803196b191a8181c6a1ad2362c225581ef0d383/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:089098effa1bc35dc055366740a067a2fc76987e8ec75349eb9484061c54f535", size = 613116 },
+    { url = "https://files.pythonhosted.org/packages/87/69/edacb37481d360d06fc947dab5734aaf511acb7d1a1f9e2849454376c0f8/bcrypt-4.0.1-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e9a51bbfe7e9802b5f3508687758b564069ba937748ad7b9e890086290d2f79e", size = 624290 },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/6a534669890725cbb8c1fb4622019be31813c8edaa7b6d5b62fc9360a17e/bcrypt-4.0.1-cp36-abi3-win32.whl", hash = "sha256:2caffdae059e06ac23fce178d31b4a702f2a3264c20bfb5ff541b338194d8fab", size = 159428 },
+    { url = "https://files.pythonhosted.org/packages/46/81/d8c22cd7e5e1c6a7d48e41a1d1d46c92f17dae70a54d9814f746e6027dec/bcrypt-4.0.1-cp36-abi3-win_amd64.whl", hash = "sha256:8a68f4341daf7522fe8d73874de8906f3a339048ba406be6ddc1b3ccb16fc0d9", size = 152930 },
 ]
 
 [[package]]
@@ -476,6 +501,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019 },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818 },
 ]
 
 [[package]]
@@ -1350,6 +1387,20 @@ wheels = [
 ]
 
 [[package]]
+name = "passlib"
+version = "1.7.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/06/9da9ee59a67fae7761aab3ccc84fa4f3f33f125b370f1ccdb915bf967c11/passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04", size = 689844 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/a4/ab6b7589382ca3df236e03faa71deac88cae040af60c071a78d254a62172/passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1", size = 525554 },
+]
+
+[package.optional-dependencies]
+bcrypt = [
+    { name = "bcrypt" },
+]
+
+[[package]]
 name = "pdfminer-six"
 version = "20251230"
 source = { registry = "https://pypi.org/simple" }
@@ -1596,6 +1647,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997 },
+]
+
+[[package]]
 name = "pycodestyle"
 version = "2.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1819,6 +1879,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624 },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "python-multipart"
 version = "0.0.22"
 source = { registry = "https://pypi.org/simple" }
@@ -1893,6 +1972,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847 },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Closes #1 — Adds JWT-based authentication to protect all 18 API endpoints.

Working as **Rabin** (Security Specialist).

### What's included:
| Component | File | Description |
|-----------|------|-------------|
| User model | `app/schema/user_models.py` | SQLModel with username, hashed_password, is_active |
| Auth security | `app/auth/security.py` | JWT create/verify + bcrypt hash/verify |
| Auth dependency | `app/auth/dependencies.py` | `get_current_user` FastAPI dependency |
| Auth router | `app/api/auth.py` | register, login, me endpoints |
| DB migration | `alembic/versions/acfa0cdeaae7_` | Users table |
| Route protection | `main.py` | Auth dependency on all 18 data routers |
| Tests | `tests/test_auth.py` | 13 auth tests (register, login, protected routes) |
| Config | `.env.example` | JWT_SECRET_KEY placeholder |

### Public endpoints (no auth required):
- `/` — health check
- `/docs` — OpenAPI docs
- `/api/auth/register` — user registration
- `/api/auth/login` — get JWT token

### All other endpoints require:
```
Authorization: Bearer <jwt_token>
```

### Test results:
- 13 new auth tests pass ✅
- 250+ existing tests still pass ✅

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>