### PR TITLE
feat(infra): Vercel project config + setup runbook (TJ-019)

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -308,3 +308,11 @@ Full CRUD API for insurance policies at `/api/insurance` — list (with optional
 
 **Branch:** `squad/18-insurance-policies-api`
 **Tests:** 114 existing tests pass (1 pre-existing failure needs Postgres)
+
+### 2026-07: TJ-019 — Vercel Project Config + Setup Runbook (GH #72)
+
+**Deliverables:** Created `apps/frontend/vercel.json` (framework, buildCommand, security headers, `preferredRegion: fra1` via functions config), `apps/frontend/.vercelignore`, updated `apps/frontend/next.config.ts` (added `images.remotePatterns` for Supabase CDN), and runbooks `vercel-04-project-link-and-env.md` + `vercel-05-deployment-flow.md`.
+**Key decisions:** Used `functions.preferredRegion` instead of top-level `regions` (Hobby-incompatible per vercel-01); `SUPABASE_SERVICE_ROLE_KEY` scoped Production-only; `experimental.serverActions` not added (stable in Next.js 15); CSP header allows `*.supabase.co` for storage CDN and WebSocket realtime.
+**User actions required:** Run `vercel login` + `vercel link` from `apps/frontend/`, add env vars via `vercel env add` per runbook §2, and assign custom domain via `vercel domains add`.
+**Branch:** `squad/72-vercel-project-setup`
+**PR:** Closes #72

--- a/.squad/decisions/inbox/hockney-tj019-vercel.md
+++ b/.squad/decisions/inbox/hockney-tj019-vercel.md
@@ -1,0 +1,82 @@
+# Decision: TJ-019 Vercel Project Config
+
+**Author:** Hockney  
+**Date:** 2026-07  
+**Issue:** TJ-019 / GH #72  
+**Status:** Decided
+
+---
+
+## Context
+
+Setting up Vercel project config files and runbooks for the Next.js frontend
+monorepo subapp at `apps/frontend/`. Key choices were needed on region, env var
+scoping, security headers, and `next.config.ts` changes.
+
+---
+
+## Decisions
+
+### 1. Region: `fra1` (Frankfurt) via `functions.preferredRegion`
+
+**Decision:** Use `fra1` (Frankfurt, `eu-central-1`) as the function region.
+
+**Rationale:**
+- User is in Tel Aviv, Israel. Frankfurt is the geographically closest Vercel
+  region with an active EU data center.
+- `fra1` is also the Supabase-recommended region for EU deployments; co-locating
+  Vercel functions and the Supabase database in Frankfurt minimises round-trip
+  latency on every Server Action (~80–120 ms savings vs. `iad1`).
+- Implemented via `functions.preferredRegion` in `vercel.json` (not the top-level
+  `regions` array, which is Pro/Enterprise only and breaks Hobby builds per
+  `vercel-01-project.md`).
+
+### 2. `SUPABASE_SERVICE_ROLE_KEY` — Production-only scope
+
+**Decision:** `SUPABASE_SERVICE_ROLE_KEY` is added to Production environment only,
+not Preview or Development.
+
+**Rationale:**
+- The service role key bypasses all Supabase RLS policies. Leaking it to preview
+  builds exposes it in Vercel build logs and to any contributor with dashboard access.
+- Preview environments use the dev Supabase project with the anon key + RLS — which
+  is the correct security posture.
+- Developers needing service-role operations locally should use `supabase status`
+  to get the local service role key.
+
+### 3. `experimental.serverActions` not added to `next.config.ts`
+
+**Decision:** Do not add `experimental.serverActions: true` to `next.config.ts`.
+
+**Rationale:**
+- Server Actions became stable (GA) in Next.js 14. This project uses Next.js 15.3.4.
+  The experimental flag is a no-op at best and potentially confusing at worst.
+
+### 4. `output: 'standalone'` not added
+
+**Decision:** Do not add `output: 'standalone'` to `next.config.ts`.
+
+**Rationale:**
+- Vercel builds Next.js natively and does not require standalone output mode.
+- Standalone mode is needed for Docker/self-hosted deployments only (TJ-024 compute worker).
+- Adding it could interfere with Vercel's own output handling. Conservative approach taken.
+
+### 5. CSP `unsafe-inline` + `unsafe-eval`
+
+**Decision:** CSP header includes `'unsafe-inline'` and `'unsafe-eval'` for scripts.
+
+**Rationale:**
+- Next.js 15 App Router injects inline scripts for hydration. Restricting these
+  breaks the app without a nonce or hash-based CSP implementation.
+- This is acceptable as a baseline; a stricter nonce-based CSP is a future hardening
+  task (coordinate with Fenster on the frontend).
+
+---
+
+## Impact on Other Members
+
+- **Fenster:** CSP header in `vercel.json` may need updating if new third-party scripts
+  (analytics, charting CDN, etc.) are added. Amend the `connect-src` directive.
+- **Keaton:** `preferredRegion: fra1` aligns with vercel-03 recommendation — no conflict.
+- **Kujan:** `SUPABASE_SERVICE_ROLE_KEY` production-only policy must be respected in all
+  Server Action code — never import from client components or preview-only code paths.

--- a/apps/frontend/.vercelignore
+++ b/apps/frontend/.vercelignore
@@ -1,0 +1,13 @@
+node_modules/
+.git/
+.env
+.env.*
+!.env.example
+.next/
+out/
+coverage/
+**/__snapshots__/
+**/*.snap
+e2e/
+.DS_Store
+*.log

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -10,6 +10,15 @@ const nextConfig: NextConfig = {
     // Pre-existing TS errors — type-check is run separately in CI
     ignoreBuildErrors: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
+    ],
+  },
   async rewrites() {
     // Determine the backend base URL. Docker sets it to http://backend:8000
     // Aspire sets it to a dynamic localhost port.

--- a/apps/frontend/vercel.json
+++ b/apps/frontend/vercel.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "npm run build",
+  "outputDirectory": ".next",
+  "functions": {
+    "app/**": {
+      "preferredRegion": "fra1"
+    }
+  },
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.supabase.co; font-src 'self'; connect-src 'self' https://*.supabase.co wss://*.supabase.co; frame-ancestors 'none';"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/design-hosting/runbooks/vercel-04-project-link-and-env.md
+++ b/docs/design-hosting/runbooks/vercel-04-project-link-and-env.md
@@ -1,0 +1,395 @@
+# Vercel Project Link + Env Wiring Runbook (Hockney)
+
+> **Scope:** Interactive `vercel link`, env var wiring for all scopes, custom domain
+> assignment, branch deploy policy, rollback procedure, Hobby plan limits, and
+> troubleshooting reference. This runbook is the **user-executed complement** to the
+> committed project config (`apps/frontend/vercel.json`). Sister runbooks:
+> `vercel-01-project.md` (API path), `vercel-02-deploys.md` (DNS/preview), `vercel-03-policy-ci.md` (CI/limits).
+
+---
+
+## 1. Login + Link (run once per developer machine)
+
+### 1.1 Install Vercel CLI
+
+```bash
+npm i -g vercel
+vercel --version   # confirm install
+```
+
+### 1.2 Authenticate
+
+```bash
+vercel login
+# → Choose "Continue with GitHub" when the browser opens.
+# → After OAuth completes, CLI stores a token in ~/.local/share/com.vercel.cli/
+vercel whoami     # should print your GitHub username (cohenjo)
+```
+
+### 1.3 Link the monorepo frontend
+
+Run from inside `apps/frontend/` — Vercel must see `next.config.ts` in the cwd.
+
+```bash
+cd apps/frontend
+vercel link
+```
+
+| Prompt | Answer |
+|--------|--------|
+| Set up and deploy? | `N` — link only |
+| Which scope? | Your personal account (`cohenjo`) |
+| Link to existing project? | `N` on first run; `Y` if project already exists on Vercel dashboard |
+| Project name | `trading-journal` |
+| In which directory is your code? | `.` (already in `apps/frontend`) |
+
+This creates `apps/frontend/.vercel/project.json` containing `orgId` and `projectId`.
+**This file is gitignored and must never be committed.** Each developer links independently.
+
+> **Monorepo note:** Vercel auto-detects the `rootDirectory: "apps/frontend"` from the
+> link step. If you need to run CLI commands from the repo root, use `--cwd apps/frontend`:
+> ```bash
+> vercel --cwd apps/frontend ls
+> ```
+
+---
+
+## 2. Setting Environment Variables
+
+> **Canonical env var source:** `docs/design-hosting/setup-vercel.md §4` lists all
+> required variables. The table below is the authoritative scoping guide for Vercel.
+
+> 🔐 **Security rule:** `NEXT_PUBLIC_*` variables are inlined into the browser bundle at
+> build time and **visible to every user**. Never put a secret behind a `NEXT_PUBLIC_`
+> prefix. `SUPABASE_SERVICE_ROLE_KEY` is **Production-only** and has server-side access
+> only — it bypasses all RLS policies.
+
+### 2.1 Env var scope reference
+
+| Variable | Production | Preview | Development | Exposure |
+|----------|:----------:|:-------:|:-----------:|---------|
+| `NEXT_PUBLIC_SUPABASE_URL` | ✅ | ✅ | ✅ | Browser + server |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | ✅ | ✅ | ✅ | Browser + server |
+| `NEXT_PUBLIC_SITE_URL` | ✅ | ✅ | ✅ | Browser + server — OAuth redirect base |
+| `NEXT_PUBLIC_API_URL` | ✅ | ✅ | ✅ | Browser + server — legacy FastAPI (phase down) |
+| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | ❌ | ❌ | **Server-only** — NEVER `NEXT_PUBLIC_`, NEVER preview |
+| `SUPABASE_JWT_SECRET` | ✅ | ✅ | ❌ | Server-only — only if server-side JWT verification needed |
+| `FASTAPI_INTERNAL_URL` | ✅ | ✅ | ❌ | Server-only — Docker FastAPI internal hostname |
+
+> ⚠️ `SUPABASE_SERVICE_ROLE_KEY` is restricted to **Production only**. Exposing it on
+> preview environments would give admin-level Supabase access to preview build logs and
+> any contributor who can inspect the deploy — avoid.
+
+### 2.2 Add vars via CLI (interactive, recommended)
+
+Run from `apps/frontend/`. The CLI prompts for the value without echoing it (safe for secrets).
+
+```bash
+cd apps/frontend
+
+# ── Production ──────────────────────────────────────────────────────────
+vercel env add NEXT_PUBLIC_SUPABASE_URL        production
+vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY   production
+vercel env add NEXT_PUBLIC_SITE_URL            production   # e.g. https://trading-journal.cohenjo.dev
+vercel env add NEXT_PUBLIC_API_URL             production   # FastAPI URL (transitional)
+vercel env add SUPABASE_SERVICE_ROLE_KEY       production   # server-only, encrypted at rest
+vercel env add SUPABASE_JWT_SECRET             production
+vercel env add FASTAPI_INTERNAL_URL            production
+
+# ── Preview (point at dev/staging Supabase project, NOT prod data) ──────
+vercel env add NEXT_PUBLIC_SUPABASE_URL        preview
+vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY   preview
+vercel env add NEXT_PUBLIC_SITE_URL            preview      # e.g. https://trading-journal-git-main-cohenjo.vercel.app
+vercel env add NEXT_PUBLIC_API_URL             preview
+vercel env add SUPABASE_JWT_SECRET             preview
+vercel env add FASTAPI_INTERNAL_URL            preview
+
+# ── Development (syncs to .env.local via `vercel env pull`) ─────────────
+vercel env add NEXT_PUBLIC_SUPABASE_URL        development  # point at local Supabase (127.0.0.1:54321)
+vercel env add NEXT_PUBLIC_SUPABASE_ANON_KEY   development
+vercel env add NEXT_PUBLIC_SITE_URL            development  # http://localhost:3000
+vercel env add NEXT_PUBLIC_API_URL             development  # http://127.0.0.1:8000
+```
+
+### 2.3 Add vars via Vercel dashboard (alternative)
+
+1. Go to https://vercel.com/dashboard → Select project `trading-journal`.
+2. **Settings → Environment Variables**.
+3. For each variable: enter **Key**, **Value**, tick the appropriate environment
+   checkboxes (Production / Preview / Development), then **Save**.
+
+### 2.4 Verify vars were saved
+
+```bash
+vercel env ls production
+vercel env ls preview
+vercel env ls development
+```
+
+### 2.5 Pull development vars to local `.env.local`
+
+```bash
+cd apps/frontend
+vercel env pull .env.local
+```
+
+> ⚠️ **Local Supabase caveat:** If you run Supabase locally (`supabase start`), override
+> the pulled URL in `.env.local` manually:
+> ```
+> NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+> NEXT_PUBLIC_SUPABASE_ANON_KEY=<local-anon-key from supabase status>
+> ```
+> Run `vercel env pull` only when you specifically want to test against the remote
+> development Supabase project. See `runbooks/supabase-01-local-dev.md` for local setup.
+
+---
+
+## 3. Custom Domain Assignment
+
+> Replace `<USER_DOMAIN>` below with your actual domain. Current placeholder domains:
+> - Production: `prod.trading-journal.cohenjo.dev` (or `<USER_DOMAIN>`)
+> - Development/preview: `dev.trading-journal.cohenjo.dev`
+
+### 3.1 Add production domain
+
+```bash
+cd apps/frontend
+vercel domains add <USER_DOMAIN>
+vercel domains inspect <USER_DOMAIN>   # shows DNS instructions + SSL status
+```
+
+### 3.2 Required DNS records
+
+Configure at your DNS registrar:
+
+| Record type | Host / Name | Value |
+|-------------|-------------|-------|
+| `A` | `@` (apex) | `76.76.21.21` ⚠️ verify at https://vercel.com/docs/projects/domains |
+| `CNAME` | `www` | `cname.vercel-dns.com` |
+| `CNAME` | `prod` (subdomain) | `cname.vercel-dns.com` |
+| `CNAME` | `dev` (subdomain) | `cname.vercel-dns.com` |
+
+> ⚠️ Verify the apex A-record IP against live Vercel docs before updating DNS — the IP
+> has changed historically.
+
+### 3.3 Link preview domain to preview environment
+
+```bash
+vercel domains add dev.trading-journal.cohenjo.dev
+```
+
+In the dashboard: **Project → Settings → Domains** → set environment scope of
+`dev.trading-journal.cohenjo.dev` to **Preview**.
+
+### 3.4 Post-domain checklist
+
+After DNS propagates and SSL is issued:
+
+- [ ] Update `NEXT_PUBLIC_SITE_URL` in Production env var to the new domain.
+- [ ] Update Supabase Auth → URL Configuration → **Site URL** to the production domain.
+- [ ] Update Google OAuth authorized origins and redirect URIs.
+- [ ] Run a full OAuth round-trip test on the production domain.
+
+See `runbooks/vercel-02-deploys.md §6` for the full production cutover sequence.
+
+---
+
+## 4. Branch Deployment Policy
+
+Vercel's default git integration handles this automatically once the project is linked.
+
+| Branch pattern | Deploy environment | URL type |
+|---------------|-------------------|---------|
+| `main` | **Production** | Your custom domain + `trading-journal.vercel.app` |
+| `squad/*` | **Preview** | `trading-journal-git-squad-<slug>-cohenjo.vercel.app` |
+| Any other branch | **Preview** | Same pattern as `squad/*` |
+
+### 4.1 Configure in dashboard
+
+**Project → Settings → Git:**
+
+| Setting | Value |
+|---------|-------|
+| Production branch | `main` |
+| Comment on Pull Requests | ✅ Enabled (Vercel bot posts preview URL) |
+| Deployment Protection | Vercel Authentication (Hobby default) |
+
+### 4.2 Skip a deploy
+
+Include `[skip ci]` in the commit message:
+
+```bash
+git commit -m "docs: update README [skip ci]"
+```
+
+Or disable deploys for specific branches in `apps/frontend/vercel.json`:
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "chore/local-only-experiment": false
+    }
+  }
+}
+```
+
+### 4.3 Preview Supabase auth redirect allowlist
+
+Preview URLs are dynamic. Add wildcard patterns to Supabase Auth:
+
+**Supabase Dashboard → Authentication → URL Configuration → Redirect URLs:**
+
+```
+https://trading-journal-git-*-cohenjo.vercel.app/auth/callback
+https://trading-journal-*-cohenjo.vercel.app/auth/callback
+http://localhost:3000/auth/callback
+```
+
+> ⚠️ Verify wildcard semantics against current Supabase docs before relying on this.
+> See `runbooks/vercel-02-deploys.md §3` for fallback strategies.
+
+---
+
+## 5. Rollback Runbook
+
+### 5.1 Instant rollback via CLI
+
+```bash
+# List recent deployments to find the target
+cd apps/frontend
+vercel ls
+
+# Roll back to a specific deployment
+vercel rollback <deployment-url-or-id>
+# Example: vercel rollback https://trading-journal-abc123.vercel.app
+```
+
+> Verify flag names with `vercel rollback --help` — syntax may vary by CLI version.
+
+### 5.2 Rollback via dashboard (easiest)
+
+1. Go to https://vercel.com/dashboard → `trading-journal`.
+2. **Deployments** tab → find the known-good deployment.
+3. Click the **⋯** menu → **Promote to Production**.
+
+The previous deployment becomes live immediately (no rebuild required).
+
+### 5.3 ⚠️ Schema mismatch caveat
+
+Rolling back a frontend deployment does **not** roll back database migrations. If the
+bad deploy included a Supabase migration:
+
+1. Coordinate with Kujan (backend) before promoting the older frontend.
+2. Check whether the older code is compatible with the current DB schema.
+3. If schemas are incompatible, roll back the migration first (see `runbooks/supabase-02-remote.md`).
+
+---
+
+## 6. Hobby Plan Limits
+
+> All figures verified against https://vercel.com/docs/plans/hobby and
+> https://vercel.com/pricing (2025-07).
+
+| Resource | Hobby Limit | Notes |
+|----------|-------------|-------|
+| **Fast Data Transfer (bandwidth)** | **100 GB / month** | Page pauses if exceeded until 30-day reset |
+| **Function Invocations** | 1,000,000 / month | Server Actions count; each call = 1 invocation |
+| **Active CPU** | 4 CPU-hrs / month | Wall-clock CPU time across all functions |
+| **Provisioned Memory** | 360 GB-hrs / month | Memory × time across all invocations |
+| **Function max duration** | 10 s default, 60 s max | Enable Fluid Compute for up to 300 s |
+| **Build execution minutes** | 6,000 / month | ~100 builds/day at ~60 s each |
+| **Deployments / day** | 100 | Hard cap — exceeding blocks new deploys until reset |
+| **Image Optimization** | 1,000 source images / month | Unique source URLs; resets monthly |
+| **Runtime log retention** | 1 hour / 4,000 rows | Logs are ephemeral — do not rely on next-day access |
+| **Concurrent builds** | 1 (sequential queue) | Hobby has 4 vCPUs, Pro has 30 |
+
+**What happens when a limit is exceeded:**
+> *"In most cases, if you exceed your usage limits on the Hobby plan, you will have to
+> wait until 30 days have passed before you can use the feature again."*
+> — Vercel Hobby plan docs
+
+Hobby does **not** auto-bill overages. Features throttle/block until the rolling window resets.
+
+**Key watchpoints for this project:**
+
+- `next/image` with many unique chart thumbnail URLs will exhaust the 1,000 source-image
+  limit. Use `unoptimized` prop for charts; save `next/image` for static UI assets.
+- Server Actions on every interaction + any polling patterns can drain the 1M invocations
+  fast. Use Supabase Realtime subscriptions for live updates instead.
+- The 100 GB bandwidth limit is the most likely hard cap to hit if users download months
+  of OHLCV data. Paginate chart data and enable gzip on API responses.
+- No spend management dashboard on Hobby — check the **Usage** tab in the Vercel project
+  dashboard manually. Consider a GitHub Actions scheduled cron to alert if usage
+  approaches the limit (see `runbooks/vercel-03-policy-ci.md §3`).
+
+**Migration triggers:** see `runbooks/vercel-03-policy-ci.md §9`.
+
+---
+
+## 7. Troubleshooting
+
+### 7.1 View build logs
+
+**CLI:**
+```bash
+cd apps/frontend
+vercel ls                              # list deployments with status
+vercel inspect <deployment-url>        # full build metadata
+```
+
+**Dashboard:**
+Project → **Deployments** → click deployment → **Build** tab.
+
+### 7.2 View runtime / function logs
+
+**CLI:**
+```bash
+vercel logs <deployment-url>           # recent function logs
+vercel logs <deployment-url> --follow  # stream live logs
+```
+
+> ⚠️ Hobby log retention is **1 hour / 4,000 rows**. Logs from earlier today may already
+> be gone. For longer retention, ship logs to [Better Stack Logtail](https://betterstack.com/logtail)
+> or [Axiom](https://axiom.co) (both have free tiers and Vercel integrations).
+
+**Dashboard:**
+Project → **Logs** tab → filter by Function, Deployment, or date range.
+Use **Live** toggle for real-time log streaming.
+
+### 7.3 Common failure patterns
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Build fails: `Module not found` | Dependency missing in `package.json` or wrong `rootDirectory` | Confirm `vercel link` was run from `apps/frontend/`; check `package.json` |
+| `FUNCTION_INVOCATION_TIMEOUT` | Server Action / API route exceeded 10 s | Move heavy work to compute worker (TJ-024); enable Fluid Compute for up to 300 s |
+| `FUNCTION_PAYLOAD_TOO_LARGE` | Request body >4.5 MB | Use Supabase Storage presigned URLs for file uploads — do not POST file through Server Action |
+| OAuth `redirect_uri_mismatch` on preview | Preview URL not in Supabase allowlist | Add wildcard to Supabase Auth → Redirect URLs (§4.3) |
+| Env var not found at runtime | Var missing for environment scope | `vercel env ls <env>`; add with `vercel env add` |
+| Build succeeds but app shows wrong data | Production branch pointed at dev Supabase | Verify `NEXT_PUBLIC_SUPABASE_URL` scope in dashboard |
+| `vercel.json` changes ignored | Config at wrong path | Must live at `apps/frontend/vercel.json`; confirm with `vercel inspect` |
+| Domain shows `Invalid Configuration` | DNS not propagated or wrong record | `vercel domains inspect <domain>`; re-check A/CNAME records |
+
+### 7.4 Re-trigger a deployment manually
+
+```bash
+cd apps/frontend
+vercel deploy --prod          # production deploy
+vercel deploy                 # preview deploy
+```
+
+Or from the dashboard: Deployments → **⋯ → Redeploy**.
+
+---
+
+## 8. Cross-References
+
+| Topic | Location |
+|-------|---------|
+| Project setup via REST API | `runbooks/vercel-01-project.md` |
+| DNS, preview URLs, auth redirect | `runbooks/vercel-02-deploys.md` |
+| Hobby limits, CI/CD, Server Actions | `runbooks/vercel-03-policy-ci.md` |
+| Deployment flow diagram | `runbooks/vercel-05-deployment-flow.md` |
+| Supabase local dev | `runbooks/supabase-01-local-dev.md` |
+| Supabase remote setup | `runbooks/supabase-02-remote.md` |
+| Related issues | TJ-019 (this), TJ-018 (Server Actions), TJ-024 (compute worker), TJ-026 (prod cutover) |

--- a/docs/design-hosting/runbooks/vercel-05-deployment-flow.md
+++ b/docs/design-hosting/runbooks/vercel-05-deployment-flow.md
@@ -1,0 +1,154 @@
+# Vercel Deployment Flow (Hockney)
+
+> **Scope:** One-page reference for the PR → preview → production deployment lifecycle.
+> For rollback, see `vercel-04-project-link-and-env.md §5`.
+> For DNS and custom domains, see `vercel-02-deploys.md`.
+
+---
+
+## Deployment Lifecycle Diagram
+
+```
+Developer pushes branch / opens PR
+         │
+         ▼
+┌────────────────────────────────────────────────────────────────┐
+│                  GitHub  (cohenjo/trading-journal)             │
+│                                                                │
+│  branch: squad/72-my-feature                                   │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  Pull Request #N opened / commits pushed                 │  │
+│  │                                                          │  │
+│  │  GitHub Actions (.github/workflows/test.yml)            │  │
+│  │    └── npm ci → lint → test → build                     │  │
+│  │         └── Status: ✅ passing / ❌ failing             │  │
+│  └──────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────┘
+         │
+         │  Vercel GitHub App webhook
+         ▼
+┌────────────────────────────────────────────────────────────────┐
+│                  Vercel (trading-journal project)              │
+│                                                                │
+│  ⚙️  Build triggered (Preview environment)                    │
+│  └── Root directory: apps/frontend/                           │
+│  └── Build command: npm run build                             │
+│  └── Env vars: PREVIEW scope                                  │
+│                                                                │
+│  ✅ Build succeeds                                            │
+│  └── Preview URL generated:                                   │
+│       https://trading-journal-git-squad-72-cohenjo.vercel.app │
+│       https://trading-journal-<hash>-cohenjo.vercel.app       │
+└────────────────────────────────────────────────────────────────┘
+         │
+         │  Vercel bot posts comment to PR
+         ▼
+┌────────────────────────────────────────────────────────────────┐
+│  PR Comment (from Vercel bot):                                 │
+│                                                                │
+│  🔍 Preview deployment is ready!                              │
+│  ├── Branch URL (stable): https://trading-journal-git-...     │
+│  └── Latest commit URL:   https://trading-journal-abc123...   │
+│                                                                │
+│  Use the Branch URL in Supabase redirect allowlists           │
+│  (stable for the lifetime of the branch).                     │
+└────────────────────────────────────────────────────────────────┘
+         │
+         │  PR approved + merged to main
+         ▼
+┌────────────────────────────────────────────────────────────────┐
+│                  Vercel — Production Deploy                    │
+│                                                                │
+│  ⚙️  Build triggered (Production environment)                 │
+│  └── Env vars: PRODUCTION scope                               │
+│  └── Vercel checks GitHub required status checks:             │
+│       ├── GitHub Actions `test` job: must be ✅               │
+│       └── Only then: Production alias promoted                │
+│                                                                │
+│  ✅ Production deployment live:                               │
+│       https://<USER_DOMAIN>  (custom domain)                  │
+│       https://trading-journal.vercel.app  (Vercel alias)      │
+└────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Trigger Summary Table
+
+| Action | Environment | URL promoted? |
+|--------|-------------|--------------|
+| Push to any branch | Preview | No (preview URL only) |
+| Open or update a PR | Preview | No (branch URL in PR comment) |
+| PR merged to `main` | Production | ✅ Yes — production alias updated |
+| `vercel --prod` (CLI) | Production | ✅ Yes |
+| `vercel` (CLI, no flag) | Preview | No |
+| `[skip ci]` in commit msg | — | 🚫 Deploy skipped entirely |
+
+---
+
+## Environment Variable Scoping
+
+Each deploy receives only the env vars configured for its environment:
+
+```
+commit → branch push
+           ├── Vercel env scope: PREVIEW
+           │     NEXT_PUBLIC_SUPABASE_URL  → dev Supabase project
+           │     SUPABASE_SERVICE_ROLE_KEY → ❌ NOT injected (prod-only)
+           │
+           └── Vercel env scope: PRODUCTION (on main)
+                 NEXT_PUBLIC_SUPABASE_URL  → prod Supabase project
+                 SUPABASE_SERVICE_ROLE_KEY → ✅ injected (server-side only)
+```
+
+---
+
+## Vercel Bot PR Comment (what it looks like)
+
+When a preview deploy completes, the Vercel GitHub app posts a comment:
+
+```
+✅  Preview deployment is ready!
+
+Visit it now: https://trading-journal-git-squad-72-my-feature-cohenjo.vercel.app
+
+Built with commit abc1234 by @cohenjo
+```
+
+To enable/disable: **Project → Settings → Git → "Comment on Pull Requests"**.
+
+---
+
+## Build Status Checks on PRs
+
+Configure in **GitHub → Settings → Branches → Branch protection rules** for `main`:
+
+| Required check | Source |
+|----------------|--------|
+| `test` | GitHub Actions workflow |
+| `Vercel — Production Deployment` | Vercel GitHub App |
+
+Both must pass before a PR can be merged to `main`. The Vercel deployment status check
+is added automatically when the Vercel GitHub App is installed.
+
+---
+
+## Skip Conditions
+
+| Skip method | Scope |
+|-------------|-------|
+| `[skip ci]` in commit message | Skips both GH Actions and Vercel |
+| `[vercel skip]` in commit message | Skips Vercel only |
+| `vercel.json` `git.deploymentEnabled: { "branch": false }` | Disables deploy for named branch |
+
+---
+
+## Cross-References
+
+| Topic | Location |
+|-------|---------|
+| Preview URL patterns + branch URL format | `runbooks/vercel-02-deploys.md §2` |
+| Auth redirect gotcha on previews | `runbooks/vercel-02-deploys.md §3` |
+| CI/CD policy + GitHub Actions workflow | `runbooks/vercel-03-policy-ci.md §4` |
+| Rollback procedure | `runbooks/vercel-04-project-link-and-env.md §5` |
+| Hobby plan limits | `runbooks/vercel-04-project-link-and-env.md §6` |


### PR DESCRIPTION
## Summary

Working as Hockney (Backend Dev) on TJ-019 / GH #72.

Closes #72

## Files Changed

| File | Action | Notes |
|------|--------|-------|
| `apps/frontend/vercel.json` | Created | Framework config, security headers, `preferredRegion: fra1` |
| `apps/frontend/.vercelignore` | Created | Excludes `.env*`, `node_modules`, snapshots, `e2e/` |
| `apps/frontend/next.config.ts` | Updated | Added `images.remotePatterns` for Supabase CDN |
| `docs/design-hosting/runbooks/vercel-04-project-link-and-env.md` | Created | Full user runbook: login, link, env vars, domains, rollback, Hobby limits, troubleshooting |
| `docs/design-hosting/runbooks/vercel-05-deployment-flow.md` | Created | One-page deployment flow reference with ASCII diagram |
| `.squad/agents/hockney/history.md` | Updated | TJ-019 entry appended |
| `.squad/decisions/inbox/hockney-tj019-vercel.md` | Created | Decision record: region, SERVICE_ROLE_KEY scoping, no standalone output |

## Key Design Decisions

- **Region `fra1`** (Frankfurt): Closest Vercel region to Tel Aviv; co-located with Supabase EU for ~80–120ms lower Server Action latency. Implemented via `functions.preferredRegion` (not the Hobby-incompatible top-level `regions` array).
- **`SUPABASE_SERVICE_ROLE_KEY` Production-only**: Restricting to production prevents admin-level Supabase access leaking through preview build logs. Preview deployments use the anon key + RLS.
- **No `experimental.serverActions`**: Server Actions are stable GA in Next.js 14+. This project uses 15.3.4. Flag is unnecessary.
- **No `output: standalone`**: Vercel handles its own output — standalone mode is for Docker/self-hosted only (TJ-024).
- **CSP includes `unsafe-inline`**: Next.js 15 App Router requires this for hydration inline scripts. Nonce-based hardening is a future task.

## Hobby Plan Limits (verified vs vercel.com/pricing + vercel.com/docs/plans/hobby)

- Bandwidth: **100 GB/month**
- Function invocations: **1,000,000/month**
- Deployments/day: **100**
- Runtime logs: **1 hour / 4,000 rows** (ephemeral)

## ⚠️ Required User Actions (cannot be automated — needs your Vercel auth)

1. `cd apps/frontend && vercel login` — authenticate with GitHub
2. `vercel link` — link the monorepo subdir to Vercel project
3. `vercel env add ...` — add each env var per `vercel-04 §2` table
4. `vercel domains add <USER_DOMAIN>` — assign custom domain

See `docs/design-hosting/runbooks/vercel-04-project-link-and-env.md` for the complete step-by-step.