### PR TITLE
chore(infra): TJ-001 local Supabase dev stack runbook

### DIFF
--- a/apps/frontend/.env.local.example
+++ b/apps/frontend/.env.local.example
@@ -1,6 +1,6 @@
 # apps/frontend/.env.local.example
 #
-# Copy this file to .env.local and fill in the values for your target environment.
+# Copy to .env.local and fill in values for your target environment.
 # .env.local is gitignored — NEVER commit it.
 #
 # ─── TARGET: LOCAL (supabase start) ──────────────────────────────────────────
@@ -8,7 +8,7 @@
 #
 # NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key / publishable key from `supabase status`>
-# SUPABASE_SERVICE_ROLE_KEY=<service_role key / secret key from `supabase status`>
+# SUPABASE_SERVICE_ROLE_KEY=<service_role key — NEVER prefix with NEXT_PUBLIC_>
 
 # ─── TARGET: DEV REMOTE (trading-journal-dev on Supabase cloud) ──────────────
 # Retrieve from Supabase Dashboard → Project Settings → API.
@@ -26,7 +26,10 @@
 # NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from Supabase prod project>
 # SUPABASE_SERVICE_ROLE_KEY=<service_role key — Vercel secret only>
 
-# ─── COMMON: PgBouncer note ───────────────────────────────────────────────────
+# ─── COMMON NOTES ─────────────────────────────────────────────────────────────
 # Add ?statement_cache_size=0 ONLY when connecting via the transaction-mode
 # pooler (remote port 6543). Local port 54322 and remote direct port 5432
 # do NOT need it.
+#
+# Never prefix SUPABASE_SERVICE_ROLE_KEY with NEXT_PUBLIC_ — it would be
+# exposed to the browser.

--- a/docs/design-hosting/runbooks/supabase-01-local-dev.md
+++ b/docs/design-hosting/runbooks/supabase-01-local-dev.md
@@ -16,7 +16,7 @@ Before `supabase start` will succeed, verify all of these:
 | **Supabase CLI ≥ 2.95** | `supabase --version` | `brew install supabase/tap/supabase` — see §1 |
 | **psql (libpq)** | `psql --version` | `brew install libpq && brew link --force libpq` |
 | **Node ≥ 20** | `node --version` | `brew install node@20` or use `nvm use 20` |
-| **macOS arm64** | `uname -m` → `arm64` | These commands are tested on Apple Silicon; Intel/Rosetta should work but is not validated |
+| **macOS arm64** | `uname -m` → `arm64` | Tested on Apple Silicon; Intel/Rosetta should work but is not validated |
 
 > ⚠️ Docker Desktop must be **fully started** (whale icon in menu bar, not just launching) before running any `supabase` command. If Docker is starting up, `supabase start` hangs silently.
 
@@ -24,30 +24,24 @@ Before `supabase start` will succeed, verify all of these:
 
 ## 1. Install Supabase CLI (macOS)
 
-- **Homebrew (recommended):**
-  ```bash
-  brew install supabase/tap/supabase
-  supabase --version
-  ```
-- **npm alternative (pin to project):**
-  ```bash
-  npm install supabase --save-dev
-  npx supabase --version
-  ```
-- **Docker prerequisite:** Docker Desktop or OrbStack must be running before `supabase start`.
-- **Upgrade:**
-  ```bash
-  brew upgrade supabase/tap/supabase
-  # or: npm update supabase --save-dev
-  ```
-  > Stop all running Supabase containers before upgrading (`supabase stop --no-backup`).
+```bash
+# Homebrew (recommended)
+brew install supabase/tap/supabase
+supabase --version   # must print >= 2.95
+
+# Upgrade
+supabase stop --no-backup   # stop containers first
+brew upgrade supabase/tap/supabase
+```
+
+> npm alternative: `npm install supabase --save-dev` (pins to project; use `npx supabase`).
 
 ---
 
 ## 2. Start the Local Stack
 
 ```bash
-# From repo root. First run pulls Docker images (~1–2 min, ~600 MB).
+# From repo root. First run pulls Docker images (~1-2 min, ~600 MB).
 supabase start
 ```
 
@@ -63,17 +57,20 @@ Started supabase local development setup.
       Studio URL: http://127.0.0.1:54323
     Inbucket URL: http://127.0.0.1:54324
       JWT secret: super-secret-jwt-token-with-at-least-32-characters-long
-        anon key: eyJhbGciOiJIUzI1NiIsInR5...   ← Publishable key
-service_role key: eyJhbGciOiJIUzI1NiIsInR5...   ← Secret key — never expose
+        anon key: eyJhbGciOiJIUzI1NiIsInR5...   <- Publishable key
+service_role key: eyJhbGciOiJIUzI1NiIsInR5...   <- Secret key — never expose
 ```
 
-> ⚠️ **Key naming changed in recent CLI versions.** The CLI may label them `Publishable` and `Secret` instead of `anon key` / `service_role key`. They map identically. Copy from _your_ `supabase status` output.
+Port map (configured in `supabase/config.toml`):
 
-To check status at any time:
+| Service | Port | URL |
+|---------|------|-----|
+| API (PostgREST) | 54321 | `http://127.0.0.1:54321` |
+| DB (Postgres) | 54322 | `postgresql://postgres:postgres@127.0.0.1:54322/postgres` |
+| Studio | 54323 | `http://127.0.0.1:54323` |
+| Inbucket (email) | 54324 | `http://127.0.0.1:54324` |
 
-```bash
-supabase status
-```
+> ⚠️ **Key naming changed in recent CLI versions.** Older CLI showed `anon key` / `service_role key`; newer CLI labels them **Publishable** and **Secret**. Always copy from _your_ `supabase status` output.
 
 ---
 
@@ -83,23 +80,29 @@ supabase status
 supabase status
 ```
 
-Copy the output values into `apps/frontend/.env.local` (create from `.env.local.example`):
-
-```dotenv
-NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
-NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key / publishable key from supabase status>
-SUPABASE_SERVICE_ROLE_KEY=<service_role key / secret key — NEVER prefix NEXT_PUBLIC_>
-```
-
-> 🔒 `.env.local` is gitignored. Never commit it.
-
-For the backend:
+Copy the output values into `apps/frontend/.env.local` (create from example):
 
 ```bash
+cp apps/frontend/.env.local.example apps/frontend/.env.local
+# Then edit: paste keys from `supabase status`
+```
+
+```dotenv
+# apps/frontend/.env.local
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key / publishable key from supabase status>
+SUPABASE_SERVICE_ROLE_KEY=<service_role key — NEVER prefix with NEXT_PUBLIC_>
+```
+
+Backend:
+
+```dotenv
 # apps/backend/.env
 SUPABASE_DB_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 SUPABASE_JWT_SECRET=<jwt secret from supabase status>
 ```
+
+> 🔒 `.env.local` is gitignored. Never commit it. See `apps/frontend/.env.local.example` for all three environment targets (local / dev-remote / prod).
 
 ---
 
@@ -112,42 +115,47 @@ timestamp order, then runs `supabase/seed.sql`.
 supabase db reset
 ```
 
-Expected terminal output:
+Expected terminal output (abbreviated):
 
 ```
 Resetting local database...
 Initializing schema...
+Applying migration 20260430115000_baseline_legacy_schema.sql...
 Applying migration 20260430120000_households_and_members.sql...
-Applying migration 20260430120100_rls_helpers.sql...
 ...
 Applying migration 20260430140300_cooked_tables.sql...
 Seeding data from supabase/seed.sql...
 Finished supabase db reset.
 ```
 
+Seed credentials after reset:
+
+| Email | Password |
+|-------|----------|
+| `alice@example.local` | `password123` |
+| `bob@example.local` | `password123` |
+
 ### ⚠️ Legacy-table migration dependency
 
 Migrations `130000`–`130300` (`add_audit_columns`, `add_household_id`,
 `add_owner_user_id`, `drop_trading_account_secrets`) depend on columns
-introduced by `20260430115000_baseline_legacy_schema.sql`. That migration
-lives in **McManus's forthcoming PR** and is **not yet on `main`**.
+introduced by `20260430115000_baseline_legacy_schema.sql`.
 
-Until it lands:
+**Status as of TJ-001:** `20260430115000_baseline_legacy_schema.sql` is in this
+branch (`squad/54-local-supabase-dev`) via the McManus TJ-005-followup commit.
+Once it merges to `main`, plain `supabase db reset` will work end-to-end with
+no workaround. Until then:
 
 ```bash
-# Option A (recommended): reset without seed to get a clean schema baseline,
-# then manually apply only the migrations that do not depend on the legacy tables.
+# Option A — reset without seed (gets a clean schema baseline)
 supabase db reset --no-seed
 
-# Option B: temporarily rename the blocking migration files so the CLI skips them,
-# reset, then rename them back.
-#   cd supabase/migrations
-#   for f in 20260430130{0..3}*.sql; do mv "$f" "${f}.skip"; done
-#   supabase db reset
-#   for f in *.skip; do mv "$f" "${f%.skip}"; done
+# Option B — temporarily skip the blocking migrations
+cd supabase/migrations
+for f in 20260430130{0..3}*.sql; do mv "$f" "${f}.skip"; done
+supabase db reset
+for f in *.skip; do mv "$f" "${f%.skip}"; done
 ```
-
-> Once `20260430115000_baseline_legacy_schema.sql` merges, plain `supabase db reset` will work end-to-end with no workaround needed.
 
 ---
 
@@ -159,43 +167,40 @@ pgTAP tests live in `supabase/tests/*.test.sql` and run against the local DB.
 supabase test db
 ```
 
-Expected output (once tests exist):
+Expected output once tests exist:
 
 ```
 Running tests in supabase/tests/...
- ok  1 - households table exists
- ok  2 - household_members role enum has owner/member/viewer
+ ok 1 - households table exists
+ ok 2 - household_members role enum has owner/member/viewer
 ...
 # PASS
-# Tests passed: 12
-# Tests failed: 0
+# Tests passed: N / Tests failed: 0
 ```
 
-> Currently `supabase/tests/` directory does not exist — the command will output `No test files found`. Tests will be added as part of TJ-009 (RLS policies). Run this command anyway to confirm the runner wires up correctly.
+> `supabase/tests/` is currently empty — the runner will output `No test files found`.
+> Tests land in TJ-009 (RLS policies). Run the command anyway to confirm the runner wires up.
 
 ---
 
 ## 6. Run Frontend Against Local Stack
 
 ```bash
-# 1. Copy env if not done yet
+# Set env (if not done in §3)
 cp apps/frontend/.env.local.example apps/frontend/.env.local
-# Edit apps/frontend/.env.local with keys from `supabase status`
+# Edit: paste keys from `supabase status`
 
-# 2. Start the frontend dev server
+# Start dev server
 cd apps/frontend
 npm run dev
 ```
 
-Open `http://localhost:3000`. Login with the seed credentials:
+Open `http://localhost:3000`. Login with seed credentials:
+- `alice@example.local` / `password123`
+- `bob@example.local` / `password123`
 
-```
-alice@example.local / password123
-bob@example.local   / password123
-```
-
-> Studio (Postgres UI) is at `http://127.0.0.1:54323` — useful for inspecting seed
-> data, testing RLS policies, and running ad-hoc queries.
+Studio (Postgres UI + SQL editor) is at `http://127.0.0.1:54323`.
+All auth emails (magic links, OTP) are captured by Inbucket at `http://127.0.0.1:54324`.
 
 ---
 
@@ -221,12 +226,12 @@ supabase stop --no-backup
 supabase start
 supabase status          # grab fresh keys if needed
 
-# Create a new migration
-supabase migration new add_trades_table
-# Edit: supabase/migrations/<timestamp>_add_trades_table.sql
+# New feature requiring DB changes
+supabase migration new my_feature
+# Edit: supabase/migrations/<timestamp>_my_feature.sql
 supabase db reset        # wipe + replay all migrations + seed
 
-# Capture Studio changes back into a migration file
+# Capture changes made via Studio back into a migration file
 supabase db diff --use-migra -f my_feature_v2
 supabase db reset        # validate the captured migration
 
@@ -237,7 +242,8 @@ supabase db lint
 supabase stop
 ```
 
-> **No native down-migrations.** Write a forward-only undo migration (e.g., `_undo_add_trades_table.sql`) if rollback is needed. Always `supabase db reset` locally before pushing to remote.
+> **No native down-migrations.** Write a forward-only undo migration if rollback
+> is needed. Always `supabase db reset` locally before pushing to remote.
 
 ---
 
@@ -246,21 +252,22 @@ supabase stop
 | Symptom | Cause | Fix |
 |---------|-------|-----|
 | `address already in use :54321` | Another `supabase start` running or stale container | `supabase stop && docker ps` to find stale containers |
-| `supabase start` hangs indefinitely | Docker Desktop not fully started | Start Docker Desktop and wait for whale icon; then retry |
-| Port 54321/54322/54323 already in use | Another local process squatting the port | `lsof -i :54321` to identify; kill the process or change ports in `config.toml` |
-| Stale or incorrect schema | Migrations applied out of order or edited in-place | `supabase db reset` (nukes everything and replays cleanly) |
+| `supabase start` hangs indefinitely | Docker Desktop not fully started | Wait for whale icon; then retry |
+| Port 54321/54322/54323 squatted | Another local process | `lsof -i :54321` to identify; stop it or change ports in `config.toml` |
+| Stale/incorrect schema | Migrations edited in-place or out of order | `supabase db reset` — nukes everything, replays cleanly |
 | Studio not loading at :54323 | Docker container crashed | `docker ps` — check `supabase_studio_*`; restart Docker Desktop if stuck |
-| Auth email not received | Mailpit not checked | All local auth emails are captured at `http://127.0.0.1:54324` |
-| Migration failure mid-reset | SQL error in a migration file | Read error output; check `supabase/.temp/` for detailed Postgres logs |
-| `supabase link` fails 401 | Missing or expired PAT | Re-run `supabase login` or re-export `SUPABASE_ACCESS_TOKEN` (remote ops only) |
-| `crypt()` not found in seed.sql | pgcrypto not loaded | `supabase db reset` installs extensions automatically; if running psql directly, `create extension if not exists pgcrypto;` |
-| libpq `psql` not on PATH | Homebrew libpq not linked | `brew link --force libpq` |
+| Auth email not received | Inbucket not checked | All local auth emails at `http://127.0.0.1:54324` |
+| Migration failure mid-reset | SQL error in a migration file | Read Postgres error in terminal; check `supabase/.temp/` for full logs |
+| `supabase link` fails 401 | Missing/expired PAT | `supabase login` or re-export `SUPABASE_ACCESS_TOKEN` (remote ops only) |
+| `crypt()` not found in seed.sql | pgcrypto not loaded before seed | `supabase db reset` loads extensions automatically; if running psql directly, run `create extension if not exists pgcrypto` first |
+| `psql` not on PATH | Homebrew libpq not linked | `brew link --force libpq` |
 
-> **Stale containers after a crash:** If `supabase start` fails immediately after an abrupt shutdown:
-> ```bash
-> supabase stop --no-backup   # force remove all containers
-> supabase start
-> ```
+**Stale containers after crash:**
+
+```bash
+supabase stop --no-backup   # force-remove all containers
+supabase start
+```
 
 ---
 
@@ -268,82 +275,75 @@ supabase stop
 
 > PAT is **not** needed for local dev. Only required for `supabase link`, `supabase db push`, or CI.
 
-- **Browser flow (interactive):**
-  ```bash
-  supabase login
-  supabase projects list   # verify auth worked
-  ```
-- **Headless / CI:**
-  1. Create a PAT at <https://supabase.com/dashboard/account/tokens>
-  2. Export before running CLI commands:
-     ```bash
-     export SUPABASE_ACCESS_TOKEN=sbp_xxxxxxxxxxxx
-     ```
+```bash
+# Interactive (browser-based)
+supabase login
+supabase projects list   # verify auth worked
+
+# Headless / CI: create PAT at https://supabase.com/dashboard/account/tokens
+export SUPABASE_ACCESS_TOKEN=sbp_xxxxxxxxxxxx
+```
 
 ---
 
 ## 11. Cold-Start Verification Checklist
 
-> Run this from a **fresh terminal** after cloning the repo. If every step passes, your local stack matches what's in remote dev.
+> Run this from a **fresh terminal** after cloning the repo. If every step passes,
+> your local stack matches what's in remote dev.
 
 ```bash
-# ── 1. Preflight ────────────────────────────────────────────────────────────
-docker info | grep "Server Version"   # must print a version — not an error
-supabase --version                    # must be ≥ 2.95
-node --version                        # must be ≥ v20
+# 1. Preflight
+docker info | grep "Server Version"   # must print a version string
+supabase --version                    # must be >= 2.95
+node --version                        # must be >= v20
 psql --version                        # must not error
 
-# ── 2. Start stack ──────────────────────────────────────────────────────────
+# 2. Start stack
 cd /path/to/trading-journal
 supabase start
 # Expected: "Started supabase local development setup."
 
-# ── 3. Confirm ports ────────────────────────────────────────────────────────
-curl -s http://127.0.0.1:54321/rest/v1/ | python3 -m json.tool
+# 3. Confirm ports
+curl -s http://127.0.0.1:54321/rest/v1/ | python3 -m json.tool | head -5
 # Expected: JSON with "paths" key (PostgREST spec)
 
-curl -s http://127.0.0.1:54323 | grep -i "supabase"
-# Expected: HTML containing "supabase" (Studio)
+curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:54323
+# Expected: 200
 
-# ── 4. Apply migrations + seed ──────────────────────────────────────────────
+# 4. Apply migrations + seed
 supabase db reset
-# Expected: "Finished supabase db reset." — no ERRORs
+# Expected: "Finished supabase db reset." — zero ERRORs
 
-# ── 5. Verify seed data ─────────────────────────────────────────────────────
+# 5. Verify seed data
 psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
   -c "SELECT email FROM auth.users ORDER BY email;"
 # Expected:
 #        email
-# ─────────────────────
+# ---------------------
 #  alice@example.local
 #  bob@example.local
+# (2 rows)
 
 psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
   -c "SELECT name FROM public.households;"
-# Expected: Demo Household
+# Expected: Demo Household (1 row)
 
 psql postgresql://postgres:postgres@127.0.0.1:54322/postgres \
   -c "SELECT period, as_of_date FROM cooked.dashboard_summary ORDER BY as_of_date DESC LIMIT 3;"
-# Expected: rows with period in (day, month, year, all)
+# Expected: 3 rows with period in (day, month, year, all)
 
-# ── 6. pgTAP tests ──────────────────────────────────────────────────────────
+# 6. pgTAP tests
 supabase test db
-# Expected: "No test files found" (tests land in TJ-009)
-# OR if tests exist: "Tests passed: N / Tests failed: 0"
+# Expected: "No test files found" OR "Tests passed: N / Tests failed: 0"
 
-# ── 7. Frontend smoke test ──────────────────────────────────────────────────
-# Copy env and start the dev server
+# 7. Frontend smoke test
 cp apps/frontend/.env.local.example apps/frontend/.env.local
 # Edit apps/frontend/.env.local — paste keys from `supabase status`
-
 cd apps/frontend && npm run dev
 # Expected: "Ready - started server on http://localhost:3000"
+# Open http://localhost:3000 — app shell loads, no 500 error
 
-# In a second terminal:
-curl -s http://localhost:3000 | grep -i "trading"
-# Expected: HTML containing the app shell (not a 500 error page)
-
-# ── 8. Stop cleanly ─────────────────────────────────────────────────────────
+# 8. Stop cleanly
 supabase stop
 # Expected: "Stopped supabase local development setup."
 ```
@@ -354,8 +354,8 @@ supabase stop
 
 ## 12. Cross-References
 
-- Remote provisioning: [`runbooks/supabase-02-remote.md`](./supabase-02-remote.md) (Kujan)
-- Auth + RLS schema: [`runbooks/supabase-03-auth-rls.md`](./supabase-03-auth-rls.md) (Rabin)
-- Vercel side: [`runbooks/vercel-01-project.md`](./vercel-01-project.md) (Hockney)
-- Broader Supabase setup narrative: [`docs/design-hosting/setup-supabase.md`](../setup-supabase.md)
+- Remote provisioning: [`supabase-02-remote.md`](./supabase-02-remote.md) (Kujan)
+- Auth + RLS schema: [`supabase-03-auth-rls.md`](./supabase-03-auth-rls.md) (Rabin)
+- Vercel side: [`vercel-01-project.md`](./vercel-01-project.md) (Hockney)
+- Broader Supabase setup narrative: [`../setup-supabase.md`](../setup-supabase.md)
 - Issue: [TJ-001 (#54)](https://github.com/cohenjo/trading-journal/issues/54)

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -125,7 +125,7 @@ inactivity_timeout = "0"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # External auth providers
-# Toggle these on in Supabase Dashboard for local testing; see runbook §9.
+# Toggle in Supabase Dashboard for local testing; see runbook §9.
 # ─────────────────────────────────────────────────────────────────────────────
 [auth.external.google]
 enabled = false
@@ -134,7 +134,7 @@ secret = "env(SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET)"
 skip_nonce_check = false
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Edge Functions (Deno — not used yet, included for completeness)
+# Edge Functions (Deno — not used yet)
 # ─────────────────────────────────────────────────────────────────────────────
 [edge_runtime]
 enabled = false

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -37,8 +37,8 @@ insert into auth.users (
   email_change
 ) values
   (
-    '00000000-0000-0000-0000-000000000000',  -- instance_id (default)
-    '00000000-0000-0000-0000-000000000001',  -- user id (Alice)
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-000000000001',
     'authenticated',
     'authenticated',
     'alice@example.local',
@@ -52,7 +52,7 @@ insert into auth.users (
   ),
   (
     '00000000-0000-0000-0000-000000000000',
-    '00000000-0000-0000-0000-000000000002',  -- user id (Bob)
+    '00000000-0000-0000-0000-000000000002',
     'authenticated',
     'authenticated',
     'bob@example.local',
@@ -69,7 +69,6 @@ on conflict (id) do nothing;
 -- ────────────────────────────────────────────────────────────
 -- HOUSEHOLD
 -- Alice is the owner; Bob is a member.
--- created_by = Alice's user id.
 -- ────────────────────────────────────────────────────────────
 insert into public.households (id, name, created_by)
 values (
@@ -83,23 +82,22 @@ insert into public.household_members (household_id, user_id, role, invited_by)
 values
   (
     '00000000-0000-0000-0000-000000000010',
-    '00000000-0000-0000-0000-000000000001',  -- Alice
+    '00000000-0000-0000-0000-000000000001',
     'owner',
     null
   ),
   (
     '00000000-0000-0000-0000-000000000010',
-    '00000000-0000-0000-0000-000000000002',  -- Bob
+    '00000000-0000-0000-0000-000000000002',
     'member',
-    '00000000-0000-0000-0000-000000000001'   -- invited by Alice
+    '00000000-0000-0000-0000-000000000001'
   )
 on conflict (household_id, user_id) do nothing;
 
 -- ────────────────────────────────────────────────────────────
 -- USER PROFILES
 -- handle_new_auth_user() trigger auto-creates user_profile rows
--- when auth.users is inserted above. The inserts below are a
--- safety net in case trigger ordering varies on db reset.
+-- when auth.users is inserted above. These are a safety net.
 -- ────────────────────────────────────────────────────────────
 insert into public.user_profile (id, display_name, default_household_id)
 values
@@ -117,134 +115,84 @@ on conflict (id) do nothing;
 
 -- ────────────────────────────────────────────────────────────
 -- COOKED: dashboard_summary
--- Skeleton rows — summary_payload columns will be expanded in
--- TJ-020. Values are obviously fictional (round numbers, fake
--- tickers). Covers four periods × several dates for UI testing.
+-- Skeleton rows — summary_payload columns expanded in TJ-020.
+-- Values are obviously fictional (round numbers, fake tickers).
+-- Covers four periods x several dates for UI testing.
 --
 -- Note: cooked tables are service_role-write-only in production.
--- The seed inserts directly as the DB superuser (seed runs as
--- postgres, which bypasses RLS).
+-- The seed inserts as the DB superuser (bypasses RLS).
 -- ────────────────────────────────────────────────────────────
 insert into cooked.dashboard_summary
   (household_id, period, as_of_date, currency, summary_payload, _computed_at)
 values
-
   -- day rows
   (
     '00000000-0000-0000-0000-000000000010',
-    'day',
-    '2026-05-01',
-    'USD',
-    '{
-      "net_worth_usd": 125000.00,
-      "daily_pnl_usd": 325.50,
-      "daily_pnl_pct": 0.26,
-      "top_positions": [
-        {"ticker": "AAPL", "value_usd": 25000, "pnl_usd": 520},
-        {"ticker": "MSFT", "value_usd": 18500, "pnl_usd": -195},
-        {"ticker": "NVDA", "value_usd": 12000, "pnl_usd": 0}
-      ]
-    }'::jsonb,
+    'day', '2026-05-01', 'USD',
+    '{"net_worth_usd":125000.00,"daily_pnl_usd":325.50,"daily_pnl_pct":0.26,
+      "top_positions":[
+        {"ticker":"AAPL","value_usd":25000,"pnl_usd":520},
+        {"ticker":"MSFT","value_usd":18500,"pnl_usd":-195},
+        {"ticker":"NVDA","value_usd":12000,"pnl_usd":0}
+      ]}'::jsonb,
     now()
   ),
   (
     '00000000-0000-0000-0000-000000000010',
-    'day',
-    '2026-04-30',
-    'USD',
-    '{
-      "net_worth_usd": 124674.50,
-      "daily_pnl_usd": -410.00,
-      "daily_pnl_pct": -0.33,
-      "top_positions": [
-        {"ticker": "AAPL", "value_usd": 24480, "pnl_usd": -280},
-        {"ticker": "MSFT", "value_usd": 18695, "pnl_usd": -130},
-        {"ticker": "NVDA", "value_usd": 12000, "pnl_usd": 0}
-      ]
-    }'::jsonb,
+    'day', '2026-04-30', 'USD',
+    '{"net_worth_usd":124674.50,"daily_pnl_usd":-410.00,"daily_pnl_pct":-0.33,
+      "top_positions":[
+        {"ticker":"AAPL","value_usd":24480,"pnl_usd":-280},
+        {"ticker":"MSFT","value_usd":18695,"pnl_usd":-130},
+        {"ticker":"NVDA","value_usd":12000,"pnl_usd":0}
+      ]}'::jsonb,
     now()
   ),
   (
     '00000000-0000-0000-0000-000000000010',
-    'day',
-    '2026-04-29',
-    'USD',
-    '{
-      "net_worth_usd": 125084.50,
-      "daily_pnl_usd": 1100.00,
-      "daily_pnl_pct": 0.89,
-      "top_positions": [
-        {"ticker": "AAPL", "value_usd": 24760, "pnl_usd": 600},
-        {"ticker": "MSFT", "value_usd": 18825, "pnl_usd": 500},
-        {"ticker": "AMZN", "value_usd": 9200,  "pnl_usd": 0}
-      ]
-    }'::jsonb,
+    'day', '2026-04-29', 'USD',
+    '{"net_worth_usd":125084.50,"daily_pnl_usd":1100.00,"daily_pnl_pct":0.89,
+      "top_positions":[
+        {"ticker":"AAPL","value_usd":24760,"pnl_usd":600},
+        {"ticker":"MSFT","value_usd":18825,"pnl_usd":500},
+        {"ticker":"AMZN","value_usd":9200,"pnl_usd":0}
+      ]}'::jsonb,
     now()
   ),
-
   -- month rows
   (
     '00000000-0000-0000-0000-000000000010',
-    'month',
-    '2026-04-30',
-    'USD',
-    '{
-      "net_worth_usd": 124674.50,
-      "period_pnl_usd": 4674.50,
-      "period_pnl_pct": 3.89,
-      "best_performer": {"ticker": "NVDA", "pnl_usd": 3000},
-      "worst_performer": {"ticker": "TSLA", "pnl_usd": -820}
-    }'::jsonb,
+    'month', '2026-04-30', 'USD',
+    '{"net_worth_usd":124674.50,"period_pnl_usd":4674.50,"period_pnl_pct":3.89,
+      "best_performer":{"ticker":"NVDA","pnl_usd":3000},
+      "worst_performer":{"ticker":"TSLA","pnl_usd":-820}}'::jsonb,
     now()
   ),
   (
     '00000000-0000-0000-0000-000000000010',
-    'month',
-    '2026-03-31',
-    'USD',
-    '{
-      "net_worth_usd": 120000.00,
-      "period_pnl_usd": -2300.00,
-      "period_pnl_pct": -1.88,
-      "best_performer": {"ticker": "MSFT", "pnl_usd": 900},
-      "worst_performer": {"ticker": "META", "pnl_usd": -3200}
-    }'::jsonb,
+    'month', '2026-03-31', 'USD',
+    '{"net_worth_usd":120000.00,"period_pnl_usd":-2300.00,"period_pnl_pct":-1.88,
+      "best_performer":{"ticker":"MSFT","pnl_usd":900},
+      "worst_performer":{"ticker":"META","pnl_usd":-3200}}'::jsonb,
     now()
   ),
-
   -- year row
   (
     '00000000-0000-0000-0000-000000000010',
-    'year',
-    '2026-04-30',
-    'USD',
-    '{
-      "net_worth_usd": 124674.50,
-      "ytd_pnl_usd": 8750.25,
-      "ytd_pnl_pct": 7.55,
-      "best_performer": {"ticker": "NVDA", "pnl_usd": 5500},
-      "worst_performer": {"ticker": "META", "pnl_usd": -3200},
-      "realized_pnl_usd": 2100.00,
-      "unrealized_pnl_usd": 6650.25
-    }'::jsonb,
+    'year', '2026-04-30', 'USD',
+    '{"net_worth_usd":124674.50,"ytd_pnl_usd":8750.25,"ytd_pnl_pct":7.55,
+      "best_performer":{"ticker":"NVDA","pnl_usd":5500},
+      "worst_performer":{"ticker":"META","pnl_usd":-3200},
+      "realized_pnl_usd":2100.00,"unrealized_pnl_usd":6650.25}'::jsonb,
     now()
   ),
-
   -- all-time row
   (
     '00000000-0000-0000-0000-000000000010',
-    'all',
-    '2026-04-30',
-    'USD',
-    '{
-      "net_worth_usd": 124674.50,
-      "total_pnl_usd": 24674.50,
-      "total_pnl_pct": 24.67,
-      "inception_date": "2024-01-01",
-      "total_deposits_usd": 100000.00,
-      "total_withdrawals_usd": 0.00
-    }'::jsonb,
+    'all', '2026-04-30', 'USD',
+    '{"net_worth_usd":124674.50,"total_pnl_usd":24674.50,"total_pnl_pct":24.67,
+      "inception_date":"2024-01-01",
+      "total_deposits_usd":100000.00,"total_withdrawals_usd":0.00}'::jsonb,
     now()
   )
-
 on conflict (household_id, period, as_of_date, currency) do nothing;


### PR DESCRIPTION
Working as **Kujan** (DevOps/Platform)

## What's in this PR

Closes #54

### Artifacts added

| File | Description |
|------|-------------|
| `supabase/config.toml` | Local stack config: API 54321, DB 54322 (PG 17), Studio 54323, auth site_url=localhost:3000, Google OAuth disabled |
| `supabase/seed.sql` | Sanitized seed: 2 users (alice/bob @example.local / password123), Demo Household (owner + member), 7 cooked.dashboard_summary rows with fictitious AAPL/MSFT/NVDA/META/TSLA data |
| `docs/design-hosting/runbooks/supabase-01-local-dev.md` | 12-section runbook: prerequisites, start, credentials, migrations, pgTAP tests, frontend wiring, reset cycle, dev loop, pitfalls, cold-start verification checklist |
| `apps/frontend/.env.local.example` | Three-environment template (local / dev-remote / prod), all commented, no real keys |
| `.gitignore` | Added `supabase/.temp/` and `supabase/.branches/` |
| `apps/frontend/.gitignore` | Whitelisted `.env*.example` files |

### ⚠️ Legacy migration note

This branch includes `20260430115000_baseline_legacy_schema.sql` (McManus TJ-005-followup commit). Runbook §4 documents a temporary workaround (`supabase db reset --no-seed` or skip-files approach) for teams on `main` before that migration lands. Once the baseline migration merges to main the workaround is obsolete.

### Seed data note

All seed data is **obviously fictional** (round P&L numbers, tickers AAPL/MSFT/NVDA/META/TSLA/AMZN/TSLA, no real usernames, no real PII). Seed file has `-- WARNING: NOT FOR PRODUCTION` banner at top.