### PR TITLE
feat(auth): JWT forwarding + auth guard + stub login

### DIFF
--- a/apps/frontend/src/app/after-i-leave/page.tsx
+++ b/apps/frontend/src/app/after-i-leave/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useRef, useState, useEffect, useCallback } from 'react';
 import { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
@@ -22,7 +23,7 @@ interface InsurancePolicy {
 
 async function fetchInsurancePolicies(): Promise<InsurancePolicy[]> {
   try {
-    const res = await fetch('/api/insurance');
+    const res = await apiFetch('/api/insurance');
     if (!res.ok) return [];
     const data = await res.json();
     return data.data || [];
@@ -33,7 +34,7 @@ async function fetchInsurancePolicies(): Promise<InsurancePolicy[]> {
 
 async function fetchFinanceData(): Promise<FinanceItem[]> {
   try {
-    const res = await fetch('/api/finances/latest');
+    const res = await apiFetch('/api/finances/latest');
     if (!res.ok) return [];
     const data = await res.json();
     return data.data?.items || [];

--- a/apps/frontend/src/app/auth/callback/route.ts
+++ b/apps/frontend/src/app/auth/callback/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * PKCE auth callback handler for @supabase/ssr.
+ *
+ * Supabase redirects here after OAuth (Google) or magic-link confirmation with
+ * a `code` query parameter. We exchange it for a session, then redirect to the
+ * original destination (or home).
+ *
+ * Route: /auth/callback
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+  const next = searchParams.get('next') ?? '/';
+
+  if (code) {
+    const supabase = await createClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      // Validate `next` to prevent open-redirect abuse
+      const isSafe = next.startsWith('/') && !next.includes('//') && !next.includes(':');
+      const destination = isSafe ? `${origin}${next}` : origin;
+      return NextResponse.redirect(destination);
+    }
+  }
+
+  // Something went wrong — send them back to login with an error hint
+  return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+}

--- a/apps/frontend/src/app/backtest/page.tsx
+++ b/apps/frontend/src/app/backtest/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState } from "react";
 import { BacktestChart } from "@/components/Backtest/BacktestChart";
@@ -47,7 +48,7 @@ export default function BacktestPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch("/api/backtest/years")
+    apiFetch("/api/backtest/years")
       .then((res) => res.json())
       .then((data) => {
         setYears(data);
@@ -63,7 +64,7 @@ export default function BacktestPage() {
     setError(null);
     setResults(null);
     try {
-      const res = await fetch("/api/backtest/run", {
+      const res = await apiFetch("/api/backtest/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ 

--- a/apps/frontend/src/app/cash-flow/page.tsx
+++ b/apps/frontend/src/app/cash-flow/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 import React, { useState, useEffect, useMemo } from 'react';
 import { useSettings } from '../settings/SettingsContext';
 import { CashFlowSankey } from '@/components/CashFlow/CashFlowSankey';
@@ -6,13 +7,13 @@ import { PlanData } from '@/components/Plan/types';
 
 // Fetch Utilities (Duplicated from PlanPage for now)
 async function fetchLatestPlan() {
-    const res = await fetch('/api/plans/latest');
+    const res = await apiFetch('/api/plans/latest');
     if (res.ok) return res.json();
     return null;
 }
 
 async function fetchFinances() {
-    const res = await fetch('/api/finances/latest');
+    const res = await apiFetch('/api/finances/latest');
     if (res.ok) return res.json();
     return {
         net_worth: 0,
@@ -46,7 +47,7 @@ export default function CashFlowPage() {
 
         // Debounce slightly
         const timer = setTimeout(() => {
-            fetch('/api/plans/simulate', {
+            apiFetch('/api/plans/simulate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/apps/frontend/src/app/current-finances/page.tsx
+++ b/apps/frontend/src/app/current-finances/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from 'react';
 import { DonutChart } from '@/components/CurrentFinances/DonutChart';
@@ -9,7 +10,7 @@ import { convertCurrency } from '@/lib/currency';
 // --- API Helper ---
 async function fetchLatestSnapshot() {
   try {
-    const res = await fetch('/api/finances/latest');
+    const res = await apiFetch('/api/finances/latest');
     if (!res.ok) {
       if (res.status === 404) return null; // No snapshot yet
       const errorText = await res.text();
@@ -34,7 +35,7 @@ async function saveSnapshot(items: FinanceItem[], metrics: { net_worth: number, 
       ...metrics
     };
 
-    const res = await fetch('/api/finances/', {
+    const res = await apiFetch('/api/finances/', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/apps/frontend/src/app/day/[date]/page.tsx
+++ b/apps/frontend/src/app/day/[date]/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
@@ -56,7 +57,7 @@ export default function DayPage() {
 
   useEffect(() => {
     if (date) {
-      fetch(`/api/day/${date}`)
+      apiFetch(`/api/day/${date}`)
         .then((res) => res.json())
         .then((data) => {
           setDayDetails(data);

--- a/apps/frontend/src/app/dividends/estimations/page.tsx
+++ b/apps/frontend/src/app/dividends/estimations/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useMemo } from "react";
 import DividendChart, { DividendChartPoint } from "../../../components/Dividends/DividendChart";
@@ -37,7 +38,7 @@ export default function DividendEstimationsPage() {
 
     // Fetch historical data on mount
     useEffect(() => {
-        fetch("/api/dividends")
+        apiFetch("/api/dividends")
             .then((res) => res.json())
             .then((data) => {
                 setHistoricalData(data);
@@ -49,7 +50,7 @@ export default function DividendEstimationsPage() {
     useEffect(() => {
         if (historicalData.length === 0) return;
 
-        fetch("/api/dividends/projection", {
+        apiFetch("/api/dividends/projection", {
             method: "POST",
             headers: { "Content-Type": "application/json" },
             body: JSON.stringify(params),
@@ -68,7 +69,7 @@ export default function DividendEstimationsPage() {
 
     const handleSaveHistory = async (newData: DividendRecord[]) => {
         try {
-            const res = await fetch("/api/dividends", {
+            const res = await apiFetch("/api/dividends", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(newData),

--- a/apps/frontend/src/app/holdings/page.tsx
+++ b/apps/frontend/src/app/holdings/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useEffect, useState } from "react";
 
@@ -26,7 +27,7 @@ export default function HoldingsPage() {
       try {
         setLoading(true);
         setError(null);
-        const res = await fetch("/api/holdings");
+        const res = await apiFetch("/api/holdings");
         if (!res.ok) {
           throw new Error(`Failed to load holdings: ${res.status}`);
         }
@@ -54,7 +55,7 @@ export default function HoldingsPage() {
 
     try {
       setSavingId(id);
-      const res = await fetch(`/api/holdings/${id}`, {
+      const res = await apiFetch(`/api/holdings/${id}`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ face_value: holding.face_value }),
@@ -77,7 +78,7 @@ export default function HoldingsPage() {
   const handleRemoveHolding = async (id: string) => {
     try {
       setSavingId(id);
-      const res = await fetch(`/api/holdings/${id}`, {
+      const res = await apiFetch(`/api/holdings/${id}`, {
         method: "DELETE",
       });
       if (!res.ok) {
@@ -274,7 +275,7 @@ export default function HoldingsPage() {
                       }
                       try {
                         setSavingId("__new__");
-                        const res = await fetch(
+                        const res = await apiFetch(
                           "/api/ladder/bonds",
                           {
                             method: "POST",

--- a/apps/frontend/src/app/insurance/page.tsx
+++ b/apps/frontend/src/app/insurance/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect, useCallback } from 'react';
 
@@ -152,7 +153,7 @@ export default function InsurancePage() {
 
   const fetchPolicies = useCallback(async () => {
     try {
-      const res = await fetch('/api/insurance');
+      const res = await apiFetch('/api/insurance');
       if (res.ok) {
         const data = await res.json();
         if (data.status === 'success') {
@@ -201,7 +202,7 @@ export default function InsurancePage() {
     try {
       const url = editingId ? `/api/insurance/${editingId}` : '/api/insurance';
       const method = editingId ? 'PUT' : 'POST';
-      const res = await fetch(url, {
+      const res = await apiFetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -222,7 +223,7 @@ export default function InsurancePage() {
   const handleDelete = async (id: string) => {
     if (!window.confirm(labels.confirmDelete)) return;
     try {
-      await fetch(`/api/insurance/${id}`, { method: 'DELETE' });
+      await apiFetch(`/api/insurance/${id}`, { method: 'DELETE' });
       await fetchPolicies();
     } catch {
       // silent

--- a/apps/frontend/src/app/ladder/page.tsx
+++ b/apps/frontend/src/app/ladder/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
@@ -28,12 +29,12 @@ function LadderPage() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const overviewRes = await fetch("/api/ladder/overview");
+      const overviewRes = await apiFetch("/api/ladder/overview");
       const overviewJson = await overviewRes.json();
       setRungs(overviewJson.rungs ?? []);
       setBonds(overviewJson.bonds ?? []);
 
-      const incomeRes = await fetch("/api/ladder/income");
+      const incomeRes = await apiFetch("/api/ladder/income");
       const incomeJson = await incomeRes.json();
       setIncomeSeries(incomeJson.income_series ?? []);
       setDistributions(incomeJson.distributions ?? []);
@@ -69,7 +70,7 @@ function LadderPage() {
             bonds={bonds}
             onUpdateRungTarget={async (rungId, targetAmount) => {
               try {
-                await fetch(`/api/ladder/rungs/${rungId}`, {
+                await apiFetch(`/api/ladder/rungs/${rungId}`, {
                   method: "PUT",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({ target_amount: targetAmount }),
@@ -86,7 +87,7 @@ function LadderPage() {
             }}
             onAddBond={async (payload) => {
               try {
-                const res = await fetch("/api/ladder/bonds", {
+                const res = await apiFetch("/api/ladder/bonds", {
                   method: "POST",
                   headers: { "Content-Type": "application/json" },
                   body: JSON.stringify({
@@ -103,12 +104,12 @@ function LadderPage() {
 
                 // After adding a bond, reload ladder and income data so
                 // all views stay in sync.
-                const overviewRes = await fetch("/api/ladder/overview");
+                const overviewRes = await apiFetch("/api/ladder/overview");
                 const overviewJson = await overviewRes.json();
                 setRungs(overviewJson.rungs ?? []);
                 setBonds(overviewJson.bonds ?? []);
 
-                const incomeRes = await fetch("/api/ladder/income");
+                const incomeRes = await apiFetch("/api/ladder/income");
                 const incomeJson = await incomeRes.json();
                 setIncomeSeries(incomeJson.income_series ?? []);
                 setDistributions(incomeJson.distributions ?? []);

--- a/apps/frontend/src/app/ladder/scanner/page.tsx
+++ b/apps/frontend/src/app/ladder/scanner/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import React, { Suspense, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
@@ -49,7 +50,7 @@ const ScannerPage: React.FC = () => {
       if (minRating) params.set("min_rating", minRating);
       if (currency) params.set("currency", currency);
 
-      const res = await fetch(`/api/bonds/scanner?${params.toString()}`);
+      const res = await apiFetch(`/api/bonds/scanner?${params.toString()}`);
       if (!res.ok) {
         throw new Error(`Request failed with status ${res.status}`);
       }

--- a/apps/frontend/src/app/login/page.tsx
+++ b/apps/frontend/src/app/login/page.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import React, { Suspense, useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+/**
+ * Validate the `next` redirect target to prevent open redirects.
+ * Must start with `/`, and must not contain `//` or `:` (protocol-relative / absolute URLs).
+ */
+function isSafeRedirect(next: string | null): next is string {
+  if (!next) return false;
+  return next.startsWith('/') && !next.includes('//') && !next.includes(':');
+}
+
+const SITE_URL =
+  typeof window !== 'undefined'
+    ? window.location.origin
+    : process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+
+/** Inner component — must be wrapped in Suspense because it calls useSearchParams(). */
+function LoginForm() {
+  const searchParams = useSearchParams();
+  const next = searchParams.get('next');
+  const redirectTo = `${SITE_URL}/auth/callback`;
+
+  const [email, setEmail] = useState('');
+  const [magicLinkSent, setMagicLinkSent] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // If user lands here while already signed in, bounce to next or home
+  useEffect(() => {
+    void import('@/lib/supabase/browser').then(({ createClient }) => createClient().auth.getSession()).then(({ data: { session } }) => {
+      if (session) {
+        const destination = isSafeRedirect(next) ? next : '/';
+        window.location.replace(destination);
+      }
+    });
+  }, [next]);
+
+  async function handleGoogleSignIn() {
+    setLoading(true);
+    setError(null);
+    const { createClient } = await import('@/lib/supabase/browser');
+    const supabase = createClient();
+    // ⚠️ KEYBOARD TASK: Enable Google OAuth provider in Supabase Studio
+    //    → Authentication → Providers → Google → enable + add Client ID & Secret
+    const { error: oauthError } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo,
+        queryParams: isSafeRedirect(next) ? { next } : undefined,
+      },
+    });
+    if (oauthError) {
+      setError(oauthError.message);
+      setLoading(false);
+    }
+    // On success the browser navigates away — no need to setLoading(false)
+  }
+
+  async function handleMagicLink(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    const { createClient } = await import('@/lib/supabase/browser');
+    const supabase = createClient();
+    const { error: otpError } = await supabase.auth.signInWithOtp({
+      email,
+      options: {
+        // Magic links use email by default — no extra Supabase Studio config needed
+        emailRedirectTo: redirectTo,
+      },
+    });
+    setLoading(false);
+    if (otpError) {
+      setError(otpError.message);
+    } else {
+      setMagicLinkSent(true);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-bold tracking-tight">Trading Journal</h1>
+          <p className="text-slate-400 text-sm">Sign in to access your portfolio</p>
+        </div>
+
+        <div className="bg-slate-900 border border-slate-800 rounded-xl p-6 space-y-4">
+          {/* Google OAuth */}
+          <button
+            onClick={handleGoogleSignIn}
+            disabled={loading}
+            className="w-full flex items-center justify-center gap-3 py-2.5 px-4 bg-white text-slate-900 font-medium rounded-lg hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <svg className="w-5 h-5" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Continue with Google
+          </button>
+
+          <div className="flex items-center gap-3">
+            <div className="flex-1 border-t border-slate-700" />
+            <span className="text-slate-500 text-xs uppercase tracking-wider">or</span>
+            <div className="flex-1 border-t border-slate-700" />
+          </div>
+
+          {/* Magic link */}
+          {magicLinkSent ? (
+            <div className="text-center space-y-2 py-4">
+              <p className="text-emerald-400 font-medium">✓ Check your inbox</p>
+              <p className="text-slate-400 text-sm">
+                We sent a magic link to <strong>{email}</strong>. Click it to sign in.
+              </p>
+              <button
+                onClick={() => setMagicLinkSent(false)}
+                className="text-slate-500 text-xs underline hover:text-slate-300"
+              >
+                Use a different email
+              </button>
+            </div>
+          ) : (
+            <form onSubmit={handleMagicLink} className="space-y-3">
+              <div>
+                <label htmlFor="email" className="block text-sm text-slate-400 mb-1">
+                  Email address
+                </label>
+                <input
+                  id="email"
+                  type="email"
+                  autoComplete="email"
+                  required
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="you@example.com"
+                  className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-slate-100 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent text-sm"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={loading || !email}
+                className="w-full py-2.5 px-4 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-lg font-medium text-sm transition-colors"
+              >
+                {loading ? 'Sending…' : 'Send magic link'}
+              </button>
+            </form>
+          )}
+
+          {error && (
+            <p className="text-red-400 text-sm text-center">{error}</p>
+          )}
+        </div>
+
+        <p className="text-center text-slate-600 text-xs">
+          Personal finance &amp; trading journal — household access only
+        </p>
+      </div>
+    </main>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <main className="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center">
+        <p className="text-slate-400">Loading…</p>
+      </main>
+    }>
+      <LoginForm />
+    </Suspense>
+  );
+}

--- a/apps/frontend/src/app/options/page.tsx
+++ b/apps/frontend/src/app/options/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useMemo, useState } from "react";
 import OptionsChart, { OptionsChartPoint } from "../../components/Options/OptionsChart";
@@ -30,7 +31,7 @@ export default function OptionsPage() {
   };
 
   useEffect(() => {
-    fetch("/api/options")
+    apiFetch("/api/options")
       .then((res) => res.json())
       .then((data) => {
         setHistoricalData(data);
@@ -41,7 +42,7 @@ export default function OptionsPage() {
   useEffect(() => {
     if (historicalData.length === 0) return;
 
-    fetch("/api/options/projection", {
+    apiFetch("/api/options/projection", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(params),
@@ -72,7 +73,7 @@ export default function OptionsPage() {
 
   const handleSaveHistory = async (newData: OptionsRecord[]) => {
     try {
-      const res = await fetch("/api/options", {
+      const res = await apiFetch("/api/options", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(newData),

--- a/apps/frontend/src/app/pension/page.tsx
+++ b/apps/frontend/src/app/pension/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PensionChart from '@/components/Pension/PensionChart';
@@ -30,7 +31,7 @@ export default function PensionPage() {
 
     const fetchDashboard = async () => {
         try {
-            const res = await fetch('/api/pension/dashboard');
+            const res = await apiFetch('/api/pension/dashboard');
             if (res.ok) {
                 const data = await res.json();
                 if (data.status === 'success') {
@@ -58,7 +59,7 @@ export default function PensionPage() {
 
     // Keep allSnapshots in sync by fetching from reports endpoint
     useEffect(() => {
-        fetch('/api/pension/reports')
+        apiFetch('/api/pension/reports')
             .then((res) => res.ok ? res.json() : null)
             .then((json) => {
                 if (json?.snapshots) {
@@ -103,7 +104,7 @@ export default function PensionPage() {
 
         try {
             const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-            const response = await fetch(`${apiUrl}/api/pension/upload`, {
+            const response = await apiFetch(`${apiUrl}/api/pension/upload`, {
                 method: 'POST',
                 body: formData,
             });
@@ -138,7 +139,7 @@ export default function PensionPage() {
 
         try {
             const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-            const res = await fetch(`${apiUrl}/api/pension/${id}`, {
+            const res = await apiFetch(`${apiUrl}/api/pension/${id}`, {
                 method: 'DELETE',
             });
             if (res.ok) {

--- a/apps/frontend/src/app/plan/page.tsx
+++ b/apps/frontend/src/app/plan/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { PlanChart } from '@/components/Plan/PlanChart';
 import { PlanEditor } from '@/components/Plan/PlanEditor';
@@ -7,13 +8,13 @@ import { Plan, PlanData } from '@/components/Plan/types';
 import { useSettings } from '../settings/SettingsContext';
 
 async function fetchLatestPlan() {
-    const res = await fetch('/api/plans/latest');
+    const res = await apiFetch('/api/plans/latest');
     if (res.ok) return res.json();
     return null;
 }
 
 async function createPlan(data: PlanData) {
-    const res = await fetch('/api/plans/', {
+    const res = await apiFetch('/api/plans/', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data), // PlanData maps to plan_in
@@ -22,7 +23,7 @@ async function createPlan(data: PlanData) {
 }
 
 async function updatePlan(id: number, data: PlanData) {
-    const res = await fetch(`/api/plans/${id}`, {
+    const res = await apiFetch(`/api/plans/${id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
@@ -31,7 +32,7 @@ async function updatePlan(id: number, data: PlanData) {
 }
 
 async function fetchFinances() {
-    const res = await fetch('/api/finances/latest');
+    const res = await apiFetch('/api/finances/latest');
     if (res.ok) {
         return res.json();
     }
@@ -91,7 +92,7 @@ export default function PlanPage() {
         if (!plan || !plan.data) return;
 
         const timer = setTimeout(() => {
-            fetch('/api/plans/simulate', {
+            apiFetch('/api/plans/simulate', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/apps/frontend/src/app/progress/page.tsx
+++ b/apps/frontend/src/app/progress/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from 'react';
 import { ProgressChart } from '@/components/Progress/ProgressChart';
@@ -8,7 +9,7 @@ import { useSettings } from '../settings/SettingsContext';
 
 async function fetchHistory() {
     try {
-        const res = await fetch('/api/finances/history?limit=100');
+        const res = await apiFetch('/api/finances/history?limit=100');
         if (!res.ok) throw new Error('Failed to fetch history');
         const data = await res.json();
         // Map backend model to frontend summary
@@ -42,7 +43,7 @@ async function saveHistory(summary: ProgressSummary) {
             total_investments: summary.total_investments
         };
 
-        const res = await fetch('/api/finances/', {
+        const res = await apiFetch('/api/finances/', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload),
@@ -58,7 +59,7 @@ async function saveHistory(summary: ProgressSummary) {
 
 async function deleteHistory(date: string) {
     try {
-        const res = await fetch(`/api/finances/${date}`, {
+        const res = await apiFetch(`/api/finances/${date}`, {
             method: 'DELETE',
         });
         if (!res.ok) throw new Error('Failed to delete history');

--- a/apps/frontend/src/app/summary/page.tsx
+++ b/apps/frontend/src/app/summary/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState, useMemo } from "react";
 import { useSettings } from "../settings/SettingsContext";
@@ -37,12 +38,12 @@ export default function SummaryPage() {
     const fetchData = async () => {
       try {
         // 1. Fetch Ladder Income
-        const ladderRes = await fetch("/api/ladder/income");
+        const ladderRes = await apiFetch("/api/ladder/income");
         const ladderJson = await ladderRes.json();
         const ladderSeries = ladderJson.income_series || [];
 
         // 2. Fetch Dividend Projection
-        const divRes = await fetch("/api/dividends/projection", {
+        const divRes = await apiFetch("/api/dividends/projection", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(divParams),
@@ -51,7 +52,7 @@ export default function SummaryPage() {
         const divData = divJson.data || [];
 
         // 3. Fetch Options Projection
-        const optRes = await fetch("/api/options/projection", {
+        const optRes = await apiFetch("/api/options/projection", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(optParams),

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useCompanyFundamentals.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useCompanyFundamentals.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -52,7 +53,7 @@ export function useCompanyFundamentals(ticker: string): UseFundamentalsReturn {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/analyze/fundamentals/${ticker}`);
+      const res = await apiFetch(`${apiUrl}/api/analyze/fundamentals/${ticker}`);
       if (!res.ok) {
         throw new Error(res.status === 404 ? `Ticker "${ticker}" not found` : `API error (${res.status})`);
       }

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useGrowthStory.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useGrowthStory.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useCallback, useRef, useEffect } from "react";
 
@@ -70,7 +71,7 @@ export function useGrowthStory(ticker: string): UseGrowthStoryReturn {
     }, 1000);
 
     try {
-      const res = await fetch(`${apiUrl}/api/analyze/growth-story/${ticker}`, {
+      const res = await apiFetch(`${apiUrl}/api/analyze/growth-story/${ticker}`, {
         method: "POST",
       });
       if (!res.ok) {

--- a/apps/frontend/src/components/Analyze/longterm/hooks/usePriceHistory.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/usePriceHistory.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -34,7 +35,7 @@ export function usePriceHistory(
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         `${apiUrl}/api/analyze/price-history/${ticker}?period=${period}&interval=${interval}`
       );
       if (!res.ok) {

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useSynthesis.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useSynthesis.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -26,7 +27,7 @@ export function useSynthesis(ticker: string): UseSynthesisReturn {
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`${apiUrl}/api/analyze/synthesis/${ticker}`);
+      const res = await apiFetch(`${apiUrl}/api/analyze/synthesis/${ticker}`);
       if (!res.ok) {
         throw new Error(`API error (${res.status})`);
       }

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -47,7 +48,7 @@ export function useOptionChain(ticker: string): UseOptionChainResult {
       ? `/api/analyze/options/${ticker}?expiry=${expiry}`
       : `/api/analyze/options/${ticker}`;
 
-    fetch(url)
+    apiFetch(url)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch options for ${ticker}`);
         return res.json();

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -29,7 +30,7 @@ export function usePriceHistory(ticker: string): UsePriceHistoryResult {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/analyze/price-history/${ticker}?period=1y&interval=1d`)
+    apiFetch(`/api/analyze/price-history/${ticker}?period=1y&interval=1d`)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch price history for ${ticker}`);
         return res.json();

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -29,7 +30,7 @@ export function useSynthesis(ticker: string): UseSynthesisResult {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/analyze/synthesis/${ticker}`)
+    apiFetch(`/api/analyze/synthesis/${ticker}`)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch synthesis for ${ticker}`);
         return res.json();

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState, useEffect, useCallback } from "react";
 
@@ -51,7 +52,7 @@ export function useTechnicals(ticker: string): UseTechnicalsResult {
     setLoading(true);
     setError(null);
 
-    fetch(`/api/analyze/technicals/${ticker}`)
+    apiFetch(`/api/analyze/technicals/${ticker}`)
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to fetch technicals for ${ticker}`);
         return res.json();

--- a/apps/frontend/src/components/Dashboard/AddTradeForm.tsx
+++ b/apps/frontend/src/components/Dashboard/AddTradeForm.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState } from "react";
 
@@ -24,7 +25,7 @@ export default function AddTradeForm() {
       pnl,
     };
 
-    await fetch("/api/trades", {
+    await apiFetch("/api/trades", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(trade),

--- a/apps/frontend/src/components/Dashboard/Calendar.tsx
+++ b/apps/frontend/src/components/Dashboard/Calendar.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
@@ -24,7 +25,7 @@ export default function CalendarView({ date, onDateChange }: CalendarViewProps) 
     const fetchSummaries = async () => {
       const year = date.getFullYear();
       const month = date.getMonth() + 1;
-      const response = await fetch(`/api/summary/${year}/${month}`);
+      const response = await apiFetch(`/api/summary/${year}/${month}`);
       const data = await response.json();
       setSummaries(data);
     };

--- a/apps/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/Dashboard/Dashboard.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState } from "react";
 import TradesList from "./TradesList";
@@ -18,7 +19,7 @@ export default function Dashboard() {
   useEffect(() => {
     const initializeDate = async () => {
       try {
-        const response = await fetch("/api/summary/latest-month");
+        const response = await apiFetch("/api/summary/latest-month");
         if (!response.ok) {
           return;
         }
@@ -40,7 +41,7 @@ export default function Dashboard() {
       const year = currentDate.getFullYear();
       const month = currentDate.getMonth() + 1;
       try {
-        const response = await fetch(`/api/summary/${year}/${month}`);
+        const response = await apiFetch(`/api/summary/${year}/${month}`);
         if (!response.ok) {
           throw new Error("Network response was not ok");
         }

--- a/apps/frontend/src/components/Dashboard/NdxChart.tsx
+++ b/apps/frontend/src/components/Dashboard/NdxChart.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useRef } from 'react';
 import { createChart, IChartApi, CandlestickData, UTCTimestamp, SeriesMarker, CandlestickSeries, createSeriesMarkers } from 'lightweight-charts';
@@ -55,9 +56,9 @@ export default function NdxChart({ date, trades }: { date: string, trades: Match
       });
 
       if (date) {
-        fetch(`/api/ndx/sync/${date}`, { method: 'POST' })
+        apiFetch(`/api/ndx/sync/${date}`, { method: 'POST' })
           .then(() => {
-            fetch(`/api/ndx/${date}`)
+            apiFetch(`/api/ndx/${date}`)
               .then((res) => res.json())
               .then((data: ChartData[]) => {
                 const formattedData: CandlestickData[] = data.map(item => ({

--- a/apps/frontend/src/components/Dashboard/TradesList.tsx
+++ b/apps/frontend/src/components/Dashboard/TradesList.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect, useState } from "react";
 
@@ -20,7 +21,7 @@ export default function TradesList() {
   useEffect(() => {
     // Fetch trades from the backend.
     // For now, we'll use a dummy date.
-    fetch("/api/day/2025-07-02")
+    apiFetch("/api/day/2025-07-02")
       .then((res) => res.json())
       .then((data) => setTrades(data));
   }, []);

--- a/apps/frontend/src/components/Dividends/AccountSettings.tsx
+++ b/apps/frontend/src/components/Dividends/AccountSettings.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from "react";
 import DeleteConfirmationModal from "./DeleteConfirmationModal";
@@ -25,8 +26,8 @@ export default function AccountSettings({ onAccountsChange }: AccountSettingsPro
     const fetchAccounts = async () => {
         try {
             const [accRes, impRes] = await Promise.all([
-                fetch("/api/dividends/accounts"),
-                fetch("/api/dividends/accounts/importable")
+                apiFetch("/api/dividends/accounts"),
+                apiFetch("/api/dividends/accounts/importable")
             ]);
 
             if (accRes.ok) {
@@ -69,7 +70,7 @@ export default function AccountSettings({ onAccountsChange }: AccountSettingsPro
         try {
             let res;
             if (selectedImport) {
-                res = await fetch("/api/dividends/accounts/import", {
+                res = await apiFetch("/api/dividends/accounts/import", {
                     method: "POST",
                     headers: { "Content-Type": "application/json" },
                     body: JSON.stringify({
@@ -78,7 +79,7 @@ export default function AccountSettings({ onAccountsChange }: AccountSettingsPro
                     })
                 });
             } else {
-                res = await fetch("/api/dividends/accounts?name=" + encodeURIComponent(newAccount), {
+                res = await apiFetch("/api/dividends/accounts?name=" + encodeURIComponent(newAccount), {
                     method: "POST"
                 });
             }
@@ -108,7 +109,7 @@ export default function AccountSettings({ onAccountsChange }: AccountSettingsPro
         setIsDeleting(true);
 
         try {
-            const res = await fetch(`/api/dividends/accounts/${encodeURIComponent(deleteModal.name)}`, {
+            const res = await apiFetch(`/api/dividends/accounts/${encodeURIComponent(deleteModal.name)}`, {
                 method: "DELETE"
             });
 

--- a/apps/frontend/src/components/Dividends/DividendDashboard.tsx
+++ b/apps/frontend/src/components/Dividends/DividendDashboard.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect, useMemo } from "react";
 import StatsRow from "./StatsRow";
@@ -33,7 +34,7 @@ export default function DividendDashboard() {
     // Initial Fetch
     const fetchAccounts = async () => {
         try {
-            const res = await fetch("/api/dividends/accounts");
+            const res = await apiFetch("/api/dividends/accounts");
             if (res.ok) {
                 const data = await res.json();
                 setAccounts(data);
@@ -46,7 +47,7 @@ export default function DividendDashboard() {
     const fetchData = async () => {
         setLoading(true);
         try {
-            const res = await fetch(`/api/dividends/dashboard?currency=${settings.mainCurrency}`);
+            const res = await apiFetch(`/api/dividends/dashboard?currency=${settings.mainCurrency}`);
             if (res.ok) {
                 const data = await res.json();
                 setStats(data.stats);
@@ -121,7 +122,7 @@ export default function DividendDashboard() {
             const method = posData.id ? "PUT" : "POST";
             const url = posData.id ? `/api/dividends/position/${posData.id}` : "/api/dividends/position";
 
-            const res = await fetch(url, {
+            const res = await apiFetch(url, {
                 method,
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
@@ -151,7 +152,7 @@ export default function DividendDashboard() {
         if (!deleteModal.id) return;
         setIsDeleting(true);
         try {
-            const res = await fetch(`/api/dividends/position/${deleteModal.id}`, { method: "DELETE" });
+            const res = await apiFetch(`/api/dividends/position/${deleteModal.id}`, { method: "DELETE" });
             if (res.ok) {
                 setPositions(prev => prev.filter(p => p.id !== deleteModal.id));
                 setDeleteModal({ isOpen: false, id: null });

--- a/apps/frontend/src/components/Pension/ReportHistory.tsx
+++ b/apps/frontend/src/components/Pension/ReportHistory.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from 'react';
 import type {
@@ -69,7 +70,7 @@ export default function ReportHistory({ onSelectSnapshot, selectedDate, refreshK
     let cancelled = false;
     setLoading(true);
 
-    fetch('/api/pension/reports')
+    apiFetch('/api/pension/reports')
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();

--- a/apps/frontend/src/components/Plan/PlanAccountDetails.tsx
+++ b/apps/frontend/src/components/Plan/PlanAccountDetails.tsx
@@ -1,3 +1,4 @@
+import { apiFetch } from '@/lib/api-client';
 import React from 'react';
 import { PlanItem, PlanMilestone } from './types';
 import { CurrencySelector } from '../Common/CurrencySelector';
@@ -50,7 +51,7 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
     // Helper to fetch data
     const fetchMarketData = async (symbol: string, type: 'price' | 'yield') => {
         try {
-            const res = await fetch(`/api/finances/price/${symbol}`);
+            const res = await apiFetch(`/api/finances/price/${symbol}`);
             if (!res.ok) throw new Error('Failed to fetch');
             const data = await res.json();
 

--- a/apps/frontend/src/components/TaxCondor/TaxCondorView.tsx
+++ b/apps/frontend/src/components/TaxCondor/TaxCondorView.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useState } from "react";
 import { TaxCondorRecommendation } from "./types";
@@ -17,7 +18,7 @@ export default function TaxCondorView() {
   const fetchRecommendations = async () => {
     setLoading(true);
     try {
-      const res = await fetch(
+      const res = await apiFetch(
         "/api/tax-condor/recommend",
         {
           method: "POST",

--- a/apps/frontend/src/components/Telemetry/PageLoadMetrics.tsx
+++ b/apps/frontend/src/components/Telemetry/PageLoadMetrics.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import { useEffect } from "react";
 
@@ -20,7 +21,7 @@ function postMetrics(payload: PageLoadMetricsPayload) {
     return;
   }
 
-  void fetch("/api/metrics/page-load", {
+  void apiFetch("/api/metrics/page-load", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,

--- a/apps/frontend/src/components/trading/TradingAccountSettings.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountSettings.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from "react";
 
@@ -24,7 +25,7 @@ export default function TradingAccountSettings() {
 
     const fetchConfigs = async () => {
         try {
-            const res = await fetch("/api/trading/configs");
+            const res = await apiFetch("/api/trading/configs");
             if (res.ok) {
                 const data = await res.json();
                 setConfigs(data || []);
@@ -39,7 +40,7 @@ export default function TradingAccountSettings() {
 
     const fetchFinanceAccounts = async () => {
         try {
-            const res = await fetch("/api/finances/latest");
+            const res = await apiFetch("/api/finances/latest");
             if (res.ok) {
                 const data = await res.json();
                 if (data && data.data && data.data.items) {
@@ -58,7 +59,7 @@ export default function TradingAccountSettings() {
         setSaving(true);
         setMessage("");
         try {
-            const res = await fetch("/api/trading/config", {
+            const res = await apiFetch("/api/trading/config", {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(editingConfig)

--- a/apps/frontend/src/lib/__tests__/api-client.test.ts
+++ b/apps/frontend/src/lib/__tests__/api-client.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock must be set up before importing api-client.
+// api-client uses a dynamic import('@/lib/supabase/browser'), so we mock the module
+// and expose a mocked getSession via the createClient factory.
+const mockGetSession = vi.fn();
+
+vi.mock('@/lib/supabase/browser', () => ({
+  createClient: () => ({
+    auth: {
+      getSession: mockGetSession,
+    },
+  }),
+}));
+
+import { apiFetch, ApiAuthError } from '../api-client';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  // Default: restore global fetch mock
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+describe('apiFetch', () => {
+  describe('when a session exists', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        data: { session: { access_token: 'test-jwt-token' } },
+        error: null,
+      } as ReturnType<typeof supabaseBrowser.auth.getSession> extends Promise<infer T> ? T : never);
+    });
+
+    it('attaches Authorization: Bearer header', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await apiFetch('/api/holdings');
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      const [, init] = mockFetch.mock.calls[0] as [unknown, RequestInit];
+      expect((init?.headers as Record<string, string>)?.Authorization).toBe(
+        'Bearer test-jwt-token',
+      );
+    });
+
+    it('merges caller-supplied headers without clobbering Authorization', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await apiFetch('/api/plans/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ foo: 1 }),
+      });
+
+      const [, init] = mockFetch.mock.calls[0] as [unknown, RequestInit];
+      const headers = init?.headers as Record<string, string>;
+      expect(headers?.Authorization).toBe('Bearer test-jwt-token');
+      expect(headers?.['Content-Type']).toBe('application/json');
+    });
+
+    it('returns the Response on success', async () => {
+      const mockResponse = new Response(JSON.stringify({ ok: true }), { status: 200 });
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+
+      const result = await apiFetch('/api/finances/latest');
+      expect(result).toBe(mockResponse);
+    });
+
+    it('throws ApiAuthError on 401', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 401 })));
+
+      await expect(apiFetch('/api/holdings')).rejects.toThrow(ApiAuthError);
+      await expect(apiFetch('/api/holdings')).rejects.toMatchObject({ status: 401 });
+    });
+
+    it('throws ApiAuthError on 403', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('', { status: 403 })));
+
+      await expect(apiFetch('/api/holdings')).rejects.toThrow(ApiAuthError);
+      await expect(apiFetch('/api/holdings')).rejects.toMatchObject({ status: 403 });
+    });
+
+    it('does NOT throw on other error status codes (e.g. 500)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('error', { status: 500 })));
+
+      const result = await apiFetch('/api/holdings');
+      expect(result.status).toBe(500);
+    });
+  });
+
+  describe('when no session exists', () => {
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue({
+        data: { session: null },
+        error: null,
+      } as ReturnType<typeof supabaseBrowser.auth.getSession> extends Promise<infer T> ? T : never);
+    });
+
+    it('makes the request without an Authorization header', async () => {
+      const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
+      vi.stubGlobal('fetch', mockFetch);
+
+      await apiFetch('/api/holdings');
+
+      const [, init] = mockFetch.mock.calls[0] as [unknown, RequestInit];
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers?.Authorization).toBeUndefined();
+    });
+  });
+
+  describe('ApiAuthError', () => {
+    it('is an instance of Error', () => {
+      const err = new ApiAuthError(401);
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(ApiAuthError);
+    });
+
+    it('carries the status code', () => {
+      expect(new ApiAuthError(401).status).toBe(401);
+      expect(new ApiAuthError(403).status).toBe(403);
+    });
+
+    it('uses a default message when none provided', () => {
+      expect(new ApiAuthError(401).message).toContain('401');
+    });
+
+    it('accepts a custom message', () => {
+      const err = new ApiAuthError(403, 'Forbidden');
+      expect(err.message).toBe('Forbidden');
+    });
+  });
+});

--- a/apps/frontend/src/lib/api-client.ts
+++ b/apps/frontend/src/lib/api-client.ts
@@ -1,0 +1,64 @@
+/**
+ * Central API client for all FastAPI backend calls.
+ *
+ * Every fetch against the backend MUST go through `apiFetch` so that the
+ * Supabase JWT is forwarded and backend RLS can enforce per-user isolation.
+ *
+ * Usage (Client Component or hook):
+ *   import { apiFetch } from '@/lib/api-client';
+ *   const res = await apiFetch('/api/holdings');
+ *   const data = await res.json();
+ */
+
+/** Thrown when the backend returns 401 or 403. */
+export class ApiAuthError extends Error {
+  constructor(public readonly status: 401 | 403, message?: string) {
+    super(message ?? `Backend returned ${status} — session may have expired.`);
+    this.name = 'ApiAuthError';
+  }
+}
+
+async function buildAuthHeaders(): Promise<HeadersInit> {
+  // Dynamic import avoids initializing the Supabase browser client at module
+  // evaluation time, which would fail during Next.js static generation where
+  // NEXT_PUBLIC_SUPABASE_URL is not available.
+  const { createClient } = await import('@/lib/supabase/browser');
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (session?.access_token) {
+    return { Authorization: `Bearer ${session.access_token}` };
+  }
+  return {};
+}
+
+/**
+ * Drop-in replacement for `fetch` that attaches the Supabase JWT.
+ *
+ * - Merges Authorization header before any caller-supplied headers so callers
+ *   can still override if needed.
+ * - Throws `ApiAuthError` on 401/403 so callers don't silently consume
+ *   permission errors.
+ * - Returns the raw `Response`; callers still call `.json()`, `.text()`, etc.
+ */
+export async function apiFetch(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> {
+  const authHeaders = await buildAuthHeaders();
+
+  const response = await fetch(input, {
+    ...init,
+    headers: {
+      ...authHeaders,
+      ...init?.headers,
+    },
+  });
+
+  if (response.status === 401 || response.status === 403) {
+    throw new ApiAuthError(response.status as 401 | 403);
+  }
+
+  return response;
+}

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -2,13 +2,33 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
 /**
+ * Routes that do NOT require authentication.
+ * Add paths here that should be accessible without a login.
+ */
+const PUBLIC_ROUTES: readonly string[] = [
+  '/login',
+  '/favicon.ico',
+];
+
+/** Prefixes whose entire subtree is public (no auth required). */
+const PUBLIC_PREFIXES: readonly string[] = [
+  '/auth/',     // auth callback, OAuth redirects
+  '/_next/',    // Next.js internals
+  '/api/auth/', // next-auth / Supabase auth API routes
+];
+
+function isPublicRoute(pathname: string): boolean {
+  if (PUBLIC_ROUTES.includes(pathname)) return true;
+  return PUBLIC_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+/**
  * Refreshes the Supabase auth session on every request and propagates the
  * updated tokens to both the request (for Server Components) and the response
  * (for the browser).
  *
- * This is the "proxy / middleware" pattern from @supabase/ssr — it must run
- * before any Server Component that calls `supabase.auth.getUser()` or
- * `supabase.auth.getClaims()` so that sessions do not expire mid-navigation.
+ * Also enforces authentication: if the user is not signed in and is requesting
+ * a protected route, they are redirected to /login?next=<original-path>.
  */
 async function updateSession(request: NextRequest): Promise<NextResponse> {
   let supabaseResponse = NextResponse.next({ request });
@@ -40,7 +60,23 @@ async function updateSession(request: NextRequest): Promise<NextResponse> {
   );
 
   // Refresh the session; result is written back via setAll above.
-  await supabase.auth.getClaims();
+  const { data } = await supabase.auth.getClaims();
+
+  const { pathname } = request.nextUrl;
+
+  // Auth guard: redirect unauthenticated users to /login
+  if (!data?.claims && !isPublicRoute(pathname)) {
+    const loginUrl = request.nextUrl.clone();
+    loginUrl.pathname = '/login';
+    loginUrl.searchParams.set('next', pathname);
+    // IMPORTANT: copy updated cookies onto the redirect so the session
+    // refresh from getClaims() isn't lost.
+    const redirectResponse = NextResponse.redirect(loginUrl);
+    supabaseResponse.cookies.getAll().forEach(({ name, value, ...opts }) => {
+      redirectResponse.cookies.set(name, value, opts);
+    });
+    return redirectResponse;
+  }
 
   // IMPORTANT: return supabaseResponse as-is so the updated cookies reach
   // the browser. If you must return a different response, copy the cookies:


### PR DESCRIPTION
## Summary

Closes both P0 auth gaps identified in `docs/design-hosting/page-audit.md`:
1. **JWT forwarding gap** — zero pages were attaching `Authorization: Bearer` to FastAPI fetches; backend RLS had no token to enforce against.
2. **No auth guard** — every page was publicly readable; middleware refreshed sessions but never redirected unauthenticated users.

Working as **Fenster** (Frontend Dev).

---

## Files Changed

### New files
| File | Purpose |
|------|---------|
| `apps/frontend/src/lib/api-client.ts` | `apiFetch()` wrapper — attaches JWT, throws `ApiAuthError` on 401/403 |
| `apps/frontend/src/lib/__tests__/api-client.test.ts` | 11 vitest unit tests for the wrapper |
| `apps/frontend/src/app/login/page.tsx` | Stub login UI: Google OAuth + magic-link form, `next` redirect validation |
| `apps/frontend/src/app/auth/callback/route.ts` | PKCE exchange handler (`supabase.auth.exchangeCodeForSession`) |

### Modified
- **`src/middleware.ts`** — auth guard with public-route allowlist const; redirects unauthenticated requests to `/login?next=<path>`
- **36 page/component files** — all `fetch(` calls against FastAPI replaced with `apiFetch(`; import added automatically

---

## Architecture Notes

- `apiFetch` uses a **dynamic import** of the Supabase browser client to avoid module-level initialisation during Next.js static generation (the `supabaseBrowser` singleton in `browser.ts` would throw without env vars during build time).
- Login page uses **Suspense boundary** around the inner component to satisfy Next.js 15's `useSearchParams()` requirement.
- `/login` page uses dynamic imports for all Supabase calls (same reason).

---

## Verification

- `npx vitest run`: **11 new tests pass**, 87 total pass, 3 pre-existing failures in PensionChart/PensionTable unchanged
- `npm run build`: **✓ Build succeeds** — all 26 pages generate; `typescript.ignoreBuildErrors` and `eslint.ignoreDuringBuilds` already set in `next.config.ts` (pre-existing lint/type issues not introduced by this PR)
- New files only: `npx eslint src/lib/api-client.ts src/middleware.ts src/app/login/page.tsx src/app/auth/callback/route.ts` → **zero errors**

---

## ⚠️ Keyboard tasks remaining

- **Google OAuth**: Enable in Supabase Studio → Authentication → Providers → Google (add Client ID + Secret). Magic-link works today without any config.
- Pre-existing lint errors (~20 `any` usages across components) are unrelated to this PR.