### PR TITLE
fix(api): forward Supabase JWT from Next.js to FastAPI backend

### DIFF
--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -8,7 +8,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
 from app.dal.database import create_db_and_tables
 from app.utils.decimal_encoder import decimal_default
-from app.auth.dependencies import get_current_user
+from app.dependencies import get_current_user
 from app.api import (
     auth as auth_router_module,
     trades,


### PR DESCRIPTION
**Closes #121**

## Problem

After Supabase signin, all frontend `/api/*` calls to FastAPI returned 403 `{"detail":"Not authenticated"}` because the backend was using the wrong JWT validator.

- **Frontend**: `apiFetch` (from PR #96) correctly forwards Supabase JWTs via `Authorization: Bearer` header
- **Backend**: `main.py` imported `get_current_user` from `app.auth.dependencies` (local JWT system using `JWT_SECRET_KEY` + HS256)
- **Mismatch**: Backend couldn't validate Supabase JWTs (signed by Supabase with RS256 via JWKS)

Confirmed broken endpoints (Redfoot's PR #118 smoke run):
- POST `/api/metrics/page-load`, GET `/api/options`, `/api/options/projection`
- GET `/api/pension/dashboard`, `/api/pension/reports`
- GET `/api/plans/latest`, `/api/plans/simulate`
- GET `/api/finances/latest`, `/api/cash-flow`

## Solution

Changed `main.py` import from:
```python
from app.auth.dependencies import get_current_user  # OLD: local JWT
```

To:
```python
from app.dependencies import get_current_user  # NEW: Supabase JWT
```

The new dependency (`app.dependencies.get_current_user`):
- Validates Supabase JWTs via `app.supabase_auth.verify_supabase_jwt`
- Fetches public keys from Supabase JWKS endpoint (RS256/ES256)
- Falls back to `SUPABASE_JWT_SECRET` for local HS256 dev tokens
- Returns `SupabaseClaims` with authenticated user UUID

The backend already initialized the JWKS cache in the lifespan handler (line 88), so this was a **one-line import change**.

## Configuration Required

Backend `.env` must include:
```bash
SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
# Optional: SUPABASE_JWT_SECRET for HS256 fallback
```

## Testing

**Before** (PR #118 smoke run): All protected endpoints returned 403  
**After** (this PR): 53/60 smoke tests passed  
- 7 webkit failures due to Supabase rate limiting (not auth errors)
- Manual curl tests confirm backend properly validates JWTs:
  - No token → 401 "Authorization header missing"
  - Invalid token → 401 "Malformed token"
  - Valid token → 200 (tested via smoke test auth flow)

All 5 Wave 1 endpoints now return 2xx when authenticated.

## Impact

**Unblocks Wave 1, 2, and most of Wave 3** — this was the single highest-leverage fix per issue #121.

---

Working as **Fenster (Frontend Dev)**
