### PR TITLE
fix(frontend): finances Server Action (stop /api/finances 404)

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -205,3 +205,42 @@ SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
 **Output artifact:** `docs/design-hosting/frontend-api-callsites.md` — 89 call sites inventoried, detailed migration plan for `POST /api/finances`, decision criteria for Server Action vs direct client.
 
 **Branch:** Not yet created — this is planning/audit work only. Implementation PR will follow after team review.
+
+## finances Server Action — Stop-the-Bleed Fix (2026-07-31)
+
+**Branch:** squad/finances-server-action → PR opened  
+**Context:** POST `/api/finances` → 404 on Vercel (rewrites to undeployed FastAPI)
+
+### What was done
+
+1. Created `apps/frontend/src/app/current-finances/actions.ts`
+   - `saveFinanceSnapshot(items, metrics)` — upserts to `finance_snapshots` via SSR Supabase
+   - `getLatestFinanceSnapshot()` — reads latest snapshot via SSR Supabase
+   - `resolveHouseholdId(userId)` — looks up `household_members` from session, **never from caller**
+
+2. Updated `apps/frontend/src/app/current-finances/page.tsx`
+   - Replaced both `apiFetch('/api/finances/*')` calls with Server Actions
+   - Replaced `alert('Failed to save...')` with dismissable inline error banner (role="alert")
+   - Removed dead variable computations (`netWorth`, `totalAssets`, `totalLiabilities`) that caused lint errors
+
+3. Created `apps/frontend/src/app/current-finances/actions.test.ts`
+   - 8 vitest unit tests: unauth path, no-household path, household_id from session (not caller), DB failure, input validation, read happy/error paths
+   - Follows the mock pattern from `src/lib/__tests__/api-client.test.ts`
+
+### Key decisions
+
+- `household_id` ALWAYS comes from `household_members` table via `supabase.auth.getUser()`.  Never accepted from form input or function parameters.
+- Supabase RLS (`is_household_writer`) enforces write isolation at DB layer — confirmed GREEN by Rabin's audit.
+- next.config.ts rewrite guard left untouched (commit 89dff6e).
+- Upsert uses `onConflict: 'date'` (PK). RLS blocks cross-household updates at DB level.
+
+### Pattern established
+
+This is the **template for all 32 MOVE endpoints**. See decision note at:
+`.squad/decisions/inbox/fenster-finances-server-action.md`
+
+### Build/test results
+
+- `npm run test`: 8/8 new tests pass. 3 pre-existing Pension test failures (unrelated).
+- `npm run lint`: 0 errors in changed files. All other lint errors are pre-existing.
+- `npm run build`: ✅ succeeds with env vars set.

--- a/apps/frontend/src/app/current-finances/actions.test.ts
+++ b/apps/frontend/src/app/current-finances/actions.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the finances Server Action.
+ *
+ * Focus: auth / household-scoping logic — the security-critical path.
+ * We verify that:
+ *   1. household_id is NEVER accepted from the caller; it is always resolved
+ *      from the authenticated session via `household_members`.
+ *   2. Unauthenticated callers receive an error, not a DB write.
+ *   3. Users with no active household receive an error, not a DB write.
+ *   4. A happy-path call passes the correct household_id to the upsert.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Supabase server client mock ───────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+const mockMaybeSingleHousehold = vi.fn();
+const mockUpsert = vi.fn();
+const mockMaybeSingleSnapshot = vi.fn();
+
+/**
+ * Minimal mock of the fluent Supabase query builder.
+ * Each `.from(table)` call selects a pre-configured chain.
+ */
+const makeSupabaseMock = () => ({
+  auth: {
+    getUser: mockGetUser,
+  },
+  from: vi.fn((table: string) => {
+    if (table === 'household_members') {
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: mockMaybeSingleHousehold,
+      };
+    }
+    if (table === 'finance_snapshots') {
+      return {
+        upsert: mockUpsert,
+        select: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: mockMaybeSingleSnapshot,
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  }),
+});
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+// Import after mock setup
+import { saveFinanceSnapshot, getLatestFinanceSnapshot } from './actions';
+import { createClient } from '@/lib/supabase/server';
+
+const MOCK_USER_ID = 'user-uuid-1234';
+const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
+
+const VALID_ITEMS = [
+  {
+    id: 'item-1',
+    category: 'Assets' as const,
+    name: 'Apartment',
+    value: 1_000_000,
+    type: 'Real Estate',
+    owner: 'Jony',
+    currency: 'ILS',
+  },
+];
+
+const VALID_METRICS = {
+  net_worth: 1_000_000,
+  total_assets: 1_000_000,
+  total_liabilities: 0,
+  total_savings: 0,
+  total_investments: 0,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  (createClient as ReturnType<typeof vi.fn>).mockResolvedValue(makeSupabaseMock());
+});
+
+// ── saveFinanceSnapshot ───────────────────────────────────────────────────────
+
+describe('saveFinanceSnapshot', () => {
+  it('returns an error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+
+    const result = await saveFinanceSnapshot(VALID_ITEMS, VALID_METRICS);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authenticated/i);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the user has no active household', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleHousehold.mockResolvedValue({ data: null, error: null });
+
+    const result = await saveFinanceSnapshot(VALID_ITEMS, VALID_METRICS);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/no active household/i);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+
+  it('passes the session-resolved household_id to the upsert — never caller-supplied', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleHousehold.mockResolvedValue({
+      data: { household_id: MOCK_HOUSEHOLD_ID },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    const result = await saveFinanceSnapshot(VALID_ITEMS, VALID_METRICS);
+
+    expect(result.success).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledOnce();
+    const [row] = mockUpsert.mock.calls[0] as [Record<string, unknown>];
+    expect(row.household_id).toBe(MOCK_HOUSEHOLD_ID);
+    // Confirm the payload carries the items inside `data`, not as a top-level key
+    expect((row.data as { items: unknown }).items).toEqual(VALID_ITEMS);
+  });
+
+  it('returns an error when the DB upsert fails', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleHousehold.mockResolvedValue({
+      data: { household_id: MOCK_HOUSEHOLD_ID },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: { message: 'RLS violation' } });
+
+    const result = await saveFinanceSnapshot(VALID_ITEMS, VALID_METRICS);
+
+    expect(result.success).toBe(false);
+  });
+
+  it('validates that items must be an array', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleHousehold.mockResolvedValue({
+      data: { household_id: MOCK_HOUSEHOLD_ID },
+      error: null,
+    });
+
+    // @ts-expect-error intentionally passing wrong type for runtime validation test
+    const result = await saveFinanceSnapshot('not-an-array', VALID_METRICS);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/items must be an array/i);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+});
+
+// ── getLatestFinanceSnapshot ──────────────────────────────────────────────────
+
+describe('getLatestFinanceSnapshot', () => {
+  it('returns an error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const result = await getLatestFinanceSnapshot();
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authenticated/i);
+  });
+
+  it('returns null data when no snapshot exists', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleSnapshot.mockResolvedValue({ data: null, error: null });
+
+    const result = await getLatestFinanceSnapshot();
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toBeNull();
+  });
+
+  it('returns the snapshot data on success', async () => {
+    const snapshotData = { items: VALID_ITEMS, ...VALID_METRICS };
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleSnapshot.mockResolvedValue({ data: { data: snapshotData }, error: null });
+
+    const result = await getLatestFinanceSnapshot();
+
+    expect(result.success).toBe(true);
+    if (result.success) expect(result.data).toEqual(snapshotData);
+  });
+});

--- a/apps/frontend/src/app/current-finances/actions.ts
+++ b/apps/frontend/src/app/current-finances/actions.ts
@@ -1,0 +1,149 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import type { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface FinanceMetrics {
+  net_worth: number;
+  total_assets: number;
+  total_liabilities: number;
+  total_savings: number;
+  total_investments: number;
+}
+
+/** Shape stored in the `data` jsonb column and returned to the client. */
+export interface SnapshotData {
+  items: FinanceItem[];
+  net_worth: number;
+  total_assets: number;
+  total_liabilities: number;
+  total_savings: number;
+  total_investments: number;
+}
+
+export type SaveSnapshotResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type GetSnapshotResult =
+  | { success: true; data: SnapshotData | null }
+  | { success: false; error: string };
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Looks up the calling user's primary active household_id.
+ * household_id must NEVER come from user input — always from the session.
+ */
+async function resolveHouseholdId(userId: string): Promise<string | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data.household_id as string;
+}
+
+// ── Server Actions ────────────────────────────────────────────────────────────
+
+/**
+ * Upserts a finance snapshot for today into `finance_snapshots`.
+ *
+ * Security guarantees:
+ * - `household_id` is resolved from the authenticated session; never from caller input.
+ * - Supabase RLS (`is_household_writer`) enforces write isolation at the DB layer.
+ */
+export async function saveFinanceSnapshot(
+  items: FinanceItem[],
+  metrics: FinanceMetrics,
+): Promise<SaveSnapshotResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  // Validate inputs before hitting the DB
+  if (!Array.isArray(items)) {
+    return { success: false, error: 'Invalid payload: items must be an array' };
+  }
+  if (
+    typeof metrics.net_worth !== 'number' ||
+    typeof metrics.total_assets !== 'number' ||
+    typeof metrics.total_liabilities !== 'number' ||
+    typeof metrics.total_savings !== 'number' ||
+    typeof metrics.total_investments !== 'number'
+  ) {
+    return { success: false, error: 'Invalid payload: all metric fields must be numbers' };
+  }
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) {
+    return { success: false, error: 'No active household found for your account' };
+  }
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const snapshotData: SnapshotData = { items, ...metrics };
+
+  const { error: upsertError } = await supabase.from('finance_snapshots').upsert(
+    {
+      date: today,
+      household_id: householdId,
+      data: snapshotData,
+      net_worth: metrics.net_worth,
+      total_assets: metrics.total_assets,
+      total_liabilities: metrics.total_liabilities,
+    },
+    { onConflict: 'date' },
+  );
+
+  if (upsertError) {
+    console.error('[saveFinanceSnapshot] upsert error:', upsertError.message);
+    return { success: false, error: 'Failed to save snapshot. Please try again.' };
+  }
+
+  return { success: true };
+}
+
+/**
+ * Fetches the most-recent finance snapshot for the authenticated user's household.
+ * Returns `{ data: null }` when no snapshot exists yet (not an error).
+ */
+export async function getLatestFinanceSnapshot(): Promise<GetSnapshotResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const { data, error } = await supabase
+    .from('finance_snapshots')
+    .select('data')
+    .order('date', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[getLatestFinanceSnapshot] query error:', error.message);
+    return { success: false, error: 'Failed to load snapshot. Please refresh.' };
+  }
+
+  return { success: true, data: (data?.data as SnapshotData) ?? null };
+}

--- a/apps/frontend/src/app/current-finances/page.tsx
+++ b/apps/frontend/src/app/current-finances/page.tsx
@@ -1,56 +1,11 @@
 'use client';
-import { apiFetch } from '@/lib/api-client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { DonutChart } from '@/components/CurrentFinances/DonutChart';
 import { FinanceTabs, FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
 import { useSettings } from '../settings/SettingsContext';
 import { convertCurrency } from '@/lib/currency';
-
-// --- API Helper ---
-async function fetchLatestSnapshot() {
-  try {
-    const res = await apiFetch('/api/finances/latest');
-    if (!res.ok) {
-      if (res.status === 404) return null; // No snapshot yet
-      const errorText = await res.text();
-      throw new Error(`Failed to fetch snapshot: ${res.status} ${errorText}`);
-    }
-    const data = await res.json();
-    // Use the inner 'data' which matches our SnapshotData structure
-    // But check if it has the 'items' key.
-    // The backend stores JSON in 'data' column. 
-    // And FinanceSnapshot model has 'data' field.
-    return data.data;
-  } catch (err) {
-    console.error(err);
-    return null;
-  }
-}
-
-async function saveSnapshot(items: FinanceItem[], metrics: { net_worth: number, total_assets: number, total_liabilities: number, total_savings: number, total_investments: number }) {
-  try {
-    const payload = {
-      items,
-      ...metrics
-    };
-
-    const res = await apiFetch('/api/finances/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-
-    if (!res.ok) {
-      const errorText = await res.text();
-      throw new Error(`Failed to save snapshot: ${res.status} ${errorText}`);
-    }
-    return await res.json();
-  } catch (err) {
-    console.error(err);
-    alert('Failed to save changes. Check console.');
-  }
-}
+import { saveFinanceSnapshot, getLatestFinanceSnapshot } from './actions';
 
 
 export default function CurrentFinancesPage() {
@@ -58,12 +13,13 @@ export default function CurrentFinancesPage() {
   const mainCurrency = settings.mainCurrency || 'USD';
   const [items, setItems] = useState<FinanceItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   // --- Initial Fetch ---
   useEffect(() => {
-    fetchLatestSnapshot().then(data => {
-      if (data && data.items) {
-        setItems(data.items);
+    getLatestFinanceSnapshot().then(result => {
+      if (result.success && result.data?.items) {
+        setItems(result.data.items);
       }
       setLoading(false);
     });
@@ -79,39 +35,18 @@ export default function CurrentFinancesPage() {
   const totalSavings = savingsItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
   const totalInvestments = investmentItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
   const totalEquity = totalSavings + totalInvestments;
-  const totalLiabilities = liabilityItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
-
-  const totalAssets = totalRealAssets + totalEquity;
-  const netWorth = totalAssets - totalLiabilities;
 
   // Save logic tied to items update
   // We wrap setItems to also trigger save, or use an effect. 
   // Using a handler is safer to control when save happens.
-  const handleUpdateItems = (newItems: FinanceItem[]) => {
+  const handleUpdateItems = useCallback((newItems: FinanceItem[]) => {
     setItems(newItems);
+    setSaveError(null);
 
     const tAssetsItems = newItems.filter(i => i.category === 'Assets');
     const tSavingsItems = newItems.filter(i => i.category === 'Savings');
     const tInvestItems = newItems.filter(i => i.category === 'Investments');
     const tLiabilityItems = newItems.filter(i => i.category === 'Liabilities');
-
-    // NOTE: For 'metrics' we save them in the main currency or base?
-    // Logic: The snapshot store should probably be agnostic or we store it 'as is' and convert on read.
-    // But the 'metrics' fields are summations.
-    // Let's store them as Main Currency values at the time of save, OR usage consistency.
-    // Given we use these for "Net Worth History" which might not convert retroactively if rates change,
-    // it is safer to store the SUM in the users Main Currency at that time. 
-    // OR store them in Base ILS if we want consistency. 
-    // The current flow doesn't check 'mainCurrency' for save logic (user context).
-    // Let's save the calculated totals (which are now in Main Currency).
-    // But wait: if user switches currency, history chart will jump!
-    // Ideally history is normalized to a Base currency (e.g. ILS or USD).
-    // Since backend doesn't seem to have multi-currency history support yet,
-    // let's stick to saving what the user sees (Main Currency) and assume they don't flip flop often OR backend handles it.
-    // PROPOSAL: Store metrics in base currency (ILS or USD) always?
-    // Let's assume the backend expects raw values and `PlanService` converts them.
-    // Actually `saveSnapshot` just dumps JSON.
-    // Let's simply save the converted totals so the snapshot matches the dashboard view.
 
     const tRealAssets = tAssetsItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
     const tSavings = tSavingsItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
@@ -119,14 +54,18 @@ export default function CurrentFinancesPage() {
     const tLiabilities = tLiabilityItems.reduce((sum, i) => sum + convertCurrency(i.value, i.currency || 'ILS', mainCurrency), 0);
     const tTotalAssets = tRealAssets + tSavings + tInvestments;
 
-    saveSnapshot(newItems, {
+    saveFinanceSnapshot(newItems, {
       net_worth: tTotalAssets - tLiabilities,
       total_assets: tTotalAssets,
       total_liabilities: tLiabilities,
       total_savings: tSavings,
-      total_investments: tInvestments
+      total_investments: tInvestments,
+    }).then(result => {
+      if (!result.success) {
+        setSaveError(result.error);
+      }
     });
-  };
+  }, [mainCurrency]);
 
 
   // Chart Data Preparation 
@@ -186,6 +125,23 @@ export default function CurrentFinancesPage() {
           </div>
           {/* Could add date selector here later */}
         </header>
+
+        {saveError && (
+          <div
+            role="alert"
+            className="mb-4 flex items-start gap-3 rounded-lg border border-red-500/40 bg-red-950/50 px-4 py-3 text-sm text-red-300"
+          >
+            <span className="mt-0.5 shrink-0">⚠️</span>
+            <span>{saveError}</span>
+            <button
+              onClick={() => setSaveError(null)}
+              aria-label="Dismiss error"
+              className="ml-auto shrink-0 text-red-400 hover:text-red-200"
+            >
+              ✕
+            </button>
+          </div>
+        )}
 
         {/* Compact Charts Row */}
         <div className="flex flex-col md:flex-row gap-4 mb-8 justify-between items-center bg-slate-900/30 p-4 rounded-xl border border-slate-800/50 overflow-x-auto">


### PR DESCRIPTION
Re-opened after PR #138 was auto-closed by GitHub during force-push rebase.

## Summary
Replaces failing `POST /api/finances` (404 in production) with a Next.js Server Action that writes directly to Supabase `finance_snapshots`.

- New Server Actions: `saveFinanceSnapshot` + `getLatestFinanceSnapshot` in `apps/frontend/src/app/current-finances/actions.ts`
- `household_id` resolved from authenticated session — never accepted from caller input
- Inline error banner replaces `alert()`
- 8 unit tests added, all passing
- Backed by Rabin's RLS GREEN-LIGHT audit (`finance_snapshots` has full 4-policy coverage)

## Refs
- Phase 3 plan: `docs/design-hosting/phase-3-execution-plan.md`
- Frontend audit: `docs/design-hosting/frontend-api-callsites.md`
- RLS audit: `docs/design-hosting/rls-coverage-audit.md`
- Pattern note: `.squad/decisions/inbox/fenster-finances-server-action.md`
- Stacks on top of #139 (soften /api rewrite guard)

Closes the production write failure originally tracked under PR #138.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>