### PR TITLE
feat(e2e): extend Playwright harness — unified fixtures + test tagging (closes #144)

### DIFF
--- a/.squad/agents/redfoot/history.md
+++ b/.squad/agents/redfoot/history.md
@@ -155,3 +155,39 @@ Reviewed `docs/design-hosting/design.md` plus six section docs as Redfoot. Wrote
 **Notes**: This was unauthenticated smoke testing. All pages render but may show empty states without auth. Authenticated functional testing is the next phase.
 
 📌 Team update (2026-05-01T19:02:15+03:00): Platform workflows audit — removed 6 squad-* workflows, kept core CI. Flagged test-rls.yml for review. — decided by kujan
+
+### 2026-05-02: E2E Harness Extension — Unified Fixtures + Test Tagging (Issue #144, PR #152)
+
+**Context**: Issue #144 requested extending the existing E2E scaffold with unified fixtures and test tagging per `docs/testing/e2e-strategy.md`. Scaffold already existed (fixtures, smoke, flows from prior work). This round adds the household-aware test-user fixture and seed-data helpers.
+
+**What was done:**
+
+- **`e2e/fixtures/test-user.ts`** — new canonical fixture for auth+household tests:
+  - Creates throwaway e2e user via admin API
+  - Injects auth cookie via direct REST password grant (matches `auth-cookie.ts` pattern)
+  - Polls `household_members` table ≤5s for the auto-provision trigger to fire (migration `20260502120000`)
+  - Returns `{ page, userId, email, householdId }` — household ready to seed
+  - Tears down in afterAll (cascade via FK)
+
+- **`e2e/fixtures/seed-data.ts`** — per-test data seeding helpers:
+  - `seedFund(householdId, data)` → upserts Investments FinanceItem into `finance_snapshots.data.items`
+  - `seedAsset(householdId, data)` → upserts Assets FinanceItem into `finance_snapshots.data.items`
+  - `seedTrade(householdId, data)` → inserts IB Flex-format row into `public.trade`
+  - `cleanupHouseholdData(householdId)` → deletes seeded rows from finance_snapshots + trade
+
+- **Tag annotations**: Added `@smoke` to all `e2e/smoke/` tests, `@flow` to all `e2e/flows/` tests. `@auth` and `@rls` reserved for issue #146–#149.
+
+- **npm scripts added**: `test:e2e:smoke`, `test:e2e:flows`, `test:e2e:auth` (using `--grep`)
+
+- **`e2e/README.md`** updated with new fixtures, tagging table, seeding usage examples.
+
+**Verification:**
+- `--list --grep @smoke` → 27 tests (9 × 3 browsers) ✅
+- `--list --grep @flow` → 51 tests (17 × 3 browsers) ✅
+- `tsc --noEmit` → 0 errors in new files ✅
+
+**Blockers:**
+- `testUser` fixture and seed helpers cannot run green without Supabase env vars (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`).
+- Depends on Hockney's issue #145 (test-user provisioning env) before @auth-tier tests can execute.
+
+**PR:** https://github.com/cohenjo/trading-journal/pull/152 — marked ready-for-review (smoke + flow listing verified; authenticated run pending env from #145).

--- a/apps/frontend/e2e/README.md
+++ b/apps/frontend/e2e/README.md
@@ -6,6 +6,15 @@
 # Local dev server (must be running separately)
 cd apps/frontend && npm run test:e2e
 
+# Run only smoke tests (no auth required — fast)
+npm run test:e2e:smoke
+
+# Run only flow tests (requires Supabase env)
+npm run test:e2e:flows
+
+# Run only auth tests (requires Supabase env)
+npm run test:e2e:auth
+
 # Against a deployed Vercel preview / dev URL
 BASE_URL=https://trading-journal-git-main-cohenjos-projects.vercel.app npm run test:e2e:dev
 
@@ -34,12 +43,18 @@ e2e/
 ├── auth/                   ← P1: login + logout flow against dev Supabase
 │   └── (next round — after Kujan confirms env boots)
 ├── flows/                  ← P1: critical user flows
-│   └── (next round — after Fenster's page audit lands in docs/design-hosting/page-audit.md)
+│   ├── root.spec.ts
+│   ├── current-finances.spec.ts
+│   ├── plan.spec.ts
+│   └── summary.spec.ts
 ├── rls/                    ← P2: data isolation tests
 │   └── (next round — maps to pgTAP tests in supabase/tests/)
 ├── fixtures/
 │   ├── admin.ts            ← Supabase service-role admin client (server-only)
-│   └── auth.ts             ← authenticatedUser + householdOwner Playwright fixtures
+│   ├── auth.ts             ← authenticatedUser + householdOwner Playwright fixtures
+│   ├── auth-cookie.ts      ← cookie-injection auth (preferred over auth.ts)
+│   ├── test-user.ts        ← unified fixture: user + household provisioning (issue #144)
+│   └── seed-data.ts        ← per-test data seeding helpers (issue #144)
 └── scripts/
     └── cleanup-stale-users.ts  ← delete e2e_* users older than 1h
 ```
@@ -109,18 +124,106 @@ Reads from env:
 - `NEXT_PUBLIC_SUPABASE_URL` — shared with the app
 - `SUPABASE_SERVICE_ROLE_KEY` — test-only; **never prefix with NEXT_PUBLIC_**
 
-### `fixtures/auth.ts` — Playwright fixtures
+### `fixtures/auth-cookie.ts` — preferred auth fixture (cookie injection)
+
+Directly calls the Supabase REST password-grant endpoint, builds the
+`@supabase/ssr` cookie format, and injects it into the browser context.
+This is more reliable than the CDN-based `auth.ts` fixture because it
+sets cookies correctly for the Next.js SSR middleware.
+
+### `fixtures/test-user.ts` — unified user + household fixture (issue #144)
+
+The canonical fixture for tests that need a fully provisioned user.
+
+**What it does:**
+1. Creates a throwaway Supabase user via admin API.
+2. Injects auth cookie using the `auth-cookie.ts` pattern.
+3. Polls `household_members` until the auto-provision trigger fires (≤5s timeout).
+4. Returns `{ page, userId, email, householdId }`.
+5. Tears down (deletes user → cascades household data) in afterAll.
+
+**Usage:**
+```typescript
+import { test } from '../fixtures/test-user';
+
+test('my auth flow @auth', async ({ testUser: { page, householdId } }) => {
+  await page.goto('/current-finances');
+  // householdId available for seeding via seed-data.ts helpers
+});
+```
+
+### `fixtures/seed-data.ts` — per-test data seeding (issue #144)
+
+Data seeding helpers scoped to a household. All helpers use the admin client (bypass RLS).
+
+| Helper | Table | Description |
+|--------|-------|-------------|
+| `seedFund(householdId, data)` | `finance_snapshots` | Inserts an Investments-category FinanceItem |
+| `seedAsset(householdId, data)` | `finance_snapshots` | Inserts an Assets-category FinanceItem |
+| `seedTrade(householdId, data)` | `public.trade` | Inserts an IB Flex-format trade row |
+| `cleanupHouseholdData(householdId)` | multiple | Deletes all seeded rows for the household |
+
+**Usage:**
+```typescript
+import { test } from '../fixtures/test-user';
+import { seedFund, seedTrade, cleanupHouseholdData } from '../fixtures/seed-data';
+
+test.describe('holdings flow', () => {
+  let householdId: string;
+
+  test.beforeEach(async ({ testUser }) => {
+    householdId = testUser.householdId;
+    await seedFund(householdId, { name: 'S&P 500 ETF', value: 50_000 });
+    await seedTrade(householdId, { symbol: 'SPY', side: 'BUY', quantity: 10, price: 500 });
+  });
+
+  test.afterEach(async () => {
+    await cleanupHouseholdData(householdId);
+  });
+
+  test('holdings page shows seeded fund @flow', async ({ testUser: { page } }) => {
+    await page.goto('/holdings');
+    await expect(page.locator('text=S&P 500 ETF')).toBeVisible();
+  });
+});
+```
+
+### `fixtures/auth.ts` — Playwright fixtures (legacy)
 
 Exports two custom fixtures:
 
 **`authenticatedUser`** — creates a throwaway Supabase user, signs in via the
 browser login flow, and returns `{ page, user }`. Tears down (deletes user)
-after the test.
+after the test. ⚠️ Uses CDN-loaded supabase-js — prefer `auth-cookie.ts` or
+`test-user.ts` for new tests.
 
 **`householdOwner`** — builds on `authenticatedUser`; additionally creates a
 household and membership row via the admin API, then returns `{ page, user, householdId }`.
 
 ---
+
+## Test Tagging Conventions
+
+Tests use inline tags in the test name to enable `--grep` filtering:
+
+| Tag | Tier | Meaning |
+|-----|------|---------|
+| `@smoke` | P0 | No auth, no seed data — just proves page renders |
+| `@auth` | P1 | Requires Supabase auth (uses `testUser` fixture) |
+| `@flow` | P1 | End-to-end user flow (requires auth + optional seed data) |
+| `@rls` | P2 | Data-isolation / Row Level Security verification |
+
+**Example:**
+```typescript
+test('user sees only their own trades @rls', async ({ testUser: { page } }) => { ... });
+```
+
+**Running tagged subsets:**
+```bash
+npm run test:e2e:smoke    # --grep @smoke
+npm run test:e2e:flows    # --grep @flow
+npm run test:e2e:auth     # --grep @auth
+```
 
 ## Test Data Hygiene
 

--- a/apps/frontend/e2e/fixtures/seed-data.ts
+++ b/apps/frontend/e2e/fixtures/seed-data.ts
@@ -1,0 +1,266 @@
+/**
+ * e2e/fixtures/seed-data.ts
+ *
+ * Per-test data seeding helpers for E2E tests.
+ *
+ * All helpers use the service-role admin client (bypasses RLS) so they can
+ * seed data for a household without requiring the test user to be the owner.
+ *
+ * Data model:
+ *   - Funds and Assets are FinanceItems stored in `finance_snapshots.data.items` (JSONB).
+ *     category: 'Investments' → fund-type items
+ *     category: 'Assets'      → asset-type items
+ *   - Trades are rows in `public.trade` (IB Flex schema + household_id).
+ *
+ * Teardown:
+ *   - `cleanupHouseholdData(householdId)` deletes all seeded rows for the household.
+ *     Because FK constraints use ON DELETE CASCADE, deleting the household row itself
+ *     would cascade everything — but we don't do that here; we only clear data rows
+ *     so the user can be reused across test hooks if needed.
+ *
+ * Usage:
+ *   import { seedFund, seedAsset, seedTrade, cleanupHouseholdData } from '../fixtures/seed-data';
+ *
+ *   test.beforeEach(async () => {
+ *     await seedFund(householdId, { name: 'S&P 500 Fund', value: 50000 });
+ *     await seedTrade(householdId, { symbol: 'AAPL', side: 'BUY' });
+ *   });
+ *
+ *   test.afterEach(async () => {
+ *     await cleanupHouseholdData(householdId);
+ *   });
+ */
+
+import { getAdminClient } from './admin';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface FundSeedData {
+  name: string;
+  value: number;
+  type?: string;
+  owner?: string;
+  currency?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface AssetSeedData {
+  name: string;
+  value: number;
+  type?: string;
+  owner?: string;
+  currency?: string;
+  details?: Record<string, unknown>;
+}
+
+export interface TradeSeedData {
+  symbol: string;
+  side: 'BUY' | 'SELL';
+  quantity?: number;
+  price?: number;
+  currency?: string;
+  tradeDate?: string;
+  accountId?: string;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/** Returns today's date as a YYYY-MM-DD string (snapshot key). */
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Upserts a FinanceItem into `finance_snapshots.data.items` for the given household.
+ *
+ * If a snapshot row already exists for (householdId, date), the new item is
+ * appended to `data.items`. If no row exists, a minimal snapshot is created.
+ */
+async function upsertFinanceItem(
+  householdId: string,
+  item: Record<string, unknown>,
+): Promise<void> {
+  const admin = getAdminClient();
+  const date = todayKey();
+
+  // Fetch existing snapshot for today
+  const { data: existing, error: fetchError } = await admin
+    .from('finance_snapshots')
+    .select('data')
+    .eq('household_id', householdId)
+    .eq('date', date)
+    .maybeSingle();
+
+  if (fetchError) {
+    throw new Error(`[seed-data] fetch finance_snapshots failed: ${fetchError.message}`);
+  }
+
+  const currentData = (existing?.data ?? {}) as {
+    items?: Record<string, unknown>[];
+    total_savings?: number;
+    total_investments?: number;
+    total_assets?: number;
+    total_liabilities?: number;
+    net_worth?: number;
+  };
+
+  const items = [...(currentData.items ?? []), item];
+
+  // Recompute simple aggregate totals (approximate — backend will recompute on real use)
+  const totalInvestments = items
+    .filter((i) => i['category'] === 'Investments')
+    .reduce((sum, i) => sum + Number(i['value'] ?? 0), 0);
+  const totalAssets = items
+    .filter((i) => i['category'] === 'Assets')
+    .reduce((sum, i) => sum + Number(i['value'] ?? 0), 0);
+  const totalSavings = items
+    .filter((i) => i['category'] === 'Savings')
+    .reduce((sum, i) => sum + Number(i['value'] ?? 0), 0);
+  const totalLiabilities = items
+    .filter((i) => i['category'] === 'Liabilities')
+    .reduce((sum, i) => sum + Number(i['value'] ?? 0), 0);
+  const netWorth = totalAssets + totalSavings + totalInvestments - totalLiabilities;
+
+  const updatedData = {
+    ...currentData,
+    items,
+    total_investments: totalInvestments,
+    total_assets: totalAssets,
+    total_savings: totalSavings,
+    total_liabilities: totalLiabilities,
+    net_worth: netWorth,
+  };
+
+  const { error: upsertError } = await admin.from('finance_snapshots').upsert(
+    {
+      household_id: householdId,
+      date,
+      data: updatedData,
+      net_worth: netWorth,
+      total_assets: totalAssets,
+      total_liabilities: totalLiabilities,
+    },
+    { onConflict: 'household_id,date' },
+  );
+
+  if (upsertError) {
+    throw new Error(`[seed-data] upsert finance_snapshots failed: ${upsertError.message}`);
+  }
+}
+
+// ─── Public seed helpers ──────────────────────────────────────────────────────
+
+/**
+ * Seeds a fund-type FinanceItem (category: 'Investments') into `finance_snapshots`
+ * for the given household.
+ */
+export async function seedFund(householdId: string, data: FundSeedData): Promise<void> {
+  const item = {
+    id: `e2e-fund-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    category: 'Investments',
+    type: data.type ?? 'Fund',
+    name: data.name,
+    value: data.value,
+    owner: data.owner ?? 'e2e-test',
+    currency: data.currency ?? 'ILS',
+    inflow_priority: 100,
+    withdrawal_priority: 100,
+    details: data.details ?? {},
+  };
+
+  await upsertFinanceItem(householdId, item);
+}
+
+/**
+ * Seeds an asset-type FinanceItem (category: 'Assets') into `finance_snapshots`
+ * for the given household.
+ */
+export async function seedAsset(householdId: string, data: AssetSeedData): Promise<void> {
+  const item = {
+    id: `e2e-asset-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+    category: 'Assets',
+    type: data.type ?? 'Property',
+    name: data.name,
+    value: data.value,
+    owner: data.owner ?? 'e2e-test',
+    currency: data.currency ?? 'ILS',
+    inflow_priority: 100,
+    withdrawal_priority: 100,
+    details: data.details ?? {},
+  };
+
+  await upsertFinanceItem(householdId, item);
+}
+
+/**
+ * Seeds a trade row into `public.trade` for the given household.
+ * Uses a minimal IB Flex-compatible schema — only required fields are set.
+ */
+export async function seedTrade(householdId: string, data: TradeSeedData): Promise<void> {
+  const admin = getAdminClient();
+
+  const tradeRow = {
+    household_id: householdId,
+    // IB Flex required columns — use placeholder values for E2E tests
+    tradeID: Date.now(),
+    accountId: data.accountId ?? 'E2E_TEST_ACCOUNT',
+    acctAlias: 'E2E Test Account',
+    currency: data.currency ?? 'USD',
+    symbol: data.symbol,
+    description: `E2E seed trade for ${data.symbol}`,
+    conid: 0,
+    assetCategory: 'STK',
+    tradeDate: data.tradeDate ?? todayKey(),
+    settleDateTarget: data.tradeDate ?? todayKey(),
+    transactionType: 'ExchTrade',
+    exchange: 'NASDAQ',
+    quantity: data.quantity ?? 1,
+    tradePrice: data.price ?? 100,
+    tradeMoney: (data.quantity ?? 1) * (data.price ?? 100),
+    proceeds: -(data.quantity ?? 1) * (data.price ?? 100),
+    taxes: 0,
+    ibCommission: 0,
+    ibCommissionCurrency: data.currency ?? 'USD',
+    netCash: -(data.quantity ?? 1) * (data.price ?? 100),
+    closePrice: data.price ?? 100,
+    openCloseIndicator: 'O',
+    cost: (data.quantity ?? 1) * (data.price ?? 100),
+    fifoPnlRealized: 0,
+    mtmPnl: 0,
+    origTradePrice: 0,
+    buySell: data.side,
+  };
+
+  const { error } = await admin.from('trade').insert(tradeRow);
+
+  if (error) {
+    throw new Error(`[seed-data] insert trade failed: ${error.message}`);
+  }
+}
+
+/**
+ * Deletes all seeded data for a household.
+ *
+ * Clears:
+ *   - `finance_snapshots` rows for this household (funds + assets)
+ *   - `trade` rows for this household
+ *
+ * Does NOT delete the household itself or the user — that is handled by
+ * the `testUser` fixture's afterAll teardown.
+ */
+export async function cleanupHouseholdData(householdId: string): Promise<void> {
+  const admin = getAdminClient();
+
+  const results = await Promise.allSettled([
+    admin.from('finance_snapshots').delete().eq('household_id', householdId),
+    admin.from('trade').delete().eq('household_id', householdId),
+  ]);
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      console.warn(`[seed-data] cleanup warning: ${result.reason}`);
+    } else if (result.value.error) {
+      console.warn(`[seed-data] cleanup warning: ${result.value.error.message}`);
+    }
+  }
+}

--- a/apps/frontend/e2e/fixtures/test-user.ts
+++ b/apps/frontend/e2e/fixtures/test-user.ts
@@ -1,0 +1,165 @@
+/**
+ * e2e/fixtures/test-user.ts
+ *
+ * Unified test-user fixture for authenticated E2E tests that require a provisioned household.
+ *
+ * Pattern:
+ *   1. Creates a throwaway Supabase user via admin API.
+ *   2. Signs in using the auth-cookie technique (direct REST password grant → cookie inject).
+ *   3. Polls the `households` table until the auto-provision trigger fires (≤5s).
+ *   4. Returns { page, userId, email, householdId } for use in the test body.
+ *   5. Tears down the user (and cascaded household data) in afterAll.
+ *
+ * Usage:
+ *   import { test } from '../fixtures/test-user';
+ *
+ *   test('my flow test @auth', async ({ testUser: { page, householdId } }) => {
+ *     await page.goto('/current-finances');
+ *     // ... householdId available for seeding
+ *   });
+ */
+
+import { test as base, type Page } from '@playwright/test';
+import { createE2eUser, deleteE2eUser, makeE2eEmail, getAdminClient } from './admin';
+
+const PASSWORD = 'E2eTestPass!1';
+
+export interface TestUserFixture {
+  page: Page;
+  userId: string;
+  email: string;
+  householdId: string;
+}
+
+/**
+ * Obtains a Supabase session via direct REST password grant and injects
+ * the resulting session cookie into the Playwright browser context.
+ *
+ * This matches the approach in auth-cookie.ts — direct REST avoids the
+ * need for browser-side CDN imports and correctly sets the @supabase/ssr
+ * cookie format the Next.js middleware reads.
+ */
+async function injectAuthCookie(
+  page: Page,
+  supabaseUrl: string,
+  anonKey: string,
+  email: string,
+  password: string,
+): Promise<string> {
+  const resp = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: { apikey: anonKey, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`[test-user] password grant failed: ${resp.status} ${body}`);
+  }
+
+  const session = await resp.json() as {
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    expires_at?: number;
+    token_type: string;
+    user: unknown;
+  };
+
+  if (!session.expires_at) {
+    session.expires_at = Math.floor(Date.now() / 1000) + (session.expires_in ?? 3600);
+  }
+
+  // Build the cookie @supabase/ssr expects:
+  //   sb-{ref}-auth-token = "base64-" + base64url(JSON.stringify(session))
+  const ref = supabaseUrl.replace('https://', '').split('.')[0];
+  const cookieName = `sb-${ref}-auth-token`;
+  const cookieValue =
+    'base64-' +
+    Buffer.from(JSON.stringify(session), 'utf-8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+
+  await page.context().addCookies([
+    {
+      name: cookieName,
+      value: cookieValue,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: false,
+      secure: false,
+      sameSite: 'Lax',
+      expires: session.expires_at,
+    },
+  ]);
+
+  return session.access_token;
+}
+
+/**
+ * Polls `public.households` via the admin client until a row owned by
+ * `userId` appears (the auto-provision trigger fires asynchronously).
+ *
+ * Returns the householdId or throws after `timeoutMs` (default 5 000 ms).
+ */
+async function waitForHousehold(userId: string, timeoutMs = 5_000): Promise<string> {
+  const admin = getAdminClient();
+  const deadline = Date.now() + timeoutMs;
+  const POLL_INTERVAL = 300;
+
+  while (Date.now() < deadline) {
+    const { data, error } = await admin
+      .from('household_members')
+      .select('household_id')
+      .eq('user_id', userId)
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      // Log but don't throw — the row may not exist yet
+      console.warn(`[test-user] household poll error: ${error.message}`);
+    } else if (data?.household_id) {
+      return data.household_id as string;
+    }
+
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+  }
+
+  throw new Error(
+    `[test-user] household not provisioned for user ${userId} within ${timeoutMs}ms. ` +
+    `Check the auto-provision trigger (migration 20260502120000).`,
+  );
+}
+
+export const test = base.extend<{ testUser: TestUserFixture }>({
+  testUser: async ({ page }, use) => {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (!supabaseUrl || !anonKey) {
+      throw new Error(
+        '[test-user] NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set.',
+      );
+    }
+
+    const email = makeE2eEmail();
+    const { id: userId } = await createE2eUser(email, PASSWORD);
+
+    // Inject session cookie so Next.js SSR middleware sees the session
+    await injectAuthCookie(page, supabaseUrl, anonKey, email, PASSWORD);
+
+    // Wait for the auto-provision trigger to create the household
+    const householdId = await waitForHousehold(userId);
+
+    await use({ page, userId, email, householdId });
+
+    // Teardown — cascades household_members + household data via FK on delete cascade
+    await deleteE2eUser(userId).catch((err: Error) =>
+      console.warn(`[test-user] teardown warning: ${err.message}`),
+    );
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/apps/frontend/e2e/flows/current-finances.spec.ts
+++ b/apps/frontend/e2e/flows/current-finances.spec.ts
@@ -25,7 +25,7 @@
 import { test, expect } from '../../e2e/fixtures/auth';
 
 test.describe('P0 flow: /current-finances (authenticated)', () => {
-  test('/current-finances loads without 5xx', async ({ authenticatedUser: { page } }) => {
+  test('/current-finances loads without 5xx @flow', async ({ authenticatedUser: { page } }) => {
     const serverErrors: string[] = [];
     page.on('response', (resp) => {
       if (resp.status() >= 500) serverErrors.push(`${resp.status()} ${resp.url()}`);
@@ -37,7 +37,7 @@ test.describe('P0 flow: /current-finances (authenticated)', () => {
     expect(serverErrors).toHaveLength(0);
   });
 
-  test('/current-finances renders the finance editor heading', async ({
+  test('/current-finances renders the finance editor heading @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/current-finances');
@@ -47,7 +47,7 @@ test.describe('P0 flow: /current-finances (authenticated)', () => {
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  test('/current-finances renders at least one donut chart or chart container', async ({
+  test('/current-finances renders at least one donut chart or chart container @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/current-finances');
@@ -57,7 +57,7 @@ test.describe('P0 flow: /current-finances (authenticated)', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('/current-finances has no console errors on load', async ({
+  test('/current-finances has no console errors on load @flow', async ({
     authenticatedUser: { page },
   }) => {
     const consoleErrors: string[] = [];

--- a/apps/frontend/e2e/flows/plan.spec.ts
+++ b/apps/frontend/e2e/flows/plan.spec.ts
@@ -25,7 +25,7 @@
 import { test, expect } from '../../e2e/fixtures/auth';
 
 test.describe('P0 flow: /plan (authenticated)', () => {
-  test('/plan loads without 5xx', async ({ authenticatedUser: { page } }) => {
+  test('/plan loads without 5xx @flow', async ({ authenticatedUser: { page } }) => {
     const serverErrors: string[] = [];
     page.on('response', (resp) => {
       if (resp.status() >= 500) serverErrors.push(`${resp.status()} ${resp.url()}`);
@@ -37,7 +37,7 @@ test.describe('P0 flow: /plan (authenticated)', () => {
     expect(serverErrors).toHaveLength(0);
   });
 
-  test('/plan renders the plan editor or loading state (not blank)', async ({
+  test('/plan renders the plan editor or loading state (not blank) @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/plan');
@@ -47,7 +47,7 @@ test.describe('P0 flow: /plan (authenticated)', () => {
     await expect(page.locator('text=Application error')).toHaveCount(0);
   });
 
-  test('/plan renders projection chart or plan editor heading', async ({
+  test('/plan renders projection chart or plan editor heading @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/plan');
@@ -61,7 +61,7 @@ test.describe('P0 flow: /plan (authenticated)', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('/plan has no console errors on load', async ({ authenticatedUser: { page } }) => {
+  test('/plan has no console errors on load @flow', async ({ authenticatedUser: { page } }) => {
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());

--- a/apps/frontend/e2e/flows/root.spec.ts
+++ b/apps/frontend/e2e/flows/root.spec.ts
@@ -18,14 +18,14 @@
 import { test, expect } from '../../e2e/fixtures/auth';
 
 test.describe('P0 flow: / → /summary (authenticated)', () => {
-  test('authenticated user lands on /summary after visiting /', async ({
+  test('authenticated user lands on /summary after visiting / @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/');
     await expect(page).toHaveURL(/\/summary/, { timeout: 10_000 });
   });
 
-  test('/summary loads without 5xx errors', async ({ authenticatedUser: { page } }) => {
+  test('/summary loads without 5xx errors @flow', async ({ authenticatedUser: { page } }) => {
     const failedRequests: string[] = [];
     page.on('response', (resp) => {
       if (resp.status() >= 500) failedRequests.push(`${resp.status()} ${resp.url()}`);
@@ -37,7 +37,7 @@ test.describe('P0 flow: / → /summary (authenticated)', () => {
     expect(failedRequests).toHaveLength(0);
   });
 
-  test('/summary renders the income chart container', async ({
+  test('/summary renders the income chart container @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/summary');
@@ -49,7 +49,7 @@ test.describe('P0 flow: / → /summary (authenticated)', () => {
     });
   });
 
-  test('/summary has no console errors', async ({ authenticatedUser: { page } }) => {
+  test('/summary has no console errors @flow', async ({ authenticatedUser: { page } }) => {
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());

--- a/apps/frontend/e2e/flows/summary.spec.ts
+++ b/apps/frontend/e2e/flows/summary.spec.ts
@@ -25,7 +25,7 @@
 import { test, expect } from '../../e2e/fixtures/auth';
 
 test.describe('P0 flow: /summary (authenticated)', () => {
-  test('/summary loads without 5xx', async ({ authenticatedUser: { page } }) => {
+  test('/summary loads without 5xx @flow', async ({ authenticatedUser: { page } }) => {
     const serverErrors: string[] = [];
     page.on('response', (resp) => {
       if (resp.status() >= 500) serverErrors.push(`${resp.status()} ${resp.url()}`);
@@ -37,7 +37,7 @@ test.describe('P0 flow: /summary (authenticated)', () => {
     expect(serverErrors).toHaveLength(0);
   });
 
-  test('/summary renders chart area or loading state (not blank)', async ({
+  test('/summary renders chart area or loading state (not blank) @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/summary');
@@ -45,7 +45,7 @@ test.describe('P0 flow: /summary (authenticated)', () => {
     await expect(page.locator('text=Application error')).toHaveCount(0);
   });
 
-  test('/summary renders a canvas or chart container', async ({
+  test('/summary renders a canvas or chart container @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/summary');
@@ -57,7 +57,7 @@ test.describe('P0 flow: /summary (authenticated)', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('/summary has no console errors on load', async ({ authenticatedUser: { page } }) => {
+  test('/summary has no console errors on load @flow', async ({ authenticatedUser: { page } }) => {
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());
@@ -77,7 +77,7 @@ test.describe('P0 flow: /summary (authenticated)', () => {
     expect(critical).toHaveLength(0);
   });
 
-  test('/summary legend renders (or is absent when no data)', async ({
+  test('/summary legend renders (or is absent when no data) @flow', async ({
     authenticatedUser: { page },
   }) => {
     await page.goto('/summary');

--- a/apps/frontend/e2e/smoke/healthcheck.spec.ts
+++ b/apps/frontend/e2e/smoke/healthcheck.spec.ts
@@ -17,7 +17,7 @@ const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 test.describe('smoke / supabase health', () => {
   test.skip(!SUPABASE_URL, 'NEXT_PUBLIC_SUPABASE_URL is not set — skipping Supabase health check');
 
-  test('Supabase Auth health endpoint responds 200', async ({ request }) => {
+  test('Supabase Auth health endpoint responds 200 @smoke', async ({ request }) => {
     const healthUrl = `${SUPABASE_URL}/auth/v1/health`;
     const response = await request.get(healthUrl, { timeout: 10_000 });
 
@@ -28,7 +28,7 @@ test.describe('smoke / supabase health', () => {
     expect(body.length).toBeGreaterThan(0);
   });
 
-  test('Supabase REST endpoint responds (not 5xx)', async ({ request }) => {
+  test('Supabase REST endpoint responds (not 5xx) @smoke', async ({ request }) => {
     // A GET to the PostgREST root returns a schema description — no auth needed
     const restUrl = `${SUPABASE_URL}/rest/v1/`;
     const response = await request.get(restUrl, {
@@ -41,7 +41,7 @@ test.describe('smoke / supabase health', () => {
     expect(response.status(), `Supabase REST at ${restUrl} should not 5xx`).toBeLessThan(500);
   });
 
-  test('app /health/auth route responds (if exists)', async ({ page }) => {
+  test('app /health/auth route responds (if exists) @smoke', async ({ page }) => {
     // Hockney's health route from PR #89 — skip gracefully if not yet deployed
     const response = await page.goto('/health/auth', { waitUntil: 'commit' });
     const status = response?.status() ?? 0;

--- a/apps/frontend/e2e/smoke/holdings.spec.ts
+++ b/apps/frontend/e2e/smoke/holdings.spec.ts
@@ -9,7 +9,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('smoke / holdings (unauthenticated)', () => {
-  test('GET /holdings does not serve portfolio data without auth', async ({ page }) => {
+  test('GET /holdings does not serve portfolio data without auth @smoke', async ({ page }) => {
     const consoleErrors: string[] = [];
     const serverErrors: string[] = [];
 
@@ -52,7 +52,7 @@ test.describe('smoke / holdings (unauthenticated)', () => {
     expect(criticalErrors, `Console errors: ${criticalErrors.join('\n')}`).toHaveLength(0);
   });
 
-  test('GET /holdings renders some DOM (not blank page)', async ({ page }) => {
+  test('GET /holdings renders some DOM (not blank page) @smoke', async ({ page }) => {
     await page.goto('/holdings');
     await expect(page.locator('body')).not.toBeEmpty();
     const html = await page.content();

--- a/apps/frontend/e2e/smoke/home.spec.ts
+++ b/apps/frontend/e2e/smoke/home.spec.ts
@@ -11,7 +11,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('smoke / home', () => {
-  test('GET / resolves (redirect to /summary) without 5xx or console errors', async ({ page }) => {
+  test('GET / resolves (redirect to /summary) without 5xx or console errors @smoke', async ({ page }) => {
     const consoleErrors: string[] = [];
     const failedRequests: string[] = [];
 
@@ -46,7 +46,7 @@ test.describe('smoke / home', () => {
     await expect(page.locator('body')).not.toBeEmpty();
   });
 
-  test('page title is present', async ({ page }) => {
+  test('page title is present @smoke', async ({ page }) => {
     await page.goto('/');
     const title = await page.title();
     expect(title.length, 'Page should have a non-empty title').toBeGreaterThan(0);

--- a/apps/frontend/e2e/smoke/settings.spec.ts
+++ b/apps/frontend/e2e/smoke/settings.spec.ts
@@ -16,7 +16,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('smoke / settings (unauthenticated)', () => {
-  test('GET /settings does not serve protected UI without auth', async ({ page }) => {
+  test('GET /settings does not serve protected UI without auth @smoke', async ({ page }) => {
     const consoleErrors: string[] = [];
     const serverErrors: string[] = [];
 
@@ -62,7 +62,7 @@ test.describe('smoke / settings (unauthenticated)', () => {
     expect(criticalErrors, `Console errors on /settings: ${criticalErrors.join('\n')}`).toHaveLength(0);
   });
 
-  test('GET /settings page renders some DOM content (not blank)', async ({ page }) => {
+  test('GET /settings page renders some DOM content (not blank) @smoke', async ({ page }) => {
     await page.goto('/settings');
     const body = page.locator('body');
     await expect(body).not.toBeEmpty();

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,6 +13,9 @@
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:ui": "playwright test --ui",
+    "test:e2e:smoke": "playwright test --grep @smoke",
+    "test:e2e:flows": "playwright test --grep @flow",
+    "test:e2e:auth": "playwright test --grep @auth",
     "test:e2e:dev": "BASE_URL=https://trading-journal-avqth0l0g-cohenjos-projects.vercel.app playwright test",
     "test:e2e:cleanup": "tsx e2e/scripts/cleanup-stale-users.ts"
   },


### PR DESCRIPTION
## Summary

Extends the existing Playwright E2E scaffold per issue #144 and the strategy in `docs/testing/e2e-strategy.md`.

**Working as Redfoot (Tester)**

---

## Changes

### New fixtures

**`e2e/fixtures/test-user.ts`** — Unified user + household fixture:
- Creates throwaway Supabase user via admin API
- Injects auth cookie via direct REST password grant (same pattern as `auth-cookie.ts`)
- Polls `household_members` until auto-provision trigger fires (≤5s, migration `20260502120000`)
- Returns `{ page, userId, email, householdId }`
- Tears down user (cascades household data) in `afterAll`

**`e2e/fixtures/seed-data.ts`** — Per-test data seeding:
- `seedFund(householdId, data)` → upserts Investments FinanceItem to `finance_snapshots`
- `seedAsset(householdId, data)` → upserts Assets FinanceItem to `finance_snapshots`
- `seedTrade(householdId, data)` → inserts IB Flex-format row to `public.trade`
- `cleanupHouseholdData(householdId)` → deletes all seeded rows (non-destructive to user/household)

### Tagging

Added `@smoke`, `@flow` tags to all existing specs:
- `e2e/smoke/`: 9 tests tagged `@smoke` → `npm run test:e2e:smoke`
- `e2e/flows/`: 17 tests tagged `@flow` → `npm run test:e2e:flows`
- `@auth` and `@rls` reserved for upcoming `testUser` fixture tests (#146, #147, #148)

### npm scripts added

```json
"test:e2e:smoke": "playwright test --grep @smoke",
"test:e2e:flows": "playwright test --grep @flow",
"test:e2e:auth":  "playwright test --grep @auth"
```

### README updated

Fixtures table, tagging conventions, seeding usage examples, updated directory structure.

---

## Verification

```
npx playwright test --list --grep @smoke  → 27 tests (9 × 3 browsers) ✅
npx playwright test --list --grep @flow   → 51 tests (17 × 3 browsers) ✅
npx tsc --noEmit  → 0 errors in new files ✅
```

The new `testUser` and seed-data fixtures **cannot be run green without Supabase env** (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`). Smoke tests targeting public routes continue to work against any running Next.js server.

---

## Depends on / Blocks

- Hockney #145 — test-user provisioning env (needed to run `@auth` tier)
- #146, #147, #148 — flow tests that will use `testUser` fixture

Closes #144