### PR TITLE
ci(e2e): GitHub Actions workflow for Playwright (closes #149)

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -1,0 +1,249 @@
+# Playwright E2E Test Workflow
+#
+# Triggers:
+#   - pull_request (main): smoke + auth tiers — merge-blocking
+#   - schedule (nightly 03:00 UTC): full suite — smoke + auth + flows
+#   - workflow_dispatch: configurable suite and target URL
+#
+# Required GitHub Secrets (set in repo Settings → Secrets and variables → Actions):
+#   E2E_BASE_URL                   — Target app URL (Vercel preview or dev deployment)
+#   E2E_SUPABASE_URL               — Dev Supabase project URL (NEXT_PUBLIC_SUPABASE_URL)
+#   E2E_SUPABASE_ANON_KEY          — Dev Supabase anon/publishable key
+#   E2E_SUPABASE_SERVICE_ROLE_KEY  — Dev Supabase service-role key (fixture setup/teardown)
+#   E2E_TEST_USER_EMAIL            — Seed test user email (for pre-seeded auth flows)
+#   E2E_TEST_USER_PASSWORD         — Seed test user password
+
+name: Playwright E2E Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+  schedule:
+    # 03:00 UTC nightly
+    - cron: '0 3 * * *'
+
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Test suite to run'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - smoke
+          - auth
+          - flows
+          - all
+      base_url:
+        description: 'Override target base URL (leave blank to use E2E_BASE_URL secret)'
+        required: false
+        default: ''
+
+# Cancel in-progress runs on new PR pushes; let nightly/manual runs finish.
+concurrency:
+  group: e2e-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+defaults:
+  run:
+    working-directory: apps/frontend
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # e2e-smoke: PR merge-blocking job — smoke + auth tiers
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e-smoke:
+    name: E2E — Smoke + Auth (PR)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run smoke + auth tests
+        run: npx playwright test --grep "@smoke|@auth" --project=chromium
+        env:
+          CI: true
+          BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+
+      - name: Upload Playwright report (on failure)
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-pr-${{ github.event.pull_request.number }}
+          path: apps/frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces + screenshots (always)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-pr-${{ github.event.pull_request.number }}
+          path: apps/frontend/test-results/
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # e2e-full: Nightly full suite — smoke + auth + flows
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e-full:
+    name: E2E — Full Suite (Nightly)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Run full suite
+        run: npx playwright test --grep "@smoke|@auth|@flow" --project=chromium
+        env:
+          CI: true
+          BASE_URL: ${{ secrets.E2E_BASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+
+      - name: Upload Playwright report (on failure)
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-nightly-${{ github.run_id }}
+          path: apps/frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces + screenshots (always)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-nightly-${{ github.run_id }}
+          path: apps/frontend/test-results/
+          retention-days: 7
+
+      - name: Create GitHub issue on nightly failure
+        uses: actions/github-script@v7
+        if: failure()
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const today = new Date().toISOString().slice(0, 10);
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `🔴 E2E nightly suite failed — ${today}`,
+              body: [
+                '## Nightly E2E Suite Failure',
+                '',
+                `The nightly Playwright full suite failed on **${today}**.`,
+                '',
+                `**Run:** ${runUrl}`,
+                '',
+                '### Next steps',
+                '1. Check the Playwright report artifact in the run above.',
+                '2. Identify flaky tests vs genuine regressions.',
+                '3. Tag this issue with the affected tier (`@smoke`, `@auth`, `@flow`).',
+                '',
+                '/cc @cohenjo',
+              ].join('\n'),
+              labels: ['e2e-testing', 'bug'],
+            });
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # e2e-dispatch: Manual on-demand run with configurable suite + URL
+  # ──────────────────────────────────────────────────────────────────────────
+  e2e-dispatch:
+    name: E2E — Manual (${{ inputs.suite || 'all' }})
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (Chromium only)
+        run: npx playwright install --with-deps chromium
+
+      - name: Resolve grep pattern
+        id: grep
+        shell: bash
+        run: |
+          case "${{ inputs.suite }}" in
+            smoke)  echo "pattern=@smoke"           >> "$GITHUB_OUTPUT" ;;
+            auth)   echo "pattern=@auth"            >> "$GITHUB_OUTPUT" ;;
+            flows)  echo "pattern=@flow"            >> "$GITHUB_OUTPUT" ;;
+            *)      echo "pattern=@smoke|@auth|@flow" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Run ${{ inputs.suite || 'all' }} tests
+        run: npx playwright test --grep "${{ steps.grep.outputs.pattern }}" --project=chromium
+        env:
+          CI: true
+          BASE_URL: ${{ inputs.base_url || secrets.E2E_BASE_URL }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_TEST_USER_EMAIL: ${{ secrets.E2E_TEST_USER_EMAIL }}
+          E2E_TEST_USER_PASSWORD: ${{ secrets.E2E_TEST_USER_PASSWORD }}
+
+      - name: Upload Playwright report (on failure)
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report-dispatch-${{ github.run_id }}
+          path: apps/frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upload test traces + screenshots (always)
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results-dispatch-${{ github.run_id }}
+          path: apps/frontend/test-results/
+          retention-days: 7

--- a/.squad/agents/kujan/history.md
+++ b/.squad/agents/kujan/history.md
@@ -121,3 +121,30 @@
 - **Canonical env var:** `BASE_URL` (per Redfoot's decision). `PLAYWRIGHT_BASE_URL` kept as legacy alias in playwright.config.ts. The `baseURL` line updated to `process.env.BASE_URL || process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000'`.
 - **New script:** `test:e2e:dev` added to `apps/frontend/package.json` targeting the pinned dev deployment URL.
 - **Curl bypass test:** Returned 401 — expected until token is registered in Vercel dashboard.
+
+📌 **E2E GitHub Actions Workflow (2026-05-02 — issue #149, PR #153):**
+
+**Requested by:** Jony via Keaton (issue #149)
+
+**Delivered:** `.github/workflows/playwright-e2e.yml` — three-job Playwright E2E CI workflow.
+
+- **`e2e-smoke`** (PR trigger, merge-blocking): runs `@smoke|@auth` on chromium via `npx playwright test --grep "@smoke|@auth" --project=chromium`. `cancel-in-progress: true` for PR concurrency group.
+- **`e2e-full`** (nightly 03:00 UTC): runs `@smoke|@auth|@flow` full suite; auto-creates a GitHub issue on failure via `actions/github-script`.
+- **`e2e-dispatch`** (workflow_dispatch): configurable suite (smoke/auth/flows/all) + custom base_url input.
+- Artifacts: `playwright-report/` (14d, failure only), `test-results/` (7d, always).
+- Updated `apps/frontend/e2e/README.md` with CI section and secrets table.
+
+**Secrets required (Jony must configure in repo Settings):**
+| Secret | Maps to |
+|--------|---------|
+| `E2E_BASE_URL` | `BASE_URL` |
+| `E2E_SUPABASE_URL` | `NEXT_PUBLIC_SUPABASE_URL` |
+| `E2E_SUPABASE_ANON_KEY` | `NEXT_PUBLIC_SUPABASE_ANON_KEY` |
+| `E2E_SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SERVICE_ROLE_KEY` |
+| `E2E_TEST_USER_EMAIL` | `E2E_TEST_USER_EMAIL` |
+| `E2E_TEST_USER_PASSWORD` | `E2E_TEST_USER_PASSWORD` |
+
+**Key learnings:**
+- `git switch -c <new-branch> origin/main` may silently stay on a different branch if run inside a multi-worktree setup — always verify with `git branch --show-current` before committing.
+- `actions/github-script@v7` needs `permissions: issues: write` on the job, not just the workflow level.
+- Chromium-only CI (`--project=chromium`) cuts install time significantly vs all-browsers.

--- a/apps/frontend/e2e/README.md
+++ b/apps/frontend/e2e/README.md
@@ -242,25 +242,42 @@ Example: `e2e_1735000000000_a3f7@example.com`
 
 ---
 
-## CI Shape (future)
+## CI — GitHub Actions
 
-Planned: `.github/workflows/playwright-e2e.yml`
+Workflow: `.github/workflows/playwright-e2e.yml`
 
-Triggers:
-- `pull_request` — smoke + auth tiers only
-- `workflow_dispatch` — full suite including flows + rls
+### Triggers
 
-Requirements:
-- `BASE_URL` secret → deployed Vercel preview URL (or `VERCEL_PREVIEW_URL` computed by the workflow)
-- `NEXT_PUBLIC_SUPABASE_URL` secret → dev Supabase project URL
-- `NEXT_PUBLIC_SUPABASE_ANON_KEY` secret
-- `SUPABASE_SERVICE_ROLE_KEY` secret → service-role key for fixture setup/teardown
+| Event | Job | Suite |
+|-------|-----|-------|
+| `pull_request` → `main` | `e2e-smoke` | `@smoke` + `@auth` — **merge-blocking** |
+| `schedule` (03:00 UTC nightly) | `e2e-full` | `@smoke` + `@auth` + `@flow` |
+| `workflow_dispatch` | `e2e-dispatch` | Configurable (smoke / auth / flows / all) + custom URL input |
 
-Steps:
-1. Install deps (`npm ci`)
-2. Install Playwright browsers (`npx playwright install --with-deps chromium`)
-3. Run `npm run test:e2e` with appropriate `BASE_URL`
-4. Upload `playwright-report/` and `test-results/` as artifacts on failure
+Nightly failures automatically open a GitHub issue tagged `e2e-testing`.
+
+### Required GitHub Secrets
+
+Go to **repo → Settings → Secrets and variables → Actions → New repository secret** and add each of the following:
+
+| Secret name | Maps to env var | Description |
+|-------------|-----------------|-------------|
+| `E2E_BASE_URL` | `BASE_URL` | Target app URL — Vercel dev deployment or preview URL |
+| `E2E_SUPABASE_URL` | `NEXT_PUBLIC_SUPABASE_URL` | Dev Supabase project URL (e.g. `https://<ref>.supabase.co`) |
+| `E2E_SUPABASE_ANON_KEY` | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Dev Supabase anon/publishable key |
+| `E2E_SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SERVICE_ROLE_KEY` | Dev Supabase service-role key — **never expose to browser** |
+| `E2E_TEST_USER_EMAIL` | `E2E_TEST_USER_EMAIL` | Pre-seeded test user email (for deterministic auth flows) |
+| `E2E_TEST_USER_PASSWORD` | `E2E_TEST_USER_PASSWORD` | Pre-seeded test user password |
+
+> ⚠️ All secrets must use the **dev** Supabase project — never production.
+> `E2E_SUPABASE_SERVICE_ROLE_KEY` bypasses RLS; treat it as you would a root DB password.
+
+### Artifact retention
+
+| Artifact | Trigger | Retention |
+|----------|---------|-----------|
+| `playwright-report-*` | On failure only | 14 days |
+| `test-results-*` (traces + screenshots) | Always | 7 days |
 
 ---
 


### PR DESCRIPTION
Working as **Kujan** (DevOps/Platform) — closes #149

## Summary

Delivers the Playwright E2E GitHub Actions workflow per Keaton's E2E strategy (`docs/testing/e2e-strategy.md`) and issue #149 acceptance criteria.

## What's in this PR

- **`.github/workflows/playwright-e2e.yml`** — three-job workflow:

| Job | Trigger | Suite | Blocking? |
|-----|---------|-------|-----------|
| `e2e-smoke` | `pull_request` → `main` | `@smoke` + `@auth` | ✅ merge-blocking |
| `e2e-full` | `schedule` (03:00 UTC nightly) | `@smoke` + `@auth` + `@flow` | — |
| `e2e-dispatch` | `workflow_dispatch` | Configurable: smoke / auth / flows / all + custom URL | — |

- Concurrency cancels in-progress runs on PR re-push.
- Nightly failures auto-create a GitHub issue via `actions/github-script`.
- Artifacts: `playwright-report/` (14-day, failure only) + `test-results/` (7-day, always).
- Chromium only in CI for speed; `--with-deps` covers OS browser libs.
- `apps/frontend/e2e/README.md` updated with CI section + full secrets table.

## ⚠️ Required GitHub Secrets — MUST configure before workflow succeeds

Go to **repo → Settings → Secrets and variables → Actions → New repository secret**:

| Secret name | Maps to env var | Description |
|-------------|-----------------|-------------|
| `E2E_BASE_URL` | `BASE_URL` | Target app URL (Vercel dev deployment or preview URL) |
| `E2E_SUPABASE_URL` | `NEXT_PUBLIC_SUPABASE_URL` | Dev Supabase project URL |
| `E2E_SUPABASE_ANON_KEY` | `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Dev Supabase anon/publishable key |
| `E2E_SUPABASE_SERVICE_ROLE_KEY` | `SUPABASE_SERVICE_ROLE_KEY` | Dev Supabase service-role key (fixture setup/teardown) |
| `E2E_TEST_USER_EMAIL` | `E2E_TEST_USER_EMAIL` | Pre-seeded test user email |
| `E2E_TEST_USER_PASSWORD` | `E2E_TEST_USER_PASSWORD` | Pre-seeded test user password |

> **The first CI run will fail until these secrets are set — this is expected.**
> All secrets must point at the **dev** Supabase project, never production.
> `E2E_SUPABASE_SERVICE_ROLE_KEY` bypasses RLS; treat it like a root DB credential.

## Testing

- All 14 structural checks passed locally (triggers, concurrency, secrets, artifacts, github-script).
- `actionlint` unavailable locally; GitHub Actions will syntax-check on push.
- Once secrets are configured, re-run `e2e-smoke` to get a real pass/fail signal.

## References

- Closes #149
- Strategy: `docs/testing/e2e-strategy.md`
- Harness: PR #152 (Redfoot) — `test:e2e:smoke`, `test:e2e:flows`, `test:e2e:auth` scripts