### PR TITLE
fix(telemetry): stub /api/metrics/page-load — resolves smoke test 405 console errors

### DIFF
--- a/apps/frontend/src/app/api/metrics/page-load/route.ts
+++ b/apps/frontend/src/app/api/metrics/page-load/route.ts
@@ -1,0 +1,18 @@
+/**
+ * Stub handler for client-side page-load telemetry.
+ *
+ * PageLoadMetrics fires on every page (including the unauthenticated /login
+ * redirect) and POSTs timing data here. When a self-hosted Python backend is
+ * configured (NEXT_PUBLIC_API_URL), the request is rewritten there via
+ * next.config.ts. When no backend is configured (Vercel / preview deploys),
+ * this stub accepts the POST and drops the payload so the browser never sees
+ * a 4xx and no console errors are generated.
+ *
+ * This route is intentionally public (listed under /api/metrics/ in the
+ * middleware PUBLIC_PREFIXES) because the session is not yet available when
+ * the metrics fire after an unauthenticated redirect.
+ */
+export async function POST(): Promise<Response> {
+  // Accept the payload and return No Content — metrics are best-effort.
+  return new Response(null, { status: 204 });
+}

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -12,9 +12,10 @@ const PUBLIC_ROUTES: readonly string[] = [
 
 /** Prefixes whose entire subtree is public (no auth required). */
 const PUBLIC_PREFIXES: readonly string[] = [
-  '/auth/',     // auth callback, OAuth redirects
-  '/_next/',    // Next.js internals
-  '/api/auth/', // next-auth / Supabase auth API routes
+  '/auth/',         // auth callback, OAuth redirects
+  '/_next/',        // Next.js internals
+  '/api/auth/',     // next-auth / Supabase auth API routes
+  '/api/metrics/',  // telemetry — fire-and-forget, no session required
 ];
 
 function isPublicRoute(pathname: string): boolean {


### PR DESCRIPTION
## Root Cause

`PageLoadMetrics` (in the root layout) fires on every page load, including
the `/login` page that unauthenticated visitors are redirected to. It POSTs
page-timing data to `/api/metrics/page-load`.

In production builds without `NEXT_PUBLIC_API_URL` set, the `/api/*`
rewrites are disabled (`next.config.ts`). The middleware intercepted the
unauthenticated POST and issued a **307 Temporary Redirect** to `/login` —
which preserves the HTTP method. Next.js received `POST /login` (a page
route), responded with **405 Method Not Allowed**, and the browser logged a
console error that failed the `settings` and `holdings` smoke tests.

## Changes

| File | Change |
|------|--------|
| `src/middleware.ts` | Add `/api/metrics/` to `PUBLIC_PREFIXES` — telemetry POSTs are fire-and-forget and need no auth |
| `src/app/api/metrics/page-load/route.ts` | New stub handler — returns **204 No Content** when no backend is configured; `next.config.ts` rewrites the path to the real backend when `NEXT_PUBLIC_API_URL` is set |

## Testing

- Smoke tests `e2e/smoke/settings.spec.ts:19` and `e2e/smoke/holdings.spec.ts:12` should pass — the 405 no longer fires
- Auth-protected pages still redirect unauthenticated users to `/login`
- The metrics route is intentionally public (no session required)

Working as **Redfoot (Tester)** on the Squad.

Requested by: Jony