### PR TITLE
fix(current-finances): correct onConflict to composite (household_id, date)

### DIFF
--- a/apps/frontend/e2e/flows/current-finances.spec.ts
+++ b/apps/frontend/e2e/flows/current-finances.spec.ts
@@ -102,20 +102,21 @@ test.describe('P0 flow: /current-finances (authenticated)', () => {
 
 // ── Regression: fund-save with active household (Jony's bug) ─────────────────
 //
-// Regression guard for the bug where saving a fund on /current-finances failed
-// silently when the user had an active household (finance_snapshots write was
-// rejected by RLS because the JWT wasn't forwarded to FastAPI).
+// Regression guard for the bug where saving on /current-finances failed with
+// "Failed to save snapshot. Please try again." when the user had an active
+// household.  Root cause: `onConflict: 'date'` did not match the composite PK
+// (household_id, date) on finance_snapshots, causing a PostgREST 42P10 error.
 //
-// Status: skip until Fenster's auth-guard PR + Hockney's ensure_household RPC
-//         are deployed and the FastAPI backend accepts household-scoped JWTs.
-// Tracking: https://github.com/cohenjo/trading-journal/issues/155
+// The save path goes through the Next.js server action (saveFinanceSnapshot in
+// actions.ts), which calls Supabase directly — no FastAPI dependency.
+//
+// Unit-level regression is covered by actions.test.ts
+// ("regression: upsert uses onConflict household_id,date — not date alone").
+//
+// The E2E below covers the full browser → server action → Supabase path once
+// a deployed Supabase env is available.
 
 testWithUser.describe('regression: fund save with household @auth', () => {
-  // test.skip: depends on FastAPI backend accepting JWT + household scope.
-  // Unblock when:
-  //   1. Fenster's auth-guard PR is merged (JWT forwarded to FastAPI)
-  //   2. Hockney's ensure_household RPC ships (household row guaranteed present)
-  //   3. FastAPI /api/finances/save accepts and persists household-scoped writes
   testWithUser.skip(
     'adding a fund saves successfully when a household is present @auth',
     async ({ testUser: { page, householdId } }) => {
@@ -129,8 +130,8 @@ testWithUser.describe('regression: fund save with household @auth', () => {
       await page.goto('/current-finances');
       await page.waitForLoadState('domcontentloaded');
 
-      // Locate the "Add fund" / "Add item" button (exact selector TBD once Fenster's
-      // auth-guard PR ships and the component renders in an authenticated context)
+      // Locate the "Add fund" / "Add item" button (exact selector TBD once
+      // the component renders in a fully authenticated context)
       const addFundBtn = page
         .getByRole('button', { name: /add fund|add item|new fund/i })
         .first();

--- a/apps/frontend/src/app/current-finances/actions.test.ts
+++ b/apps/frontend/src/app/current-finances/actions.test.ts
@@ -127,6 +127,32 @@ describe('saveFinanceSnapshot', () => {
     expect((row.data as { items: unknown }).items).toEqual(VALID_ITEMS);
   });
 
+  /**
+   * Regression: onConflict must use the composite PK (household_id, date).
+   *
+   * The table `finance_snapshots` has no unique constraint on `date` alone —
+   * only a composite PK on (household_id, date).  Using `onConflict: 'date'`
+   * caused PostgREST to return a 42P10 error ("no unique or exclusion constraint
+   * matching the ON CONFLICT specification"), surfaced to Jony as
+   * "Failed to save snapshot. Please try again."
+   *
+   * @see apps/frontend/src/app/current-finances/actions.ts
+   */
+  it('regression: upsert uses onConflict household_id,date — not date alone', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+    mockMaybeSingleHousehold.mockResolvedValue({
+      data: { household_id: MOCK_HOUSEHOLD_ID },
+      error: null,
+    });
+    mockUpsert.mockResolvedValue({ error: null });
+
+    await saveFinanceSnapshot(VALID_ITEMS, VALID_METRICS);
+
+    expect(mockUpsert).toHaveBeenCalledOnce();
+    const [, options] = mockUpsert.mock.calls[0] as [unknown, { onConflict?: string }];
+    expect(options?.onConflict).toBe('household_id,date');
+  });
+
   it('returns an error when the DB upsert fails', async () => {
     mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
     mockMaybeSingleHousehold.mockResolvedValue({

--- a/apps/frontend/src/app/current-finances/actions.ts
+++ b/apps/frontend/src/app/current-finances/actions.ts
@@ -106,7 +106,7 @@ export async function saveFinanceSnapshot(
       total_assets: metrics.total_assets,
       total_liabilities: metrics.total_liabilities,
     },
-    { onConflict: 'date' },
+    { onConflict: 'household_id,date' },
   );
 
   if (upsertError) {


### PR DESCRIPTION
Working as Hockney (Backend Dev)

## Root cause

`finance_snapshots` has a composite primary key on `(household_id, date)` — there is **no** unique constraint on `date` alone.

Passing `onConflict: 'date'` to the Supabase upsert caused PostgREST to return a `42P10` error ("no unique or exclusion constraint matching the ON CONFLICT specification"), surfaced to Jony as **"Failed to save snapshot. Please try again."** after the household bootstrap merged.

## Fix

| File | Change |
|------|--------|
| `apps/frontend/src/app/current-finances/actions.ts` | `onConflict: 'date'` → `onConflict: 'household_id,date'` |
| `apps/frontend/src/app/current-finances/actions.test.ts` | New regression test asserting the correct `onConflict` option is forwarded to the Supabase upsert (all 9 tests pass) |
| `apps/frontend/e2e/flows/current-finances.spec.ts` | Corrected stale skip comment: save path is a Next.js server action calling Supabase directly, no FastAPI dependency |

## Audit of other upsert calls

Searched entire codebase for `.upsert(` + `onConflict`:

- `e2e/fixtures/seed-data.ts` — already correct: `onConflict: 'household_id,date'`
- No other `onConflict` usages found in application source

## Verification

- `npm run lint` — exit 0
- `vitest run actions.test.ts` — 9/9 tests pass
- `tsc --noEmit` — exit 0
