### PR TITLE
chore(db): align finance_snapshots PK migration filename with applied version

### DIFF
--- a/supabase/migrations/20260503103216_finance_snapshots_household_pk_fix.sql
+++ b/supabase/migrations/20260503103216_finance_snapshots_household_pk_fix.sql
@@ -27,9 +27,9 @@ DROP INDEX IF EXISTS public.finance_snapshots_user_date_key;
 DO $$
 BEGIN
   IF EXISTS (
-    SELECT 1 FROM information_schema.columns 
-    WHERE table_schema = 'public' 
-    AND table_name = 'finance_snapshots' 
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+    AND table_name = 'finance_snapshots'
     AND column_name = 'user_id'
   ) THEN
     UPDATE public.finance_snapshots fs
@@ -60,8 +60,8 @@ ALTER TABLE public.finance_snapshots
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint 
-    WHERE conname = 'finance_snapshots_pkey' 
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'finance_snapshots_pkey'
     AND conrelid = 'public.finance_snapshots'::regclass
   ) THEN
     ALTER TABLE public.finance_snapshots


### PR DESCRIPTION
## Why
Migration `20260501110927_finance_snapshots_household_pk_fix.sql` was authored locally days ago but never reached the production Supabase project. Today I discovered the production `finance_snapshots` table had **no primary key** and still carried the wave2 `user_id` column — explaining the persistent 'Failed to save snapshot' error after PR #168.

## What
Applied the missing migration directly via the Supabase MCP. Supabase recorded it as version `20260503103216`. This PR renames the local SQL file to match, so local and remote migration histories agree.

## Verification
- `finance_snapshots_pkey` now exists: `PRIMARY KEY (household_id, date)`
- API logs confirm the upsert with `on_conflict=household_id,date` now succeeds

## Follow-up
No CI workflow runs `supabase db push` on merge to main, so DDL can sit unapplied indefinitely. Will open a separate issue.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>