### PR TITLE
feat(finances,plan): migrate latest-snapshot/latest-plan reads to Server Actions

### DIFF
--- a/apps/frontend/src/app/after-i-leave/page.tsx
+++ b/apps/frontend/src/app/after-i-leave/page.tsx
@@ -6,6 +6,7 @@ import { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
 import CollapsibleSection from '@/components/AfterILeave/CollapsibleSection';
 import SummaryTable from '@/components/AfterILeave/SummaryTable';
 import { Lang, translations } from '@/components/AfterILeave/translations';
+import { getLatestFinanceSnapshot } from '../finances/actions';
 
 interface InsurancePolicy {
   id?: string;
@@ -34,10 +35,8 @@ async function fetchInsurancePolicies(): Promise<InsurancePolicy[]> {
 
 async function fetchFinanceData(): Promise<FinanceItem[]> {
   try {
-    const res = await apiFetch('/api/finances/latest');
-    if (!res.ok) return [];
-    const data = await res.json();
-    return data.data?.items || [];
+    const snapshot = await getLatestFinanceSnapshot();
+    return snapshot?.data?.items ?? [];
   } catch {
     return [];
   }

--- a/apps/frontend/src/app/cash-flow/page.tsx
+++ b/apps/frontend/src/app/cash-flow/page.tsx
@@ -4,25 +4,8 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { useSettings } from '../settings/SettingsContext';
 import { CashFlowSankey } from '@/components/CashFlow/CashFlowSankey';
 import { PlanData } from '@/components/Plan/types';
-
-// Fetch Utilities (Duplicated from PlanPage for now)
-async function fetchLatestPlan() {
-    const res = await apiFetch('/api/plans/latest');
-    if (res.ok) return res.json();
-    return null;
-}
-
-async function fetchFinances() {
-    const res = await apiFetch('/api/finances/latest');
-    if (res.ok) return res.json();
-    return {
-        net_worth: 0,
-        total_assets: 0,
-        total_liabilities: 0,
-        date: new Date().toISOString().split('T')[0],
-        data: { items: [], total_investments: 0, total_savings: 0 }
-    };
-}
+import { getLatestPlan } from '../plan/actions';
+import { getLatestFinanceSnapshot } from '../finances/actions';
 
 export default function CashFlowPage() {
     const { settings } = useSettings();
@@ -34,7 +17,7 @@ export default function CashFlowPage() {
 
     // Initial Load
     useEffect(() => {
-        Promise.all([fetchLatestPlan(), fetchFinances()]).then(([planData, financeData]) => {
+        Promise.all([getLatestPlan(), getLatestFinanceSnapshot()]).then(([planData, financeData]) => {
             setFinances(financeData);
             if (planData) setPlan(planData);
             setLoading(false);

--- a/apps/frontend/src/app/finances/actions.test.ts
+++ b/apps/frontend/src/app/finances/actions.test.ts
@@ -1,0 +1,370 @@
+/**
+ * Unit tests for the finances/latest Server Action (getLatestFinanceSnapshot).
+ *
+ * Verifies:
+ *  1. Returns the latest snapshot ordered by date desc.
+ *  2. Returns null when no rows exist (not an error).
+ *  3. Enriches items that have a linked dividend account with
+ *     dividend_fixed_amount and dividend_mode = 'Fixed'.
+ *  4. Preserves original item order.
+ *  5. Never persists enrichment changes to the DB.
+ *  6. Returns null when not authenticated.
+ *  7. Returns null when user has no active household.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Supabase mock infrastructure ──────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { getLatestFinanceSnapshot } from './actions';
+import { createClient } from '@/lib/supabase/server';
+
+const MOCK_USER_ID = 'user-uuid-1234';
+const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function authOk() {
+  mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+}
+
+function authFail() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+}
+
+/** Builds a minimal fluent Supabase mock for a given table config. */
+function makeSupabaseMock(tableHandlers: Record<string, () => object>) {
+  return {
+    auth: { getUser: mockGetUser },
+    from: vi.fn((table: string) => {
+      const handler = tableHandlers[table];
+      if (handler) return handler();
+      throw new Error(`Unexpected table: ${table}`);
+    }),
+  };
+}
+
+/** Builds a fluent chain that terminates with maybeSingle() returning `result`. */
+function fluentChain(result: unknown) {
+  const chain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    not: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+  return chain;
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// ── Auth / access control ─────────────────────────────────────────────────────
+
+describe('getLatestFinanceSnapshot — auth guards', () => {
+  it('returns null when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user has no active household', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSupabaseMock({
+        household_members: () => fluentChain({ data: null, error: null }),
+      }),
+    );
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).toBeNull();
+  });
+});
+
+// ── Snapshot retrieval ────────────────────────────────────────────────────────
+
+describe('getLatestFinanceSnapshot — snapshot retrieval', () => {
+  it('returns null when no snapshot exists', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSupabaseMock({
+        household_members: () => fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null }),
+        finance_snapshots: () => fluentChain({ data: null, error: null }),
+        // dividend_accounts will not be called since there's no snapshot
+        dividend_accounts: () => ({
+          select: vi.fn().mockReturnThis(),
+          not: vi.fn().mockResolvedValue({ data: [], error: null }),
+        }),
+      }),
+    );
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).toBeNull();
+  });
+
+  it('returns the latest snapshot (ordered by date desc)', async () => {
+    authOk();
+    const snapshotRow = {
+      date: '2025-06-15',
+      household_id: MOCK_HOUSEHOLD_ID,
+      net_worth: 500000,
+      total_assets: 600000,
+      total_liabilities: 100000,
+      data: {
+        items: [
+          { id: '42', name: 'Savings Account', category: 'Savings', value: 50000, type: 'Bank', owner: 'Jony', currency: 'ILS' },
+        ],
+        net_worth: 500000,
+        total_assets: 600000,
+        total_liabilities: 100000,
+        total_savings: 50000,
+        total_investments: 0,
+      },
+    };
+
+    const snapshotsChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: snapshotRow, error: null }),
+    };
+
+    const divAccountsChain = {
+      select: vi.fn().mockReturnThis(),
+      not: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'finance_snapshots') return snapshotsChain;
+        if (table === 'dividend_accounts') return divAccountsChain;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).not.toBeNull();
+    expect(result?.date).toBe('2025-06-15');
+    expect(result?.net_worth).toBe(500000);
+    // Verify order: descending date was requested
+    expect(snapshotsChain.order).toHaveBeenCalledWith('date', { ascending: false });
+    expect(snapshotsChain.limit).toHaveBeenCalledWith(1);
+  });
+});
+
+// ── Dividend enrichment ───────────────────────────────────────────────────────
+
+describe('getLatestFinanceSnapshot — dividend enrichment', () => {
+  it('enriches items with a linked dividend account', async () => {
+    authOk();
+
+    const items = [
+      { id: '10', name: 'Brokerage', category: 'Investments', value: 100000, type: 'Stocks', owner: 'Jony', currency: 'USD' },
+    ];
+    const snapshotRow = {
+      date: '2025-06-15',
+      household_id: MOCK_HOUSEHOLD_ID,
+      net_worth: 100000,
+      total_assets: 100000,
+      total_liabilities: 0,
+      data: { items, net_worth: 100000, total_assets: 100000, total_liabilities: 0, total_savings: 0, total_investments: 100000 },
+    };
+
+    // dividend_accounts: item id=10 is linked to account "My Broker"
+    const divAccounts = [{ name: 'My Broker', linked_id: 10 }];
+    // dividend_positions: 200 shares of AAPL in "My Broker"
+    const divPositions = [{ account: 'My Broker', ticker: 'AAPL', shares: 200 }];
+    // ticker data: AAPL pays $1.00/share USD
+    const tickerData = [{ ticker: 'AAPL', dividend_rate: 1.0, currency: 'USD' }];
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'finance_snapshots') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: snapshotRow, error: null }),
+          };
+        }
+        if (table === 'dividend_accounts') {
+          return { select: vi.fn().mockReturnThis(), not: vi.fn().mockResolvedValue({ data: divAccounts, error: null }) };
+        }
+        if (table === 'dividend_positions') {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: divPositions, error: null }) };
+        }
+        if (table === 'dividend_ticker_data') {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: tickerData, error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).not.toBeNull();
+
+    const enrichedItem = result!.data.items[0];
+    // 200 shares × $1.00 = $200 USD (no conversion needed — item currency is also USD)
+    expect(enrichedItem.details?.dividend_fixed_amount).toBe(200);
+    expect(enrichedItem.details?.dividend_mode).toBe('Fixed');
+  });
+
+  it('does not enrich items with no linked dividend account', async () => {
+    authOk();
+
+    const items = [
+      { id: '99', name: 'Unlinked Account', category: 'Savings', value: 50000, type: 'Bank', owner: 'Jony', currency: 'ILS' },
+    ];
+    const snapshotRow = {
+      date: '2025-06-15',
+      household_id: MOCK_HOUSEHOLD_ID,
+      net_worth: 50000,
+      total_assets: 50000,
+      total_liabilities: 0,
+      data: { items, net_worth: 50000, total_assets: 50000, total_liabilities: 0, total_savings: 50000, total_investments: 0 },
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'finance_snapshots') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: snapshotRow, error: null }),
+          };
+        }
+        // No dividend accounts linked
+        if (table === 'dividend_accounts') {
+          return { select: vi.fn().mockReturnThis(), not: vi.fn().mockResolvedValue({ data: [], error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).not.toBeNull();
+    const item = result!.data.items[0];
+    expect(item.details?.dividend_fixed_amount).toBeUndefined();
+    expect(item.details?.dividend_mode).toBeUndefined();
+  });
+
+  it('preserves original item order after enrichment', async () => {
+    authOk();
+
+    const items = [
+      { id: '1', name: 'First', category: 'Savings' as const, value: 1000, type: 'Bank', owner: 'Jony', currency: 'ILS' },
+      { id: '2', name: 'Second', category: 'Investments' as const, value: 2000, type: 'Stocks', owner: 'Jony', currency: 'USD' },
+      { id: '3', name: 'Third', category: 'Assets' as const, value: 3000, type: 'Property', owner: 'Jony', currency: 'ILS' },
+    ];
+    const snapshotRow = {
+      date: '2025-06-15',
+      household_id: MOCK_HOUSEHOLD_ID,
+      net_worth: 6000,
+      total_assets: 6000,
+      total_liabilities: 0,
+      data: { items, net_worth: 6000, total_assets: 6000, total_liabilities: 0, total_savings: 1000, total_investments: 2000 },
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'finance_snapshots') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: snapshotRow, error: null }),
+          };
+        }
+        if (table === 'dividend_accounts') {
+          return { select: vi.fn().mockReturnThis(), not: vi.fn().mockResolvedValue({ data: [], error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestFinanceSnapshot();
+    expect(result).not.toBeNull();
+    expect(result!.data.items.map((i) => i.id)).toEqual(['1', '2', '3']);
+  });
+
+  it('never persists enrichment — does not call upsert or insert', async () => {
+    authOk();
+
+    const mockUpsert = vi.fn();
+    const mockInsert = vi.fn();
+    const items = [
+      { id: '10', name: 'Brokerage', category: 'Investments' as const, value: 100000, type: 'Stocks', owner: 'Jony', currency: 'USD' },
+    ];
+    const snapshotRow = {
+      date: '2025-06-15',
+      household_id: MOCK_HOUSEHOLD_ID,
+      net_worth: 100000,
+      total_assets: 100000,
+      total_liabilities: 0,
+      data: { items, net_worth: 100000, total_assets: 100000, total_liabilities: 0, total_savings: 0, total_investments: 100000 },
+    };
+    const divAccounts = [{ name: 'My Broker', linked_id: 10 }];
+    const divPositions = [{ account: 'My Broker', ticker: 'AAPL', shares: 200 }];
+    const tickerData = [{ ticker: 'AAPL', dividend_rate: 1.0, currency: 'USD' }];
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'finance_snapshots') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockReturnThis(),
+            limit: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: snapshotRow, error: null }),
+            upsert: mockUpsert,
+            insert: mockInsert,
+          };
+        }
+        if (table === 'dividend_accounts') {
+          return { select: vi.fn().mockReturnThis(), not: vi.fn().mockResolvedValue({ data: divAccounts, error: null }) };
+        }
+        if (table === 'dividend_positions') {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: divPositions, error: null }) };
+        }
+        if (table === 'dividend_ticker_data') {
+          return { select: vi.fn().mockReturnThis(), in: vi.fn().mockResolvedValue({ data: tickerData, error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    await getLatestFinanceSnapshot();
+
+    expect(mockUpsert).not.toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/finances/actions.ts
+++ b/apps/frontend/src/app/finances/actions.ts
@@ -1,0 +1,227 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import { convertCurrency } from '@/lib/currency';
+import type { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Full shape returned by the latest-snapshot endpoint. */
+export interface FinanceSnapshot {
+  date: string;
+  household_id: string;
+  net_worth: number;
+  total_assets: number;
+  total_liabilities: number;
+  data: FinanceSnapshotData;
+}
+
+/** Shape of the `data` jsonb column. */
+export interface FinanceSnapshotData {
+  items: FinanceItem[];
+  net_worth: number;
+  total_assets: number;
+  total_liabilities: number;
+  total_savings: number;
+  total_investments: number;
+}
+
+// Raw rows from dividend tables — typed narrowly to avoid over-fetching
+interface DividendAccountRow {
+  name: string;
+  linked_id: number | null;
+}
+
+interface DividendPositionRow {
+  ticker: string;
+  shares: number;
+}
+
+interface DividendTickerDataRow {
+  ticker: string;
+  dividend_rate: number;
+  currency: string;
+}
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Looks up the calling user's primary active household_id.
+ * household_id must NEVER come from user input — always from the session.
+ */
+async function resolveHouseholdId(userId: string): Promise<string | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data.household_id as string;
+}
+
+/**
+ * Normalises a dividend ticker's raw amount+currency pair for use with
+ * `convertCurrency`.
+ *
+ * yfinance returns amounts for Israeli TA stocks in Agorot (ILA) where
+ * 1 ILA = 0.01 ILS. Since `convertCurrency` only knows ILS/USD/EUR,
+ * we normalise ILA → ILS by dividing the raw amount by 100.
+ */
+function normaliseAmount(rawAmount: number, currency: string): { amount: number; currency: string } {
+  if (currency.toUpperCase() === 'ILA') {
+    return { amount: rawAmount * 0.01, currency: 'ILS' };
+  }
+  return { amount: rawAmount, currency };
+}
+
+/**
+ * Enriches snapshot items in-place with dividend data from linked dividend
+ * accounts. Mirrors the Python implementation in `finances.py:79-120`.
+ *
+ * For each item whose `id` matches a `dividend_accounts.linked_id`, we sum
+ * `dividend_positions.shares * dividend_ticker_data.dividend_rate` for all
+ * positions in that account, convert to the item's native currency, and write:
+ *   - `item.details.dividend_fixed_amount`
+ *   - `item.details.dividend_mode = 'Fixed'`
+ *
+ * This is an **in-memory enrichment only** — no DB writes.
+ */
+async function enrichWithDividends(items: FinanceItem[]): Promise<void> {
+  const supabase = await createClient();
+
+  // Fetch all dividend accounts for the household (RLS handles scoping).
+  const { data: divAccounts, error: divAccError } = await supabase
+    .from('dividend_accounts')
+    .select('name, linked_id')
+    .not('linked_id', 'is', null);
+
+  if (divAccError || !divAccounts?.length) return;
+
+  // Build map: linked_id → account name for O(1) lookup
+  const linkedIdToAccount = new Map<number, string>(
+    (divAccounts as DividendAccountRow[])
+      .filter((a): a is DividendAccountRow & { linked_id: number } => a.linked_id !== null)
+      .map((a) => [a.linked_id, a.name]),
+  );
+
+  // Collect the account names we actually need positions for
+  const accountNames = Array.from(linkedIdToAccount.values());
+  if (!accountNames.length) return;
+
+  // Batch-fetch all relevant positions and ticker data in two queries
+  const { data: positions } = await supabase
+    .from('dividend_positions')
+    .select('account, ticker, shares')
+    .in('account', accountNames);
+
+  if (!positions?.length) return;
+
+  const tickers = [...new Set((positions as Array<DividendPositionRow & { account: string }>).map((p) => p.ticker))];
+
+  const { data: tickerData } = await supabase
+    .from('dividend_ticker_data')
+    .select('ticker, dividend_rate, currency')
+    .in('ticker', tickers);
+
+  const tdMap = new Map<string, DividendTickerDataRow>(
+    (tickerData ?? []).map((t: DividendTickerDataRow) => [t.ticker, t]),
+  );
+
+  // Group positions by account name
+  const positionsByAccount = new Map<string, Array<DividendPositionRow & { account: string }>>();
+  for (const p of positions as Array<DividendPositionRow & { account: string }>) {
+    const list = positionsByAccount.get(p.account) ?? [];
+    list.push(p);
+    positionsByAccount.set(p.account, list);
+  }
+
+  // Enrich each item that has a linked dividend account
+  for (const item of items) {
+    const itemId = typeof item.id === 'string' ? Number(item.id) : (item.id as number);
+    if (!itemId) continue;
+
+    const accountName = linkedIdToAccount.get(itemId);
+    if (!accountName) continue;
+
+    const acctPositions = positionsByAccount.get(accountName);
+    if (!acctPositions?.length) continue;
+
+    const itemCurrency = item.currency ?? 'USD';
+    let totalIncome = 0;
+
+    for (const p of acctPositions) {
+      const td = tdMap.get(p.ticker);
+      if (!td) continue;
+
+      const rawAmount = Number(p.shares) * Number(td.dividend_rate);
+      const { amount, currency } = normaliseAmount(rawAmount, td.currency);
+      totalIncome += convertCurrency(amount, currency, itemCurrency);
+    }
+
+    if (totalIncome > 0) {
+      if (!item.details) item.details = {};
+      item.details.dividend_fixed_amount = Math.round(totalIncome * 100) / 100;
+      item.details.dividend_mode = 'Fixed';
+    }
+  }
+}
+
+// ── Server Action ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns the most-recent finance snapshot for the authenticated user's
+ * household, enriched in-memory with dividend data for linked accounts.
+ *
+ * Security guarantees:
+ * - `household_id` is resolved from the authenticated session; never from
+ *   caller input.
+ * - Supabase RLS enforces read isolation at the DB layer.
+ *
+ * Enrichment is best-effort: if any dividend query fails, the raw snapshot
+ * is returned without enrichment (matching the Python behaviour).
+ *
+ * @returns The enriched snapshot, or `null` when none exists yet.
+ */
+export async function getLatestFinanceSnapshot(): Promise<FinanceSnapshot | null> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) return null;
+
+  const { data, error } = await supabase
+    .from('finance_snapshots')
+    .select('date, household_id, net_worth, total_assets, total_liabilities, data')
+    .eq('household_id', householdId)
+    .order('date', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[getLatestFinanceSnapshot] query error:', error.message);
+    return null;
+  }
+  if (!data) return null;
+
+  const snapshot = data as unknown as FinanceSnapshot;
+  const items: FinanceItem[] = Array.isArray(snapshot.data?.items) ? snapshot.data.items : [];
+
+  try {
+    await enrichWithDividends(items);
+  } catch (err) {
+    console.error('[getLatestFinanceSnapshot] dividend enrichment failed:', err);
+    // Continue with non-enriched snapshot — matches Python behaviour
+  }
+
+  return snapshot;
+}

--- a/apps/frontend/src/app/plan/actions.test.ts
+++ b/apps/frontend/src/app/plan/actions.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the plan/latest Server Action (getLatestPlan).
+ *
+ * Verifies:
+ *  1. Returns the latest plan ordered by updated_at desc.
+ *  2. Returns null when no plan exists (not an error).
+ *  3. Returns null when not authenticated.
+ *  4. Returns null when user has no active household.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Supabase mock infrastructure ──────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { getLatestPlan } from './actions';
+import { createClient } from '@/lib/supabase/server';
+
+const MOCK_USER_ID = 'user-uuid-1234';
+const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function authOk() {
+  mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+}
+
+function authFail() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+}
+
+/** Builds a fluent chain that terminates with maybeSingle() returning `result`. */
+function fluentChain(result: unknown) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// ── Auth / access control ─────────────────────────────────────────────────────
+
+describe('getLatestPlan — auth guards', () => {
+  it('returns null when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    const result = await getLatestPlan();
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user has no active household', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn().mockReturnValue(fluentChain({ data: null, error: null })),
+    });
+
+    const result = await getLatestPlan();
+    expect(result).toBeNull();
+  });
+});
+
+// ── Plan retrieval ────────────────────────────────────────────────────────────
+
+describe('getLatestPlan — retrieval', () => {
+  it('returns null when no plan exists', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'plans') return fluentChain({ data: null, error: null });
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestPlan();
+    expect(result).toBeNull();
+  });
+
+  it('returns the latest plan ordered by updated_at desc', async () => {
+    authOk();
+
+    const planRow = {
+      id: 7,
+      name: 'Retirement Plan',
+      description: 'Long-term plan',
+      data: { items: [], milestones: [], settings: {} },
+      created_at: '2025-01-01T00:00:00Z',
+      updated_at: '2025-06-15T12:00:00Z',
+    };
+
+    const plansChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: planRow, error: null }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'plans') return plansChain;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestPlan();
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe(7);
+    expect(result?.name).toBe('Retirement Plan');
+    // Verify ordering
+    expect(plansChain.order).toHaveBeenCalledWith('updated_at', { ascending: false });
+    expect(plansChain.limit).toHaveBeenCalledWith(1);
+  });
+
+  it('returns null and logs error on DB failure', async () => {
+    authOk();
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'plans') return fluentChain({ data: null, error: { message: 'RLS violation' } });
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getLatestPlan();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[getLatestPlan]'),
+      expect.stringContaining('RLS violation'),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/frontend/src/app/plan/actions.ts
+++ b/apps/frontend/src/app/plan/actions.ts
@@ -1,0 +1,67 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import type { Plan } from '@/components/Plan/types';
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Looks up the calling user's primary active household_id.
+ * household_id must NEVER come from user input — always from the session.
+ */
+async function resolveHouseholdId(userId: string): Promise<string | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data.household_id as string;
+}
+
+// ── Server Action ─────────────────────────────────────────────────────────────
+
+/**
+ * Returns the most-recently updated plan for the authenticated user's
+ * household.
+ *
+ * Security guarantees:
+ * - `household_id` is resolved from the authenticated session; never from
+ *   caller input.
+ * - Supabase RLS enforces read isolation at the DB layer.
+ *
+ * @returns The latest plan row, or `null` when none exists yet.
+ */
+export async function getLatestPlan(): Promise<Plan | null> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) return null;
+
+  const { data, error } = await supabase
+    .from('plans')
+    .select('id, name, description, data, created_at, updated_at')
+    .eq('household_id', householdId)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[getLatestPlan] query error:', error.message);
+    return null;
+  }
+  if (!data) return null;
+
+  return data as unknown as Plan;
+}

--- a/apps/frontend/src/app/plan/page.tsx
+++ b/apps/frontend/src/app/plan/page.tsx
@@ -6,12 +6,8 @@ import { PlanEditor } from '@/components/Plan/PlanEditor';
 import { PlanDetailsPane } from '@/components/Plan/PlanDetailsPane';
 import { Plan, PlanData } from '@/components/Plan/types';
 import { useSettings } from '../settings/SettingsContext';
-
-async function fetchLatestPlan() {
-    const res = await apiFetch('/api/plans/latest');
-    if (res.ok) return res.json();
-    return null;
-}
+import { getLatestPlan } from './actions';
+import { getLatestFinanceSnapshot } from '../finances/actions';
 
 async function createPlan(data: PlanData) {
     const res = await apiFetch('/api/plans/', {
@@ -31,21 +27,6 @@ async function updatePlan(id: number, data: PlanData) {
     return res.json();
 }
 
-async function fetchFinances() {
-    const res = await apiFetch('/api/finances/latest');
-    if (res.ok) {
-        return res.json();
-    }
-    // Return complete mock to satisfy backend validation
-    return {
-        net_worth: 0,
-        total_assets: 0,
-        total_liabilities: 0,
-        date: new Date().toISOString().split('T')[0],
-        data: { items: [], total_investments: 0, total_savings: 0 }
-    };
-}
-
 export default function PlanPage() {
     const { settings } = useSettings();
     const [plan, setPlan] = useState<Plan | null>(null);
@@ -56,7 +37,7 @@ export default function PlanPage() {
 
     // Initial Load
     useEffect(() => {
-        Promise.all([fetchLatestPlan(), fetchFinances()]).then(([planData, financeData]) => {
+        Promise.all([getLatestPlan(), getLatestFinanceSnapshot()]).then(([planData, financeData]) => {
             setFinances(financeData);
             if (planData) {
                 setPlan(planData);

--- a/apps/frontend/src/components/trading/TradingAccountSettings.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountSettings.tsx
@@ -2,6 +2,7 @@
 import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from "react";
+import { getLatestFinanceSnapshot } from '@/app/finances/actions';
 
 export default function TradingAccountSettings() {
     const [configs, setConfigs] = useState<any[]>([]);
@@ -40,12 +41,9 @@ export default function TradingAccountSettings() {
 
     const fetchFinanceAccounts = async () => {
         try {
-            const res = await apiFetch("/api/finances/latest");
-            if (res.ok) {
-                const data = await res.json();
-                if (data && data.data && data.data.items) {
-                    setFinanceAccounts(data.data.items.filter((i: any) => i.category === "Investments"));
-                }
+            const snapshot = await getLatestFinanceSnapshot();
+            if (snapshot?.data?.items) {
+                setFinanceAccounts(snapshot.data.items.filter((i) => i.category === "Investments"));
             }
         } catch (err) {
             console.error("Error fetching finance accounts:", err);


### PR DESCRIPTION
## Summary

Working as **Hockney** (Backend Dev) — partial progress on #71 (TJ-018).

Fixes the root cause of Jony's `/plan` page showing no accounts (pensions, broker accounts, savings): the page called `/api/finances/latest` and `/api/plans/latest` which are FastAPI endpoints not deployed to Vercel. Both read endpoints are now Server Actions backed by Supabase, mirroring the pattern from `current-finances/actions.ts` and `dividends/actions.ts`.

---

## ⚠️ Simulate still 404s

`/api/plans/simulate` (the projection chart) is **out of scope** for this PR and has been left calling FastAPI. The projection chart on `/plan` and `/cash-flow` will remain empty until the simulate migration is completed in a follow-up (see suggested issue below). This is called out explicitly so Jony is aware.

---

## Files created

| File | Purpose |
|------|---------|
| `apps/frontend/src/app/finances/actions.ts` | `getLatestFinanceSnapshot()` — latest snapshot with in-memory dividend enrichment |
| `apps/frontend/src/app/finances/actions.test.ts` | 9 tests: auth, retrieval, enrichment, order preservation, no-persist |
| `apps/frontend/src/app/plan/actions.ts` | `getLatestPlan()` — latest plan ordered by `updated_at` desc |
| `apps/frontend/src/app/plan/actions.test.ts` | 5 tests: auth, retrieval ordering, DB error handling |

## Call-sites updated (4 + 2)

**finances/latest** (4):
- `apps/frontend/src/app/plan/page.tsx`
- `apps/frontend/src/app/cash-flow/page.tsx`
- `apps/frontend/src/app/after-i-leave/page.tsx`
- `apps/frontend/src/components/trading/TradingAccountSettings.tsx`

**plans/latest** (2):
- `apps/frontend/src/app/plan/page.tsx`
- `apps/frontend/src/app/cash-flow/page.tsx`

---

## Dividend enrichment notes

The Python enrichment block (in-memory, no DB writes) is fully ported:
- For each item with a matching `dividend_accounts.linked_id`, sums `shares × dividend_rate`, currency-converts to item currency, writes `details.dividend_fixed_amount` + `details.dividend_mode = 'Fixed'`
- ILA (Israeli Agorot) normalisation: `amount × 0.01 → ILS` before calling the existing `convertCurrency` utility (which doesn't know ILA)
- Enrichment is best-effort; failures log and return the raw snapshot

---

## Currency conversion

Rates are **static** in `apps/backend/app/utils/currency.py` (ILS=1, USD=3, EUR=3.5, ILA=0.01). Ported directly to TypeScript — reuses the existing `src/lib/currency.ts` `convertCurrency` with ILA normalisation handled locally. No network calls required.

---

## Test results

```
Test Files  2 passed (2)
     Tests  13 passed (13)
```

3 pre-existing failures in `PensionChart.test.tsx` / `PensionTable.test.tsx` remain — unrelated to this PR (lightweight-charts mock issue + onToggleOwner prop removal).

---

## Follow-up issue (simulate migration)

Suggested text for Squad to file:
> **feat(plan): migrate `/api/plans/simulate` to Server Action** — port `apps/backend/app/services/plan_service.py:calculate_projection` (316 lines) to TypeScript. Requires design for the projection algorithm, tax calculations, and milestone-hit detection. Blocking: projection chart on `/plan` and `/cash-flow` pages.