### PR TITLE
feat(TJ-018a): migrate /api/finances history/POST/DELETE to Server Actions (#178)

### DIFF
--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -15,7 +15,6 @@ const PAGES = [
  * sub-issue listed below should remove its entry as the migration lands.
  *
  * - /api/plans/simulate    → #173
- * - /api/finances/history  → #177
  * - /api/trading/configs   → #177
  * - /api/ladder/income     → #177
  * - /api/options           → #177
@@ -23,7 +22,6 @@ const PAGES = [
  */
 const UNMIGRATED_FASTAPI_PATHS = [
   '/api/plans/simulate',
-  '/api/finances/history',
   '/api/trading/configs',
   '/api/ladder/income',
   '/api/ladder/overview',
@@ -61,7 +59,6 @@ function isKnownAcceptableConsoleError(text: string): boolean {
 
   // App-level downstream errors caused by the same un-migrated endpoints
   if (text.includes('Simulation failed') || text.includes('Simulation error')) return true;
-  if (text.includes('Failed to fetch history')) return true;
   if (text.includes('Failed to fetch summary data')) return true;
   if (text.includes('Failed to fetch options income')) return true;
   if (text.includes('Failed to load ladder data')) return true;

--- a/apps/frontend/src/app/current-finances/actions.ts
+++ b/apps/frontend/src/app/current-finances/actions.ts
@@ -2,6 +2,7 @@
 
 import { createClient } from '@/lib/supabase/server';
 import type { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
+import { saveFinanceSnapshot as saveFinanceSnapshotForDate } from '@/app/finances/actions';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -64,57 +65,8 @@ export async function saveFinanceSnapshot(
   items: FinanceItem[],
   metrics: FinanceMetrics,
 ): Promise<SaveSnapshotResult> {
-  const supabase = await createClient();
-
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser();
-
-  if (authError || !user) {
-    return { success: false, error: 'Not authenticated' };
-  }
-
-  // Validate inputs before hitting the DB
-  if (!Array.isArray(items)) {
-    return { success: false, error: 'Invalid payload: items must be an array' };
-  }
-  if (
-    typeof metrics.net_worth !== 'number' ||
-    typeof metrics.total_assets !== 'number' ||
-    typeof metrics.total_liabilities !== 'number' ||
-    typeof metrics.total_savings !== 'number' ||
-    typeof metrics.total_investments !== 'number'
-  ) {
-    return { success: false, error: 'Invalid payload: all metric fields must be numbers' };
-  }
-
-  const householdId = await resolveHouseholdId(user.id);
-  if (!householdId) {
-    return { success: false, error: 'No active household found for your account' };
-  }
-
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
-  const snapshotData: SnapshotData = { items, ...metrics };
-
-  const { error: upsertError } = await supabase.from('finance_snapshots').upsert(
-    {
-      date: today,
-      household_id: householdId,
-      data: snapshotData,
-      net_worth: metrics.net_worth,
-      total_assets: metrics.total_assets,
-      total_liabilities: metrics.total_liabilities,
-    },
-    { onConflict: 'household_id,date' },
-  );
-
-  if (upsertError) {
-    console.error('[saveFinanceSnapshot] upsert error:', upsertError.message);
-    return { success: false, error: 'Failed to save snapshot. Please try again.' };
-  }
-
-  return { success: true };
+  return saveFinanceSnapshotForDate(today, { items, ...metrics });
 }
 
 /**

--- a/apps/frontend/src/app/finances/__tests__/actions.test.ts
+++ b/apps/frontend/src/app/finances/__tests__/actions.test.ts
@@ -21,7 +21,12 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }));
 
-import { getLatestFinanceSnapshot } from './actions';
+import {
+  deleteFinanceSnapshot,
+  getFinanceHistory,
+  getLatestFinanceSnapshot,
+  saveFinanceSnapshot,
+} from '../actions';
 import { createClient } from '@/lib/supabase/server';
 
 const MOCK_USER_ID = 'user-uuid-1234';
@@ -166,6 +171,95 @@ describe('getLatestFinanceSnapshot — snapshot retrieval', () => {
     // Verify order: descending date was requested
     expect(snapshotsChain.order).toHaveBeenCalledWith('date', { ascending: false });
     expect(snapshotsChain.limit).toHaveBeenCalledWith(1);
+  });
+});
+
+// ── History / write actions ───────────────────────────────────────────────────
+
+describe('getFinanceHistory', () => {
+  it('returns snapshots ordered by date desc with the requested limit', async () => {
+    authOk();
+    const rows = [
+      {
+        date: '2025-06-15',
+        household_id: MOCK_HOUSEHOLD_ID,
+        net_worth: 500000,
+        total_assets: 600000,
+        total_liabilities: 100000,
+        data: { items: [], net_worth: 500000, total_assets: 600000, total_liabilities: 100000, total_savings: 200000, total_investments: 300000 },
+      },
+    ];
+    const historyChain = { select: vi.fn().mockReturnThis(), eq: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue({ data: rows, error: null }) };
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn((table: string) => {
+      if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+      if (table === 'finance_snapshots') return historyChain;
+      throw new Error(`Unexpected table: ${table}`);
+    }) });
+    const result = await getFinanceHistory(25);
+    expect(result).toEqual(rows);
+    expect(historyChain.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+    expect(historyChain.order).toHaveBeenCalledWith('date', { ascending: false });
+    expect(historyChain.limit).toHaveBeenCalledWith(25);
+  });
+
+  it('returns an empty array when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn() });
+    await expect(getFinanceHistory()).resolves.toEqual([]);
+  });
+});
+
+describe('saveFinanceSnapshot', () => {
+  const payload = { items: [], net_worth: 500000, total_assets: 600000, total_liabilities: 100000, total_savings: 200000, total_investments: 300000 };
+
+  it('upserts by session household and date using the composite conflict target', async () => {
+    authOk();
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn((table: string) => {
+      if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+      if (table === 'finance_snapshots') return { upsert };
+      throw new Error(`Unexpected table: ${table}`);
+    }) });
+    const result = await saveFinanceSnapshot('2025-06-15', payload);
+    expect(result.success).toBe(true);
+    expect(upsert).toHaveBeenCalledWith({ date: '2025-06-15', household_id: MOCK_HOUSEHOLD_ID, data: payload, net_worth: payload.net_worth, total_assets: payload.total_assets, total_liabilities: payload.total_liabilities }, { onConflict: 'household_id,date' });
+  });
+
+  it('rejects invalid dates before writing', async () => {
+    authOk();
+    const upsert = vi.fn();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn(() => ({ upsert })) });
+    const result = await saveFinanceSnapshot('06/15/2025', payload);
+    expect(result.success).toBe(false);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('deleteFinanceSnapshot', () => {
+  it('deletes by session household and date', async () => {
+    authOk();
+    const deleteEq = vi.fn();
+    const deleteChain = { eq: deleteEq };
+    deleteEq.mockReturnValueOnce(deleteChain).mockResolvedValueOnce({ error: null });
+    const deleteFromTable = vi.fn().mockReturnValue(deleteChain);
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn((table: string) => {
+      if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+      if (table === 'finance_snapshots') return { delete: deleteFromTable };
+      throw new Error(`Unexpected table: ${table}`);
+    }) });
+    const result = await deleteFinanceSnapshot('2025-06-15');
+    expect(result.success).toBe(true);
+    expect(deleteFromTable).toHaveBeenCalledOnce();
+    expect(deleteEq).toHaveBeenNthCalledWith(1, 'household_id', MOCK_HOUSEHOLD_ID);
+    expect(deleteEq).toHaveBeenNthCalledWith(2, 'date', '2025-06-15');
+  });
+
+  it('returns an error when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn() });
+    const result = await deleteFinanceSnapshot('2025-06-15');
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error).toMatch(/not authenticated/i);
   });
 });
 

--- a/apps/frontend/src/app/finances/actions.ts
+++ b/apps/frontend/src/app/finances/actions.ts
@@ -26,6 +26,16 @@ export interface FinanceSnapshotData {
   total_investments: number;
 }
 
+export type SaveFinanceSnapshotPayload = FinanceSnapshotData;
+
+export type SaveFinanceSnapshotResult =
+  | { success: true }
+  | { success: false; error: string };
+
+export type DeleteFinanceSnapshotResult =
+  | { success: true }
+  | { success: false; error: string };
+
 // Raw rows from dividend tables — typed narrowly to avoid over-fetching
 interface DividendAccountRow {
   name: string;
@@ -224,4 +234,139 @@ export async function getLatestFinanceSnapshot(): Promise<FinanceSnapshot | null
   }
 
   return snapshot;
+}
+
+/**
+ * Returns finance snapshots for the authenticated user's household, newest first.
+ * `household_id` is resolved from the session and RLS enforces read isolation.
+ */
+export async function getFinanceHistory(limit = 100): Promise<FinanceSnapshot[]> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return [];
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) return [];
+
+  const boundedLimit = Number.isFinite(limit)
+    ? Math.min(Math.max(Math.trunc(limit), 1), 500)
+    : 100;
+
+  const { data, error } = await supabase
+    .from('finance_snapshots')
+    .select('date, household_id, net_worth, total_assets, total_liabilities, data')
+    .eq('household_id', householdId)
+    .order('date', { ascending: false })
+    .limit(boundedLimit);
+
+  if (error) {
+    console.error('[getFinanceHistory] query error:', error.message);
+    return [];
+  }
+
+  return (data ?? []) as unknown as FinanceSnapshot[];
+}
+
+/**
+ * Upserts a finance snapshot for the authenticated user's household.
+ * The household scope is session-derived; callers can only choose date/payload.
+ */
+export async function saveFinanceSnapshot(
+  date: string,
+  payload: SaveFinanceSnapshotPayload,
+): Promise<SaveFinanceSnapshotResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const snapshotDate = typeof date === 'string' ? date.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(snapshotDate)) {
+    return { success: false, error: 'Invalid date' };
+  }
+
+  if (!payload || typeof payload !== 'object' || !Array.isArray(payload.items)) {
+    return { success: false, error: 'Invalid payload: items must be an array' };
+  }
+  if (
+    typeof payload.net_worth !== 'number' ||
+    typeof payload.total_assets !== 'number' ||
+    typeof payload.total_liabilities !== 'number' ||
+    typeof payload.total_savings !== 'number' ||
+    typeof payload.total_investments !== 'number'
+  ) {
+    return { success: false, error: 'Invalid payload: all metric fields must be numbers' };
+  }
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) {
+    return { success: false, error: 'No active household found for your account' };
+  }
+
+  const { error: upsertError } = await supabase.from('finance_snapshots').upsert(
+    {
+      date: snapshotDate,
+      household_id: householdId,
+      data: payload,
+      net_worth: payload.net_worth,
+      total_assets: payload.total_assets,
+      total_liabilities: payload.total_liabilities,
+    },
+    { onConflict: 'household_id,date' },
+  );
+
+  if (upsertError) {
+    console.error('[saveFinanceSnapshot] upsert error:', upsertError.message);
+    return { success: false, error: 'Failed to save snapshot. Please try again.' };
+  }
+
+  return { success: true };
+}
+
+/** Deletes one finance snapshot by date for the authenticated user's household. */
+export async function deleteFinanceSnapshot(dateStr: string): Promise<DeleteFinanceSnapshotResult> {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return { success: false, error: 'Not authenticated' };
+  }
+
+  const snapshotDate = typeof dateStr === 'string' ? dateStr.trim() : '';
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(snapshotDate)) {
+    return { success: false, error: 'Invalid date' };
+  }
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) {
+    return { success: false, error: 'No active household found for your account' };
+  }
+
+  const { error: deleteError } = await supabase
+    .from('finance_snapshots')
+    .delete()
+    .eq('household_id', householdId)
+    .eq('date', snapshotDate);
+
+  if (deleteError) {
+    console.error('[deleteFinanceSnapshot] delete error:', deleteError.message);
+    return { success: false, error: 'Failed to delete snapshot. Please try again.' };
+  }
+
+  return { success: true };
 }

--- a/apps/frontend/src/app/progress/page.tsx
+++ b/apps/frontend/src/app/progress/page.tsx
@@ -1,29 +1,22 @@
 'use client';
-import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useEffect } from 'react';
 import { ProgressChart } from '@/components/Progress/ProgressChart';
 import { ProgressTable } from '@/components/Progress/ProgressTable';
 import { AddHistoryModal, ProgressSummary } from '@/components/Progress/AddHistoryModal';
 import { useSettings } from '../settings/SettingsContext';
+import { deleteFinanceSnapshot, getFinanceHistory, saveFinanceSnapshot } from '../finances/actions';
 
-async function fetchHistory() {
+async function fetchHistory(): Promise<ProgressSummary[]> {
     try {
-        const res = await apiFetch('/api/finances/history?limit=100');
-        if (!res.ok) throw new Error('Failed to fetch history');
-        const data = await res.json();
-        // Map backend model to frontend summary
-        // Backend returns FinanceSnapshot objects which contain data dict
-        return data.map((d: any) => ({
+        const data = await getFinanceHistory(100);
+        return data.map((d) => ({
             date: d.date,
             net_worth: d.net_worth,
             total_assets: d.total_assets,
             total_liabilities: d.total_liabilities,
-            // The following might be in d.data (the json column) or computed if we updated backend to return them.
-            // Based on my backend update, I didn't add them as columns on FinanceSnapshot, 
-            // so they are in d.data.total_savings etc.
             total_savings: d.data.total_savings || 0,
-            total_investments: d.data.total_investments || 0
+            total_investments: d.data.total_investments || 0,
         }));
     } catch (err) {
         console.error(err);
@@ -32,43 +25,29 @@ async function fetchHistory() {
 }
 
 async function saveHistory(summary: ProgressSummary) {
-    try {
-        const payload = {
-            items: [],
-            date: summary.date,
-            net_worth: summary.net_worth,
-            total_assets: summary.total_assets,
-            total_liabilities: summary.total_liabilities,
-            total_savings: summary.total_savings,
-            total_investments: summary.total_investments
-        };
+    const result = await saveFinanceSnapshot(summary.date, {
+        items: [],
+        net_worth: summary.net_worth,
+        total_assets: summary.total_assets,
+        total_liabilities: summary.total_liabilities,
+        total_savings: summary.total_savings,
+        total_investments: summary.total_investments,
+    });
 
-        const res = await apiFetch('/api/finances/', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(payload),
-        });
-
-        if (!res.ok) throw new Error('Failed to save history');
-        return await res.json();
-    } catch (err) {
-        console.error(err);
+    if (!result.success) {
+        console.error(result.error);
         alert('Failed to save.');
     }
 }
 
 async function deleteHistory(date: string) {
-    try {
-        const res = await apiFetch(`/api/finances/${date}`, {
-            method: 'DELETE',
-        });
-        if (!res.ok) throw new Error('Failed to delete history');
-        return true;
-    } catch (err) {
-        console.error(err);
+    const result = await deleteFinanceSnapshot(date);
+    if (!result.success) {
+        console.error(result.error);
         alert('Failed to delete.');
         return false;
     }
+    return true;
 }
 
 export default function ProgressPage() {


### PR DESCRIPTION
Closes #178

References #71 #177.

Working as Hockney (Backend Dev).

## Summary
- Add finance history, upsert, and delete Server Actions scoped by resolved household_id.
- Reuse the new dated save action from /current-finances via a thin wrapper.
- Move /progress history CRUD off /api/finances and remove history from the walkthrough allow-list.
- Add unit coverage for history/save/delete actions.

## Validation
- npm --prefix apps/frontend test -- src/app/finances/__tests__/actions.test.ts src/app/current-finances/actions.test.ts --reporter=dot
- npm --prefix apps/frontend run build

Note: full npm --prefix apps/frontend test currently has unrelated Pension test failures (PensionChart lightweight-charts AreaSeries mock; PensionTable onToggleOwner expectation).