### PR TITLE
feat(TJ-018b): migrate /api/plans CRUD to Server Actions (#179)

### DIFF
--- a/apps/frontend/src/app/plan/actions.test.ts
+++ b/apps/frontend/src/app/plan/actions.test.ts
@@ -1,11 +1,7 @@
 /**
- * Unit tests for the plan/latest Server Action (getLatestPlan).
+ * Unit tests for plan Server Actions.
  *
- * Verifies:
- *  1. Returns the latest plan ordered by updated_at desc.
- *  2. Returns null when no plan exists (not an error).
- *  3. Returns null when not authenticated.
- *  4. Returns null when user has no active household.
+ * Verifies household scoping, auth guards, and CRUD persistence behavior.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -17,11 +13,22 @@ vi.mock('@/lib/supabase/server', () => ({
   createClient: vi.fn(),
 }));
 
-import { getLatestPlan } from './actions';
+import {
+  createPlan,
+  deletePlan,
+  getLatestPlan,
+  getPlan,
+  listPlans,
+  updatePlan,
+} from './actions';
 import { createClient } from '@/lib/supabase/server';
+import type { PlanData } from '@/components/Plan/types';
 
 const MOCK_USER_ID = 'user-uuid-1234';
 const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
+const HOUSEHOLD_ROW = { household_id: MOCK_HOUSEHOLD_ID };
+
+const EMPTY_PLAN_DATA: PlanData = { items: [], milestones: [], settings: {} };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -42,6 +49,22 @@ function fluentChain(result: unknown) {
     order: vi.fn().mockReturnThis(),
     limit: vi.fn().mockReturnThis(),
     maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+}
+
+function householdChain() {
+  return fluentChain({ data: HOUSEHOLD_ROW, error: null });
+}
+
+function planRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 7,
+    name: 'Retirement Plan',
+    description: 'Long-term plan',
+    data: EMPTY_PLAN_DATA,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-06-15T12:00:00Z',
+    ...overrides,
   };
 }
 
@@ -83,7 +106,7 @@ describe('getLatestPlan — retrieval', () => {
     (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
       auth: { getUser: mockGetUser },
       from: vi.fn((table: string) => {
-        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'household_members') return householdChain();
         if (table === 'plans') return fluentChain({ data: null, error: null });
         throw new Error(`Unexpected table: ${table}`);
       }),
@@ -95,28 +118,19 @@ describe('getLatestPlan — retrieval', () => {
 
   it('returns the latest plan ordered by updated_at desc', async () => {
     authOk();
-
-    const planRow = {
-      id: 7,
-      name: 'Retirement Plan',
-      description: 'Long-term plan',
-      data: { items: [], milestones: [], settings: {} },
-      created_at: '2025-01-01T00:00:00Z',
-      updated_at: '2025-06-15T12:00:00Z',
-    };
-
+    const row = planRow();
     const plansChain = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn().mockResolvedValue({ data: planRow, error: null }),
+      maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }),
     };
 
     (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
       auth: { getUser: mockGetUser },
       from: vi.fn((table: string) => {
-        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'household_members') return householdChain();
         if (table === 'plans') return plansChain;
         throw new Error(`Unexpected table: ${table}`);
       }),
@@ -126,7 +140,6 @@ describe('getLatestPlan — retrieval', () => {
     expect(result).not.toBeNull();
     expect(result?.id).toBe(7);
     expect(result?.name).toBe('Retirement Plan');
-    // Verify ordering
     expect(plansChain.order).toHaveBeenCalledWith('updated_at', { ascending: false });
     expect(plansChain.limit).toHaveBeenCalledWith(1);
   });
@@ -138,7 +151,7 @@ describe('getLatestPlan — retrieval', () => {
     (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
       auth: { getUser: mockGetUser },
       from: vi.fn((table: string) => {
-        if (table === 'household_members') return fluentChain({ data: { household_id: MOCK_HOUSEHOLD_ID }, error: null });
+        if (table === 'household_members') return householdChain();
         if (table === 'plans') return fluentChain({ data: null, error: { message: 'RLS violation' } });
         throw new Error(`Unexpected table: ${table}`);
       }),
@@ -151,5 +164,229 @@ describe('getLatestPlan — retrieval', () => {
       expect.stringContaining('RLS violation'),
     );
     consoleSpy.mockRestore();
+  });
+});
+
+describe('listPlans', () => {
+  it('returns empty array when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    await expect(listPlans()).resolves.toEqual([]);
+  });
+
+  it('lists household-scoped plans ordered by updated_at desc', async () => {
+    authOk();
+    const rows = [planRow({ id: 2 }), planRow({ id: 1 })];
+    const listChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return listChain;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await listPlans();
+    expect(result).toEqual(rows);
+    expect(listChain.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+    expect(listChain.order).toHaveBeenCalledWith('updated_at', { ascending: false });
+  });
+});
+
+describe('getPlan', () => {
+  it('returns null for invalid IDs', async () => {
+    await expect(getPlan('not-a-number')).resolves.toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('gets a single household-scoped plan by ID', async () => {
+    authOk();
+    const row = planRow({ id: 42 });
+    const getChain = fluentChain({ data: row, error: null });
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return getChain;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getPlan(42);
+    expect(result).toEqual(row);
+    expect(getChain.eq).toHaveBeenCalledWith('id', 42);
+    expect(getChain.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+  });
+});
+
+// ── Plan mutations ────────────────────────────────────────────────────────────
+
+describe('createPlan', () => {
+  it('returns an auth error when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    const result = await createPlan(EMPTY_PLAN_DATA);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not authenticated/i);
+  });
+
+  it('creates a plan with session-derived household_id and default name', async () => {
+    authOk();
+    const row = planRow({ name: 'My Plan' });
+    const singleMock = vi.fn().mockResolvedValue({ data: row, error: null });
+    const selectMock = vi.fn().mockReturnValue({ single: singleMock });
+    const insertMock = vi.fn().mockReturnValue({ select: selectMock });
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return { insert: insertMock };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await createPlan(EMPTY_PLAN_DATA);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.plan).toEqual(row);
+    expect(insertMock).toHaveBeenCalledWith({
+      household_id: MOCK_HOUSEHOLD_ID,
+      name: 'My Plan',
+      description: null,
+      data: EMPTY_PLAN_DATA,
+    });
+  });
+
+  it('honors explicit name and description payload fields', async () => {
+    authOk();
+    const row = planRow({ name: 'Custom Plan', description: 'Scenario A' });
+    const insertMock = vi.fn().mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data: row, error: null }),
+      }),
+    });
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return { insert: insertMock };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await createPlan({
+      name: '  Custom Plan  ',
+      description: 'Scenario A',
+      data: EMPTY_PLAN_DATA,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Custom Plan', description: 'Scenario A' }),
+    );
+  });
+});
+
+describe('updatePlan', () => {
+  it('validates IDs and empty patches before querying', async () => {
+    await expect(updatePlan(0, { data: EMPTY_PLAN_DATA })).resolves.toEqual({
+      ok: false,
+      error: 'Invalid plan ID',
+    });
+    await expect(updatePlan(1, {})).resolves.toEqual({
+      ok: false,
+      error: 'No plan fields to update',
+    });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('updates only provided fields within the active household', async () => {
+    authOk();
+    const updated = planRow({ id: 7, name: 'New Name' });
+    const updateChain = {
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: updated, error: null }),
+    };
+    const updateMock = vi.fn().mockReturnValue(updateChain);
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return { update: updateMock };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await updatePlan(7, { name: '  New Name  ', data: EMPTY_PLAN_DATA });
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.plan).toEqual(updated);
+    expect(updateMock).toHaveBeenCalledWith({ name: 'New Name', data: EMPTY_PLAN_DATA });
+    expect(updateChain.eq).toHaveBeenCalledWith('id', 7);
+    expect(updateChain.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+  });
+});
+
+describe('deletePlan', () => {
+  it('deletes by ID within the active household', async () => {
+    authOk();
+    const deleteChain = {
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: { id: 7 }, error: null }),
+    };
+    const deleteMock = vi.fn().mockReturnValue(deleteChain);
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return { delete: deleteMock };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await deletePlan(7);
+    expect(result).toEqual({ ok: true });
+    expect(deleteMock).toHaveBeenCalledOnce();
+    expect(deleteChain.eq).toHaveBeenCalledWith('id', 7);
+    expect(deleteChain.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+  });
+
+  it('returns not found when no deleted row is returned', async () => {
+    authOk();
+    const deleteChain = {
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members') return householdChain();
+        if (table === 'plans') return { delete: vi.fn().mockReturnValue(deleteChain) };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    await expect(deletePlan(7)).resolves.toEqual({ ok: false, error: 'Plan not found' });
   });
 });

--- a/apps/frontend/src/app/plan/actions.ts
+++ b/apps/frontend/src/app/plan/actions.ts
@@ -1,9 +1,33 @@
 'use server';
 
 import { createClient } from '@/lib/supabase/server';
-import type { Plan } from '@/components/Plan/types';
+import type { Plan, PlanData } from '@/components/Plan/types';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type PlanCreatePayload =
+  | PlanData
+  | {
+      name?: string;
+      description?: string | null;
+      data: PlanData;
+    };
+
+export type PlanUpdatePatch = Partial<{
+  name: string;
+  description: string | null;
+  data: PlanData;
+}>;
+
+export type PlanMutationResult =
+  | { ok: true; plan: Plan }
+  | { ok: false; error: string };
+
+export type PlanDeleteResult = { ok: true } | { ok: false; error: string };
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
+
+const PLAN_COLUMNS = 'id, name, description, data, created_at, updated_at';
 
 /**
  * Looks up the calling user's primary active household_id.
@@ -23,7 +47,204 @@ async function resolveHouseholdId(userId: string): Promise<string | null> {
   return data.household_id as string;
 }
 
-// ── Server Action ─────────────────────────────────────────────────────────────
+function parsePlanId(id: number | string): number | null {
+  const parsed = typeof id === 'number' ? id : Number(id);
+  if (!Number.isInteger(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+function isPlanEnvelope(
+  payload: PlanCreatePayload,
+): payload is { name?: string; description?: string | null; data: PlanData } {
+  return typeof payload === 'object' && payload !== null && 'data' in payload;
+}
+
+function normalizeCreatePayload(
+  payload: PlanCreatePayload,
+): { name: string; description: string | null; data: PlanData } | null {
+  const rawName = isPlanEnvelope(payload) ? payload.name : undefined;
+  const name = typeof rawName === 'string' && rawName.trim() ? rawName.trim() : 'My Plan';
+  const description = isPlanEnvelope(payload) ? (payload.description ?? null) : null;
+  const data = isPlanEnvelope(payload) ? payload.data : payload;
+
+  if (!data || typeof data !== 'object') return null;
+  return { name, description, data };
+}
+
+async function getAuthenticatedHouseholdId(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+  return resolveHouseholdId(user.id);
+}
+
+// ── Server Actions ────────────────────────────────────────────────────────────
+
+/**
+ * Returns all plans for the authenticated user's household, newest first.
+ */
+export async function listPlans(): Promise<Plan[]> {
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) return [];
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('plans')
+    .select(PLAN_COLUMNS)
+    .eq('household_id', householdId)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    console.error('[listPlans] query error:', error.message);
+    return [];
+  }
+
+  return (data ?? []) as unknown as Plan[];
+}
+
+/**
+ * Returns one household-scoped plan by ID, or null when not found/unauthorized.
+ */
+export async function getPlan(id: number | string): Promise<Plan | null> {
+  const planId = parsePlanId(id);
+  if (!planId) return null;
+
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) return null;
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('plans')
+    .select(PLAN_COLUMNS)
+    .eq('id', planId)
+    .eq('household_id', householdId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[getPlan] query error:', error.message);
+    return null;
+  }
+
+  return data ? (data as unknown as Plan) : null;
+}
+
+/**
+ * Creates a plan in the authenticated user's household.
+ * Security: household_id is resolved from the session, never caller input.
+ */
+export async function createPlan(
+  payload: PlanCreatePayload,
+): Promise<PlanMutationResult> {
+  const normalized = normalizeCreatePayload(payload);
+  if (!normalized) return { ok: false, error: 'Plan data is required' };
+
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) return { ok: false, error: 'Not authenticated or no active household' };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('plans')
+    .insert({
+      household_id: householdId,
+      name: normalized.name,
+      description: normalized.description,
+      data: normalized.data,
+    })
+    .select(PLAN_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    console.error('[createPlan] insert error:', error?.message ?? 'No row returned');
+    return { ok: false, error: 'Failed to create plan. Please try again.' };
+  }
+
+  return { ok: true, plan: data as unknown as Plan };
+}
+
+/**
+ * Updates a household-scoped plan by ID.
+ */
+export async function updatePlan(
+  id: number | string,
+  patch: PlanUpdatePatch,
+): Promise<PlanMutationResult> {
+  const planId = parsePlanId(id);
+  if (!planId) return { ok: false, error: 'Invalid plan ID' };
+  if (!patch || typeof patch !== 'object') {
+    return { ok: false, error: 'Plan update patch is required' };
+  }
+
+  const updateValues: Record<string, unknown> = {};
+  if (Object.prototype.hasOwnProperty.call(patch, 'name')) {
+    const name = typeof patch.name === 'string' ? patch.name.trim() : '';
+    if (!name) return { ok: false, error: 'Name must not be empty' };
+    updateValues.name = name;
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'description')) {
+    updateValues.description = patch.description ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(patch, 'data')) {
+    if (!patch.data || typeof patch.data !== 'object') {
+      return { ok: false, error: 'Plan data must be an object' };
+    }
+    updateValues.data = patch.data;
+  }
+
+  if (Object.keys(updateValues).length === 0) {
+    return { ok: false, error: 'No plan fields to update' };
+  }
+
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) return { ok: false, error: 'Not authenticated or no active household' };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('plans')
+    .update(updateValues)
+    .eq('id', planId)
+    .eq('household_id', householdId)
+    .select(PLAN_COLUMNS)
+    .single();
+
+  if (error || !data) {
+    console.error('[updatePlan] update error:', error?.message ?? 'No row returned');
+    return { ok: false, error: 'Failed to update plan. Please try again.' };
+  }
+
+  return { ok: true, plan: data as unknown as Plan };
+}
+
+/**
+ * Deletes a household-scoped plan by ID.
+ */
+export async function deletePlan(id: number | string): Promise<PlanDeleteResult> {
+  const planId = parsePlanId(id);
+  if (!planId) return { ok: false, error: 'Invalid plan ID' };
+
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) return { ok: false, error: 'Not authenticated or no active household' };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('plans')
+    .delete()
+    .eq('id', planId)
+    .eq('household_id', householdId)
+    .select('id')
+    .maybeSingle();
+
+  if (error) {
+    console.error('[deletePlan] delete error:', error.message);
+    return { ok: false, error: 'Failed to delete plan. Please try again.' };
+  }
+  if (!data) return { ok: false, error: 'Plan not found' };
+
+  return { ok: true };
+}
 
 /**
  * Returns the most-recently updated plan for the authenticated user's

--- a/apps/frontend/src/app/plan/page.tsx
+++ b/apps/frontend/src/app/plan/page.tsx
@@ -6,26 +6,8 @@ import { PlanEditor } from '@/components/Plan/PlanEditor';
 import { PlanDetailsPane } from '@/components/Plan/PlanDetailsPane';
 import { Plan, PlanData } from '@/components/Plan/types';
 import { useSettings } from '../settings/SettingsContext';
-import { getLatestPlan } from './actions';
+import { createPlan, getLatestPlan, updatePlan } from './actions';
 import { getLatestFinanceSnapshot } from '../finances/actions';
-
-async function createPlan(data: PlanData) {
-    const res = await apiFetch('/api/plans/', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data), // PlanData maps to plan_in
-    });
-    return res.json();
-}
-
-async function updatePlan(id: number, data: PlanData) {
-    const res = await apiFetch(`/api/plans/${id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-    });
-    return res.json();
-}
 
 export default function PlanPage() {
     const { settings } = useSettings();
@@ -61,10 +43,11 @@ export default function PlanPage() {
         setPlan(updatedPlan); // Optimistic Update
 
         if (plan.id) {
-            await updatePlan(plan.id, newData);
+            const result = await updatePlan(plan.id, { data: newData });
+            if (result.ok) setPlan(result.plan);
         } else {
-            const saved = await createPlan(newData);
-            setPlan(saved);
+            const result = await createPlan(newData);
+            if (result.ok) setPlan(result.plan);
         }
     };
 

--- a/apps/frontend/src/lib/__tests__/api-client.test.ts
+++ b/apps/frontend/src/lib/__tests__/api-client.test.ts
@@ -47,7 +47,7 @@ describe('apiFetch', () => {
       const mockFetch = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }));
       vi.stubGlobal('fetch', mockFetch);
 
-      await apiFetch('/api/plans/', {
+      await apiFetch('/api/holdings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ foo: 1 }),


### PR DESCRIPTION
Closes #179. Refs #71. Simulate stays on FastAPI per #173.