### PR TITLE
feat(TJ-018f): migrate /api/options CRUD to Server Actions (#183)

### DIFF
--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -17,14 +17,14 @@ const PAGES = [
  * - /api/plans/simulate    → #173
  * - /api/trading/configs   → #177
  * - /api/ladder/income     → #177
- * - /api/options           → #177
+ * - /api/options/projection → #189 / TJ-019
  */
 const UNMIGRATED_FASTAPI_PATHS = [
   '/api/plans/simulate',
   '/api/trading/configs',
   '/api/ladder/income',
   '/api/ladder/overview',
-  '/api/options',
+  '/api/options/projection',
   '/api/backtest',
   '/api/dividends',
   '/api/pension',
@@ -58,7 +58,6 @@ function isKnownAcceptableConsoleError(text: string): boolean {
   // App-level downstream errors caused by the same un-migrated endpoints
   if (text.includes('Simulation failed') || text.includes('Simulation error')) return true;
   if (text.includes('Failed to fetch summary data')) return true;
-  if (text.includes('Failed to fetch options income')) return true;
   if (text.includes('Failed to load ladder data')) return true;
   if (text.includes('Failed to fetch years')) return true;
   if (text.includes('Failed to fetch dividends')) return true;

--- a/apps/frontend/src/app/options/actions.test.ts
+++ b/apps/frontend/src/app/options/actions.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetUser, mockRevalidatePath } = vi.hoisted(() => ({
+  mockGetUser: vi.fn(),
+  mockRevalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: mockRevalidatePath,
+}));
+
+import { createOptionsRecord, listOptionsRecords } from './actions';
+import { createClient } from '@/lib/supabase/server';
+
+const MOCK_USER_ID = 'user-uuid-1234';
+const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
+const HOUSEHOLD_ROW = { household_id: MOCK_HOUSEHOLD_ID };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+function authOk() {
+  mockGetUser.mockResolvedValue({ data: { user: { id: MOCK_USER_ID } }, error: null });
+}
+
+function authFail() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+}
+
+function householdQuery(data: { household_id: string } | null = HOUSEHOLD_ROW) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data, error: null }),
+  };
+}
+
+describe('listOptionsRecords', () => {
+  it('returns empty array when not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    await expect(listOptionsRecords()).resolves.toEqual([]);
+  });
+
+  it('returns household-scoped options rows sorted by year', async () => {
+    authOk();
+    const order = vi.fn().mockResolvedValue({
+      data: [
+        { year: 2024, amount: '1234.56' },
+        { year: 2025, amount: 7890 },
+      ],
+      error: null,
+    });
+    const optionsQuery = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order,
+    };
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdQuery();
+      if (table === 'options_income') return optionsQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from,
+    });
+
+    const records = await listOptionsRecords();
+
+    expect(records).toEqual([
+      { year: 2024, amount: 1234.56 },
+      { year: 2025, amount: 7890 },
+    ]);
+    expect(optionsQuery.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+    expect(order).toHaveBeenCalledWith('year', { ascending: true });
+  });
+});
+
+describe('createOptionsRecord', () => {
+  it('returns an error when not authenticated and does not write', async () => {
+    authFail();
+    const upsert = vi.fn();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(() => ({ upsert })),
+    });
+
+    const result = await createOptionsRecord([{ year: 2024, amount: 1000 }]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not authenticated/i);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the user has no active household', async () => {
+    authOk();
+    const upsert = vi.fn();
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdQuery(null);
+      if (table === 'options_income') return { upsert };
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from,
+    });
+
+    const result = await createOptionsRecord([{ year: 2024, amount: 1000 }]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/no active household/i);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('upserts records with session-resolved household_id and composite conflict target', async () => {
+    authOk();
+    const not = vi.fn().mockResolvedValue({ error: null });
+    const deleteQuery = {
+      eq: vi.fn().mockReturnThis(),
+      not,
+    };
+    const upsert = vi.fn().mockResolvedValue({ error: null });
+    const optionsQuery = {
+      upsert,
+      delete: vi.fn(() => deleteQuery),
+    };
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdQuery();
+      if (table === 'options_income') return optionsQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from,
+    });
+
+    const result = await createOptionsRecord([
+      { year: 2025, amount: 2000 },
+      { year: 2024, amount: -100.25 },
+    ]);
+
+    expect(result).toEqual({
+      ok: true,
+      records: [
+        { year: 2024, amount: -100.25 },
+        { year: 2025, amount: 2000 },
+      ],
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      [
+        { household_id: MOCK_HOUSEHOLD_ID, year: 2024, amount: -100.25 },
+        { household_id: MOCK_HOUSEHOLD_ID, year: 2025, amount: 2000 },
+      ],
+      { onConflict: 'household_id,year' },
+    );
+    expect(deleteQuery.eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+    expect(not).toHaveBeenCalledWith('year', 'in', '(2024,2025)');
+    expect(mockRevalidatePath).toHaveBeenCalledWith('/options');
+  });
+
+  it('clears all household rows when saving an empty record set', async () => {
+    authOk();
+    const eq = vi.fn().mockResolvedValue({ error: null });
+    const optionsQuery = {
+      upsert: vi.fn(),
+      delete: vi.fn(() => ({ eq })),
+    };
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdQuery();
+      if (table === 'options_income') return optionsQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from,
+    });
+
+    const result = await createOptionsRecord([]);
+
+    expect(result).toEqual({ ok: true, records: [] });
+    expect(optionsQuery.upsert).not.toHaveBeenCalled();
+    expect(eq).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
+  });
+
+  it('rejects duplicate years before writing', async () => {
+    authOk();
+    const upsert = vi.fn();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(() => ({ upsert })),
+    });
+
+    const result = await createOptionsRecord([
+      { year: 2024, amount: 1000 },
+      { year: 2024, amount: 2000 },
+    ]);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/duplicate/i);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the DB upsert fails', async () => {
+    authOk();
+    const upsert = vi.fn().mockResolvedValue({ error: { message: 'RLS violation' } });
+    const optionsQuery = {
+      upsert,
+      delete: vi.fn(),
+    };
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdQuery();
+      if (table === 'options_income') return optionsQuery;
+      throw new Error(`Unexpected table: ${table}`);
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from,
+    });
+
+    const result = await createOptionsRecord([{ year: 2024, amount: 1000 }]);
+
+    expect(result.ok).toBe(false);
+    expect(optionsQuery.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/options/actions.ts
+++ b/apps/frontend/src/app/options/actions.ts
@@ -1,0 +1,179 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+
+export interface OptionsRecord {
+  year: number;
+  amount: number;
+}
+
+export type OptionsActionResult =
+  | { ok: true; records: OptionsRecord[] }
+  | { ok: false; error: string };
+
+interface OptionsIncomeRow {
+  year: number | string;
+  amount: number | string;
+}
+
+/**
+ * Looks up the calling user's active household_id from the authenticated
+ * session. Caller input must never provide household scope.
+ */
+async function resolveHouseholdId(userId: string): Promise<string | null> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', userId)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data.household_id as string;
+}
+
+async function requireHousehold(): Promise<{ ok: true; householdId: string } | { ok: false; error: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return { ok: false, error: 'Not authenticated' };
+
+  const householdId = await resolveHouseholdId(user.id);
+  if (!householdId) return { ok: false, error: 'No active household found for your account' };
+
+  return { ok: true, householdId };
+}
+
+function toNumber(value: number | string): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeOptionsRecord(row: OptionsIncomeRow): OptionsRecord {
+  return {
+    year: Number(row.year),
+    amount: toNumber(row.amount),
+  };
+}
+
+function validateOptionsRecords(payload: unknown): OptionsActionResult {
+  if (!Array.isArray(payload)) {
+    return { ok: false, error: 'Options records payload must be an array' };
+  }
+
+  const seenYears = new Set<number>();
+  const records: OptionsRecord[] = [];
+
+  for (const rawRecord of payload) {
+    if (!rawRecord || typeof rawRecord !== 'object') {
+      return { ok: false, error: 'Each options record must be an object' };
+    }
+
+    const record = rawRecord as Record<string, unknown>;
+    const year = Number(record.year);
+    const amount = Number(record.amount);
+
+    if (!Number.isInteger(year) || year <= 0) {
+      return { ok: false, error: 'Each options record year must be a positive integer' };
+    }
+    if (!Number.isFinite(amount)) {
+      return { ok: false, error: 'Each options record amount must be a finite number' };
+    }
+    if (seenYears.has(year)) {
+      return { ok: false, error: `Duplicate options record year: ${year}` };
+    }
+
+    seenYears.add(year);
+    records.push({ year, amount });
+  }
+
+  records.sort((a, b) => a.year - b.year);
+  return { ok: true, records };
+}
+
+/**
+ * Lists historical options income rows for the authenticated user's household.
+ * Returns an empty array when unauthenticated or when no active household exists.
+ */
+export async function listOptionsRecords(): Promise<OptionsRecord[]> {
+  const household = await requireHousehold();
+  if (!household.ok) return [];
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('options_income')
+    .select('year, amount')
+    .eq('household_id', household.householdId)
+    .order('year', { ascending: true });
+
+  if (error) {
+    console.error('[listOptionsRecords] query error:', error.message);
+    return [];
+  }
+
+  return ((data ?? []) as OptionsIncomeRow[]).map(normalizeOptionsRecord);
+}
+
+/**
+ * Replaces the authenticated household's options income history.
+ *
+ * This mirrors the legacy FastAPI POST /api/options behavior: the client sends
+ * the full record set, which is upserted by year and any omitted years are
+ * removed. `household_id` is session-derived and protected by Supabase RLS.
+ */
+export async function createOptionsRecord(payload: OptionsRecord[]): Promise<OptionsActionResult> {
+  const validation = validateOptionsRecords(payload);
+  if (!validation.ok) return validation;
+
+  const household = await requireHousehold();
+  if (!household.ok) return household;
+
+  const supabase = await createClient();
+  const rows = validation.records.map((record) => ({
+    household_id: household.householdId,
+    year: record.year,
+    amount: record.amount,
+  }));
+
+  if (rows.length > 0) {
+    const { error: upsertError } = await supabase
+      .from('options_income')
+      .upsert(rows, { onConflict: 'household_id,year' });
+
+    if (upsertError) {
+      console.error('[createOptionsRecord] upsert error:', upsertError.message);
+      return { ok: false, error: 'Failed to save options income. Please try again.' };
+    }
+
+    const retainedYears = validation.records.map((record) => record.year).join(',');
+    const { error: deleteError } = await supabase
+      .from('options_income')
+      .delete()
+      .eq('household_id', household.householdId)
+      .not('year', 'in', `(${retainedYears})`);
+
+    if (deleteError) {
+      console.error('[createOptionsRecord] prune error:', deleteError.message);
+      return { ok: false, error: 'Failed to prune old options income records. Please try again.' };
+    }
+  } else {
+    const { error: deleteError } = await supabase
+      .from('options_income')
+      .delete()
+      .eq('household_id', household.householdId);
+
+    if (deleteError) {
+      console.error('[createOptionsRecord] delete error:', deleteError.message);
+      return { ok: false, error: 'Failed to clear options income. Please try again.' };
+    }
+  }
+
+  revalidatePath('/options');
+  return { ok: true, records: validation.records };
+}

--- a/apps/frontend/src/app/options/page.tsx
+++ b/apps/frontend/src/app/options/page.tsx
@@ -1,6 +1,7 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { apiFetch } from '@/lib/api-client';
+import { createOptionsRecord, listOptionsRecords } from './actions';
 import { useEffect, useMemo, useState } from "react";
 import OptionsChart, { OptionsChartPoint } from "../../components/Options/OptionsChart";
 import OptionsHistory, { OptionsRecord } from "../../components/Options/OptionsHistory";
@@ -33,19 +34,27 @@ export default function OptionsPage() {
   };
 
   useEffect(() => {
-    setLoading(true);
-    setError(null);
-    apiFetch("/api/options")
-      .then((res) => res.json())
-      .then((data) => {
-        setHistoricalData(data);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error("Failed to fetch options income:", err);
-        setError("Failed to load options data. Please try again.");
-        setLoading(false);
-      });
+    let cancelled = false;
+
+    async function loadOptionsRecords() {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = await listOptionsRecords();
+        if (!cancelled) setHistoricalData(data);
+      } catch (err) {
+        console.error("Failed to load options income:", err);
+        if (!cancelled) setError("Failed to load options data. Please try again.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadOptionsRecords();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -82,14 +91,11 @@ export default function OptionsPage() {
 
   const handleSaveHistory = async (newData: OptionsRecord[]) => {
     try {
-      const res = await apiFetch("/api/options", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(newData),
-      });
-      if (res.ok) {
-        const saved = await res.json();
-        setHistoricalData(saved);
+      const result = await createOptionsRecord(newData);
+      if (result.ok) {
+        setHistoricalData(result.records);
+      } else {
+        console.error("Failed to save options income:", result.error);
       }
     } catch (err) {
       console.error("Failed to save options income:", err);


### PR DESCRIPTION
Closes #183. Refs #71 #177 #191. /projection stays on FastAPI per TJ-019.

Working as Hockney (Backend Dev).

Validation:
- npm test -- src/app/options/actions.test.ts --reporter=dot
- npx next lint --file src/app/options/actions.ts --file src/app/options/actions.test.ts --file src/app/options/page.tsx --file e2e/walkthrough/all-pages.spec.ts

Known baseline failures observed on main/worktree:
- npm test: existing PensionChart lightweight-charts mock AreaSeries and PensionTable onToggleOwner failures
- npx tsc --noEmit: existing unrelated project type errors
- npm run lint: existing unrelated lint errors
- npm run build: requires Supabase env during /backtest prerender