### PR TITLE
arch(TJ-019): pivot compute backend to local Docker + tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,8 +21,18 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # BACKEND — FastAPI Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
 # =============================================================================
 
-# Full PostgreSQL connection string (includes credentials — treat as secret)
+# Full PostgreSQL connection string for legacy local-dev compose (includes credentials — treat as secret)
 DATABASE_URL=postgresql://user:password@localhost:5432/trading-journal
+
+# Supabase Postgres or pooler URL for docker-compose.backend.yml.
+# Include sslmode=require when using Supabase direct Postgres.
+DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
+
+# Supabase project URL for backend JWT/JWKS verification.
+SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
+
+# Browser origins allowed to call FastAPI. Supports comma-separated exact origins and limited wildcards.
+BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
 
 # HMAC-SHA256 signing key for internal JWT tokens — rotate every 90 days
 JWT_SECRET_KEY=your-jwt-secret-key-min-32-chars-here

--- a/.squad/decisions/inbox/kujan-tj019-local-docker-compute.md
+++ b/.squad/decisions/inbox/kujan-tj019-local-docker-compute.md
@@ -1,0 +1,62 @@
+# TJ-019 Decision: Local Docker Compute Backend + Tunnel
+
+## Decision
+
+Run the remaining FastAPI compute backend locally in Docker on Jony's laptop, connect it directly to Supabase Postgres with `DIRECT_DATABASE_URL`, verify Supabase JWTs at the FastAPI boundary, and expose the backend to Vercel through a public tunnel. Cloudflare Tunnel is the recommended tunnel; Tailscale Funnel or ngrok are acceptable fallbacks.
+
+## Rationale
+
+Wave-1 CRUD routes have moved to Supabase-backed frontend paths. The remaining FastAPI routes are compute-heavy workflows (`plans/simulate`, options projection, backtest, pension upload, analyze, tax condor, bond scanner, price lookups, and sync jobs). Keeping those compute workloads on Jony's laptop has zero runtime hosting cost, preserves the existing FastAPI app and Docker workflow, and avoids introducing Railway or another always-on platform after PR #193 was closed.
+
+## Architecture
+
+- `docker-compose.backend.yml` runs only `apps/backend` on port `8000`; it does not start or depend on the legacy local Postgres `db` service.
+- The backend receives `DATABASE_URL=${DIRECT_DATABASE_URL}` so SQLModel/SQLAlchemy talks directly to Supabase Postgres or the Supabase pooler connection string.
+- `SUPABASE_URL` configures JWKS discovery; `SUPABASE_JWT_SECRET` remains available for local/HS256 fallback.
+- Vercel sets `NEXT_PUBLIC_API_URL` to the tunnel URL. Next.js rewrites `/api/*` to that public backend URL.
+- Cloudflare Tunnel publishes `http://localhost:8000` as HTTPS for Vercel production and preview deployments.
+
+## Security
+
+- CORS is an allow-list from `BACKEND_CORS_ORIGINS`; defaults cover local dev, the production Vercel app, and Vercel preview hostnames via `https://*.vercel.app`.
+- FastAPI compute routers remain registered with `Depends(get_current_user)`, so Supabase JWT verification gates every compute endpoint.
+- Public endpoints are limited to root, docs/OpenAPI, auth legacy routes, `/health`, `/health/auth`, and telemetry metrics that already handle optional auth.
+- No service-role key is required for this backend path. Do not expose Supabase service-role credentials to Vercel or the browser.
+- `DIRECT_DATABASE_URL` and `SUPABASE_JWT_SECRET` are server-only secrets stored in Jony's local `.env`, never committed.
+
+## Tradeoffs
+
+- Laptop offline, asleep, or tunnel stopped means Vercel `/api/*` calls return 5xx/connection failures. This is acceptable for TJ-019; the walkthrough allow-list already tolerates the remaining compute endpoints being unavailable.
+- Direct database connectivity keeps the backend simple, but Jony is responsible for local Docker health, laptop uptime, and tunnel process uptime.
+- Cloudflare Tunnel avoids opening router ports, but it adds one local daemon and DNS configuration step. Tailscale Funnel or ngrok can replace it if Cloudflare setup is inconvenient.
+- Runtime cost is effectively zero beyond laptop/network power.
+
+## How to run it
+
+1. Create a local `.env` from `.env.example` and fill:
+   - `DIRECT_DATABASE_URL` from Supabase project `zvbwgxdgxwgduhhzdwjj` Database settings. Include `sslmode=require` when using the direct Postgres URL.
+   - `SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co`.
+   - `SUPABASE_JWT_SECRET` from Supabase Auth JWT settings if HS256 fallback is needed.
+   - `BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app` or a tighter preview-domain list.
+2. Start the backend only:
+
+   ```bash
+   docker compose -f docker-compose.backend.yml up -d --build
+   docker compose -f docker-compose.backend.yml ps
+   curl http://localhost:8000/health
+   ```
+
+3. Create and run the Cloudflare Tunnel:
+
+   ```bash
+   cloudflared tunnel login
+   cloudflared tunnel create tj-backend
+   cloudflared tunnel route dns tj-backend api.your-domain.example
+   cloudflared tunnel run tj-backend --url http://localhost:8000
+   ```
+
+4. In Vercel, set `NEXT_PUBLIC_API_URL=https://api.your-domain.example` for Production and Preview environments, then redeploy.
+
+## Owner
+
+Kujan owns the Docker/tunnel workflow. Rabin should review the CORS allow-list and JWT verification posture before merge.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,11 +1,18 @@
 # Database
 DATABASE_URL=postgresql://user:password@localhost/trading_journal
 
+# Supabase-backed local Docker compute mode
+DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
+SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
+SUPABASE_JWT_SECRET=your-supabase-jwt-secret-here
+
 # JWT Authentication
 JWT_SECRET_KEY=change-me-to-a-random-secret
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 
 # CORS
+BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
+# Legacy alias still supported for local-only dev
 CORS_ORIGINS=http://localhost:3000
 
 # OpenTelemetry

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 # Set the working directory in the container
 WORKDIR /app

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,74 @@
+# Trading Journal Backend
+
+FastAPI compute backend for Trading Journal. CRUD data paths are moving to Supabase; the remaining FastAPI routes provide compute workflows such as simulations, options projection, backtests, pension uploads, analysis, tax-condor tooling, scanners, pricing, and sync jobs.
+
+## Quick start: backend talking to Supabase locally + tunnel for Vercel
+
+This mode runs only the backend in Docker on Jony's laptop. It does **not** start the legacy local Postgres service from `docker-compose.yml`; the backend connects directly to Supabase Postgres.
+
+### Required environment variables
+
+Copy the root `.env.example` to `.env` and fill these server-only values:
+
+| Variable | Purpose | Where to get it |
+| --- | --- | --- |
+| `DIRECT_DATABASE_URL` | Supabase Postgres or pooler connection string. `docker-compose.backend.yml` passes it through as `DATABASE_URL`. Include `sslmode=require` for direct Supabase Postgres. | Supabase dashboard → project `zvbwgxdgxwgduhhzdwjj` → Database → Connection string |
+| `SUPABASE_URL` | Supabase Auth/JWKS base URL. | `https://zvbwgxdgxwgduhhzdwjj.supabase.co` |
+| `SUPABASE_JWT_SECRET` | Optional HS256 fallback for local/Supabase JWT verification. | Supabase dashboard → Auth → JWT settings |
+| `BACKEND_CORS_ORIGINS` | Comma-separated browser origins allowed to call FastAPI. | Local dev and Vercel deployment URLs |
+
+Recommended local value:
+
+```dotenv
+BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
+```
+
+Use exact preview URLs instead of `https://*.vercel.app` if you want a tighter allow-list.
+
+### Run backend-only Docker compose
+
+```bash
+docker compose -f docker-compose.backend.yml up -d --build
+docker compose -f docker-compose.backend.yml ps
+curl http://localhost:8000/health
+```
+
+The compose file uses the production-style image (no source bind mount and no `--reload`) and publishes `8000:8000`. The `/health` endpoint returns 200 only after a database `SELECT 1` succeeds.
+
+To stop it:
+
+```bash
+docker compose -f docker-compose.backend.yml down
+```
+
+### Cloudflare Tunnel for Vercel
+
+Cloudflare Tunnel is the recommended way to expose the laptop backend without opening router ports.
+
+```bash
+cloudflared tunnel login
+cloudflared tunnel create tj-backend
+cloudflared tunnel route dns tj-backend api.your-domain.example
+cloudflared tunnel run tj-backend --url http://localhost:8000
+```
+
+Alternatives: Tailscale Funnel or ngrok can expose the same local `http://localhost:8000` service. Keep the public URL HTTPS and stable enough for Vercel environment variables.
+
+### Point Vercel at the tunnel
+
+1. Open the Vercel dashboard for `https://trading-journal-cohenjos-projects.vercel.app`.
+2. Set `NEXT_PUBLIC_API_URL` to the tunnel URL, for example `https://api.your-domain.example`.
+3. Apply it to Production and Preview environments.
+4. Redeploy the frontend.
+
+`apps/frontend/next.config.ts` already proxies `/api/*` to `NEXT_PUBLIC_API_URL` when the variable is set to a public URL. If it is unset in production, `/api/*` remains disabled and unmigrated compute calls fail fast with 404.
+
+### Offline behavior
+
+If Jony's laptop is offline, asleep, Docker is stopped, or the tunnel is down, Vercel `/api/*` compute calls fail with 5xx/connection errors. This is an accepted TJ-019 tradeoff: the walkthrough allow-list already tolerates the remaining compute endpoints being unavailable while CRUD paths continue through Supabase.
+
+## Auth and CORS
+
+All compute routers in `main.py` are registered with `Depends(get_current_user)`, which verifies Supabase JWTs using JWKS from `SUPABASE_URL` or the `SUPABASE_JWT_SECRET` fallback. CORS is a tight allow-list read from `BACKEND_CORS_ORIGINS`; do not use `*` for this financial application.
+
+See also [`README-supabase-auth.md`](./README-supabase-auth.md) for JWT verification details.

--- a/apps/backend/app/dal/database.py
+++ b/apps/backend/app/dal/database.py
@@ -1,6 +1,8 @@
 import os
 from urllib.parse import quote_plus
-from sqlmodel import create_engine, Session
+
+from sqlalchemy import text
+from sqlmodel import Session, create_engine
 
 
 def _normalize_database_url(raw_url: str) -> str:
@@ -26,12 +28,26 @@ DATABASE_URL = _normalize_database_url(
     os.getenv("DATABASE_URL", "postgresql://user:password@localhost/trading-journal")
 )
 
-engine = create_engine(DATABASE_URL, echo=True)
+engine = create_engine(
+    DATABASE_URL,
+    echo=os.getenv("DATABASE_ECHO", "false").lower() == "true",
+    pool_pre_ping=True,
+)
 
 
 def create_db_and_tables():
     # SQLModel.metadata.create_all(engine)
     pass
+
+
+def check_database_connection() -> bool:
+    """Return whether the configured database can execute a trivial query."""
+    try:
+        with engine.connect() as connection:
+            connection.execute(text("SELECT 1"))
+        return True
+    except Exception:  # noqa: BLE001 - health endpoint must not leak DB errors
+        return False
 
 
 def get_session():

--- a/apps/backend/app/schema/finance_models.py
+++ b/apps/backend/app/schema/finance_models.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from typing import List, Dict, Optional, Any
+from uuid import UUID
 from pydantic import BaseModel
 from sqlalchemy import Column, Numeric
 from sqlmodel import SQLModel, Field, Column as SMColumn, JSON
@@ -7,21 +8,23 @@ from datetime import date as date_type
 
 # --- Pydantic Schemas for JSON Validation ---
 
+
 class FinanceItem(BaseModel):
     id: str
-    category: str # 'Savings', 'Investments', 'Assets', 'Liabilities'
+    category: str  # 'Savings', 'Investments', 'Assets', 'Liabilities'
     name: str
     value: Decimal
     type: str
     owner: str
     # Priorities for Cash Flow
-    inflow_priority: Optional[int] = 100 # Lower number = Higher priority
+    inflow_priority: Optional[int] = 100  # Lower number = Higher priority
     withdrawal_priority: Optional[int] = 100
     # Withdrawal Limits
-    max_withdrawal_rate: Optional[Decimal] = None # Percentage (0-100)
-    max_withdrawal_cap: Optional[Decimal] = None # Fixed amount (e.g. 200000 for RSU)
-    currency: Optional[str] = 'ILS' # Default to ILS
+    max_withdrawal_rate: Optional[Decimal] = None  # Percentage (0-100)
+    max_withdrawal_cap: Optional[Decimal] = None  # Fixed amount (e.g. 200000 for RSU)
+    currency: Optional[str] = "ILS"  # Default to ILS
     details: Optional[Dict[str, Any]] = None
+
 
 class SnapshotData(BaseModel):
     items: List[FinanceItem] = []
@@ -34,17 +37,19 @@ class SnapshotData(BaseModel):
     net_worth: Decimal
     date: Optional[date_type] = None
 
+
 # --- SQLModel Database Table ---
+
 
 class FinanceSnapshot(SQLModel, table=True):
     __tablename__ = "finance_snapshots"
 
-    household_id: str = Field(foreign_key="households.id", primary_key=True)
+    household_id: UUID = Field(foreign_key="households.id", primary_key=True)
     date: date_type = Field(primary_key=True)
-    
+
     # Store the entire snapshot as a JSON document
     data: Dict = Field(sa_column=SMColumn(JSON, nullable=False))
-    
+
     # We can also store top-level metrics as columns for easy SQL aggregation/graphing
     # without needing JSON extraction syntax in every query.
     net_worth: Decimal = Field(sa_column=Column(Numeric(18, 6)))

--- a/apps/backend/app/schema/plan_models.py
+++ b/apps/backend/app/schema/plan_models.py
@@ -1,28 +1,30 @@
 from datetime import datetime, date as date_type
 from decimal import Decimal
 from typing import List, Dict, Optional, Union
+from uuid import UUID
 from pydantic import BaseModel
 from sqlmodel import SQLModel, Field, Column, JSON
 
 # --- Pydantic Schemas for JSON Validation ---
 
+
 class PlanItem(BaseModel):
     id: str
-    name: str # e.g. "Salary", "Rent"
-    category: str # "Income", "Expense", "Asset" 
-    sub_category: Optional[str] = None # "Salary", "Housing"
-    owner: str # "You", "Spouse"
-    currency: str = "ILS" # "USD", "ILS", "EUR"
-    
+    name: str  # e.g. "Salary", "Rent"
+    category: str  # "Income", "Expense", "Asset"
+    sub_category: Optional[str] = None  # "Salary", "Housing"
+    owner: str  # "You", "Spouse"
+    currency: str = "ILS"  # "USD", "ILS", "EUR"
+
     # Financials
-    value: Decimal = Decimal("0") # Annual Amount or Current Value
-    growth_rate: Decimal = Decimal("0") # Percentage
-    
+    value: Decimal = Decimal("0")  # Annual Amount or Current Value
+    growth_rate: Decimal = Decimal("0")  # Percentage
+
     # Timing
-    start_date: Optional[Union[date_type, str]] = None # specific date or "Today"
-    end_date: Optional[Union[date_type, str]] = None # specific date or "Retirement"
-    frequency: str = "Yearly" # "Monthly", "Yearly", "OneTime"
-    
+    start_date: Optional[Union[date_type, str]] = None  # specific date or "Today"
+    end_date: Optional[Union[date_type, str]] = None  # specific date or "Retirement"
+    frequency: str = "Yearly"  # "Monthly", "Yearly", "OneTime"
+
     # New Fields matching Frontend types.ts
     tax_rate: Optional[Decimal] = Decimal("0")
     start_condition: Optional[str] = None
@@ -30,49 +32,53 @@ class PlanItem(BaseModel):
     end_condition: Optional[str] = None
     end_reference: Optional[str] = None
     recurrence: Optional[Dict] = None
-    
+
     # Priorities
     inflow_priority: Optional[int] = 100
     withdrawal_priority: Optional[int] = 100
-    
+
     # Account Settings (Top Level)
     # Commons keys: type, bond_allocation, dividend_yield, fees, withdrawal_priority
-    # Dividend Policy keys: dividend_policy ('Accumulate'|'Payout'), dividend_mode ('Percent'|'Fixed'), 
+    # Dividend Policy keys: dividend_policy ('Accumulate'|'Payout'), dividend_mode ('Percent'|'Fixed'),
     # dividend_fixed_amount, dividend_growth_rate, dividend_tax_rate
     # Dividend Timing: dividend_payout_start_condition ('Immediate'|'Age'|'Milestone'|'Date'), dividend_payout_start_reference
     account_settings: Optional[Dict] = {}
-    
+
     # Details
-    details: Dict = {} # Flexible for other props like "tax_treatment", "financing"
+    details: Dict = {}  # Flexible for other props like "tax_treatment", "financing"
+
 
 class PlanMilestone(BaseModel):
     id: str
     name: str
     date: Optional[Union[date_type, str]] = None
-    year_offset: Optional[int] = None # e.g. 20 (years from now)
-    type: str = "Custom" # "Retirement", "Financial Independence", "Debt Free", "Life Expectancy"
+    year_offset: Optional[int] = None  # e.g. 20 (years from now)
+    type: str = "Custom"  # "Retirement", "Financial Independence", "Debt Free", "Life Expectancy"
     details: Dict = {}
     icon: Optional[str] = None
     color: Optional[str] = None
     owner: Optional[str] = "You"
+
 
 class PlanData(BaseModel):
     items: List[PlanItem] = []
     milestones: List[PlanMilestone] = []
     settings: Dict = {}
 
+
 # --- SQLModel Database Table ---
+
 
 class Plan(SQLModel, table=True):
     __tablename__ = "plans"
 
     id: Optional[int] = Field(default=None, primary_key=True)
-    household_id: Optional[str] = Field(default=None, foreign_key="households.id", index=True)
+    household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)
     name: str
     description: Optional[str] = None
-    
+
     # Store complex structure as JSON
     data: Dict = Field(sa_column=Column(JSON, nullable=False))
-    
+
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -1,4 +1,6 @@
 import json
+import os
+import re
 
 from fastapi import Depends, FastAPI
 from fastapi.responses import JSONResponse
@@ -6,7 +8,7 @@ import uvicorn
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
-from app.dal.database import create_db_and_tables
+from app.dal.database import check_database_connection, create_db_and_tables
 from app.utils.decimal_encoder import decimal_default
 from app.dependencies import get_current_user
 from app.api import (
@@ -31,7 +33,6 @@ from app.api import (
     insurance,
     metrics as telemetry_metrics,
 )
-import os
 from opentelemetry import trace, metrics
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -44,24 +45,18 @@ from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.sdk.resources import Resource
 
 # Setup OTel
-resource = Resource.create(attributes={
-    "service.name": os.getenv("OTEL_SERVICE_NAME", "trading-journal-backend")
-})
+resource = Resource.create(attributes={"service.name": os.getenv("OTEL_SERVICE_NAME", "trading-journal-backend")})
 
 trace.set_tracer_provider(TracerProvider(resource=resource))
 tracer_provider = trace.get_tracer_provider()
 otlp_exporter = OTLPSpanExporter(
-    endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
-    insecure=True
+    endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"), insecure=True
 )
 span_processor = BatchSpanProcessor(otlp_exporter)
 tracer_provider.add_span_processor(span_processor)
 
 metric_reader = PeriodicExportingMetricReader(
-    OTLPMetricExporter(
-        endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"),
-        insecure=True
-    )
+    OTLPMetricExporter(endpoint=os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317"), insecure=True)
 )
 meter_provider = MeterProvider(resource=resource, metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
@@ -71,6 +66,7 @@ LoggingInstrumentor().instrument(set_logging_format=True)
 
 class DecimalSafeJSONResponse(JSONResponse):
     """JSONResponse that serializes Decimal values as numbers (float)."""
+
     def render(self, content) -> bytes:
         return json.dumps(
             content,
@@ -123,6 +119,7 @@ async def _warmup_jwks_cache() -> None:
     except Exception as exc:  # noqa: BLE001
         print(f"Supabase auth settings not configured (non-fatal): {type(exc).__name__}: {exc}")
 
+
 app = FastAPI(
     title="Trading Journal API",
     description="API for managing trades, portfolios, pensions, insurance, and financial analysis",
@@ -136,16 +133,37 @@ app = FastAPI(
 # Instrument FastAPI
 FastAPIInstrumentor.instrument_app(app)
 
-# CORS: restrict origins. Set CORS_ORIGINS env var (comma-separated) for production.
-cors_origins = [
-    o.strip()
-    for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")
-    if o.strip()
-]
+
+def _cors_settings() -> tuple[list[str], str | None]:
+    """Build CORS exact-origin and wildcard-regex settings from env."""
+    raw_origins = os.getenv(
+        "BACKEND_CORS_ORIGINS",
+        os.getenv("CORS_ORIGINS", "http://localhost:3000"),
+    )
+    exact_origins: list[str] = []
+    wildcard_patterns: list[str] = []
+
+    for origin in (item.strip() for item in raw_origins.split(",")):
+        if not origin:
+            continue
+        if "*" in origin:
+            wildcard_patterns.append(re.escape(origin).replace(r"\*", r"[^/]*"))
+        else:
+            exact_origins.append(origin)
+
+    allow_origin_regex = None
+    if wildcard_patterns:
+        allow_origin_regex = rf"^({'|'.join(wildcard_patterns)})$"
+
+    return exact_origins, allow_origin_regex
+
+
+cors_origins, cors_origin_regex = _cors_settings()
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=cors_origins,
+    allow_origin_regex=cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -154,13 +172,33 @@ app.add_middleware(
 app.add_middleware(SecurityHeadersMiddleware)
 
 # Public paths that skip JWT authentication
-PUBLIC_PATHS = {"/", "/docs", "/redoc", "/openapi.json", "/api/auth/register", "/api/auth/login"}
+PUBLIC_PATHS = {
+    "/",
+    "/health",
+    "/health/auth",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/api/auth/register",
+    "/api/auth/login",
+}
 
 
 @app.get("/")
 def read_root():
     """Health-check root endpoint."""
     return {"Hello": "World"}
+
+
+@app.get("/health", tags=["health"])
+def health():
+    """Return healthy only when the database connection succeeds."""
+    if check_database_connection():
+        return {"status": "ok", "database": "ok"}
+    return JSONResponse(
+        status_code=503,
+        content={"status": "error", "database": "unavailable"},
+    )
 
 
 @app.get("/health/auth", tags=["health"])
@@ -180,6 +218,7 @@ def health_auth():
         "key_count": cache.key_count,
         "populated": cache.is_populated,
     }
+
 
 # Auth router (public endpoints — registered first, no auth dependency)
 app.include_router(auth_router_module.router)

--- a/apps/backend/tests/conftest.py
+++ b/apps/backend/tests/conftest.py
@@ -7,7 +7,10 @@ and common test data factories.
 import sys
 import pathlib
 from typing import Generator
+from uuid import UUID
 import pytest
+from sqlalchemy import Column, String, Table, event
+from sqlalchemy.engine import Engine
 from sqlmodel import SQLModel, Session, create_engine
 from sqlalchemy.pool import StaticPool
 from fastapi.testclient import TestClient
@@ -17,17 +20,57 @@ from httpx import AsyncClient, ASGITransport
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
 
 from app.dal.database import get_session
-from app.auth.dependencies import get_current_user
-from app.schema.user_models import User
+from app.dependencies import get_current_user
+from app.supabase_auth import SupabaseClaims
+from app.schema import (  # noqa: F401
+    backtest_models,
+    bond_models,
+    dividend_models,
+    finance_models,
+    insurance_models,
+    ladder_models,
+    models,
+    options_models,
+    plan_models,
+    trading_models,
+)
+from app.schema.household_models import Household, HouseholdMember
+
+
+TEST_USER_ID = UUID("00000000-0000-0000-0000-000000000001")
+TEST_HOUSEHOLD_ID = UUID("00000000-0000-0000-0000-000000000101")
+
+
+Table(
+    "users",
+    SQLModel.metadata,
+    Column("id", String, primary_key=True),
+    schema="auth",
+    extend_existing=True,
+)
+
+
+@event.listens_for(Engine, "connect")
+def _attach_auth_schema(dbapi_connection, _connection_record) -> None:
+    """Attach an in-memory auth schema for Supabase FK targets in SQLite tests."""
+    if dbapi_connection.__class__.__module__ != "sqlite3":
+        return
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute("ATTACH DATABASE ':memory:' AS auth")
+    except Exception:
+        pass
+    finally:
+        cursor.close()
 
 
 @pytest.fixture(name="engine")
 def engine_fixture():
     """Create an in-memory SQLite engine for testing.
-    
+
     Uses StaticPool to ensure the same in-memory database is used across
     multiple connections within a test.
-    
+
     Returns:
         Engine: SQLAlchemy engine configured for testing
     """
@@ -37,19 +80,21 @@ def engine_fixture():
         poolclass=StaticPool,
     )
     SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        _seed_household(session)
     return engine
 
 
 @pytest.fixture(name="session")
 def session_fixture(engine) -> Generator[Session, None, None]:
     """Create a database session for testing.
-    
+
     This fixture creates a new session for each test and automatically
     rolls back changes after the test completes.
-    
+
     Args:
         engine: The test database engine fixture
-        
+
     Yields:
         Session: SQLModel session for database operations
     """
@@ -57,29 +102,55 @@ def session_fixture(engine) -> Generator[Session, None, None]:
         yield session
 
 
+def _seed_household(session: Session) -> None:
+    """Seed the Supabase household membership expected by protected routes."""
+    session.add(
+        Household(
+            id=TEST_HOUSEHOLD_ID,
+            name="Test Household",
+            created_by=TEST_USER_ID,
+        )
+    )
+    session.add(
+        HouseholdMember(
+            household_id=TEST_HOUSEHOLD_ID,
+            user_id=TEST_USER_ID,
+            role="owner",
+            invited_by=TEST_USER_ID,
+        )
+    )
+    session.commit()
+
+
 def _fake_current_user():
-    """Return a stub user for tests that bypass real auth."""
-    return User(id=1, username="testuser", hashed_password="x", is_active=True)
+    """Return stub Supabase claims for tests that bypass real auth."""
+    return SupabaseClaims(
+        sub=TEST_USER_ID,
+        email="testuser@example.com",
+        role="authenticated",
+        aud="authenticated",
+        exp=4_102_444_800,
+    )
 
 
 @pytest.fixture(name="client")
 def client_fixture(session: Session) -> Generator[TestClient, None, None]:
     """Create a FastAPI TestClient with dependency overrides.
-    
+
     Provides an authenticated test client by default — all protected
     endpoints are accessible without a real JWT.
     """
     from main import app
-    
+
     def get_session_override():
         return session
-    
+
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_user] = _fake_current_user
-    
+
     with TestClient(app) as client:
         yield client
-    
+
     app.dependency_overrides.clear()
 
 
@@ -106,21 +177,18 @@ def unauth_client_fixture(session: Session) -> Generator[TestClient, None, None]
 @pytest.fixture(name="async_client")
 async def async_client_fixture(session: Session) -> Generator[AsyncClient, None, None]:
     """Create an async HTTPX client for testing async API endpoints.
-    
+
     Provides an authenticated async client by default.
     """
     from main import app
-    
+
     def get_session_override():
         return session
-    
+
     app.dependency_overrides[get_session] = get_session_override
     app.dependency_overrides[get_current_user] = _fake_current_user
-    
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test"
-    ) as client:
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         yield client
-    
+
     app.dependency_overrides.clear()

--- a/apps/backend/tests/test_auth.py
+++ b/apps/backend/tests/test_auth.py
@@ -7,6 +7,7 @@ from app.auth.security import hash_password, verify_password, create_access_toke
 # Unit tests for security helpers
 # ---------------------------------------------------------------------------
 
+
 class TestPasswordHashing:
     def test_hash_and_verify(self):
         hashed = hash_password("secret123")
@@ -31,6 +32,7 @@ class TestJWT:
 # ---------------------------------------------------------------------------
 # Integration tests for auth endpoints
 # ---------------------------------------------------------------------------
+
 
 class TestRegister:
     def test_register_success(self, unauth_client):
@@ -107,7 +109,7 @@ class TestProtectedRoutes:
     def test_protected_route_rejects_no_auth(self, unauth_client):
         """Any data endpoint should reject unauthenticated requests."""
         resp = unauth_client.get("/api/holdings")
-        assert resp.status_code == 403
+        assert resp.status_code == 401
 
     def test_health_check_public(self, unauth_client):
         """Root health-check must remain public."""

--- a/apps/backend/tests/test_pension_api.py
+++ b/apps/backend/tests/test_pension_api.py
@@ -1,4 +1,5 @@
 from datetime import date
+from uuid import UUID
 
 from sqlmodel import SQLModel, Session, create_engine, select
 
@@ -16,12 +17,17 @@ from app.api.pension import (
     upsert_snapshot_pension,
 )
 from app.schema.finance_models import FinanceSnapshot
+from app.schema.household_models import Household, HouseholdMember
 from app.schema.plan_models import Plan
+
+TEST_USER_ID = UUID("00000000-0000-0000-0000-000000000001")
+TEST_HOUSEHOLD_ID = UUID("00000000-0000-0000-0000-000000000101")
 
 
 def make_snapshot(snapshot_date: date, items: list[dict]) -> FinanceSnapshot:
     total_investments = sum(item.get("value", 0) for item in items)
     return FinanceSnapshot(
+        household_id=TEST_HOUSEHOLD_ID,
         date=snapshot_date,
         data={
             "items": items,
@@ -37,13 +43,28 @@ def make_snapshot(snapshot_date: date, items: list[dict]) -> FinanceSnapshot:
 
 
 def make_plan() -> Plan:
-    return Plan(name="Retirement Plan", data={"items": [], "milestones": [], "settings": {}})
+    return Plan(
+        household_id=TEST_HOUSEHOLD_ID,
+        name="Retirement Plan",
+        data={"items": [], "milestones": [], "settings": {}},
+    )
 
 
 def make_session() -> Session:
     engine = create_engine("sqlite://", connect_args={"check_same_thread": False})
     SQLModel.metadata.create_all(engine)
-    return Session(engine)
+    session = Session(engine)
+    session.add(Household(id=TEST_HOUSEHOLD_ID, name="Test Household", created_by=TEST_USER_ID))
+    session.add(
+        HouseholdMember(
+            household_id=TEST_HOUSEHOLD_ID,
+            user_id=TEST_USER_ID,
+            role="owner",
+            invited_by=TEST_USER_ID,
+        )
+    )
+    session.commit()
+    return session
 
 
 def test_extract_pension_payload_separates_owner_product_and_account() -> None:
@@ -256,10 +277,8 @@ def test_delete_pension_removes_history_and_plan_entries() -> None:
     session.add(plan)
     session.commit()
 
-    response = delete_pension(gemel["id"], db=session)
-    persisted_snapshots = session.exec(
-        select(FinanceSnapshot).order_by(FinanceSnapshot.date.asc())
-    ).all()
+    response = delete_pension(gemel["id"], db=session, user_id=TEST_USER_ID)
+    persisted_snapshots = session.exec(select(FinanceSnapshot).order_by(FinanceSnapshot.date.asc())).all()
     persisted_plan = session.exec(select(Plan)).first()
     dashboard = build_pension_dashboard_payload(persisted_snapshots, persisted_plan)
 
@@ -331,9 +350,7 @@ def test_upload_propagates_to_latest_snapshot() -> None:
     assert latest_items[0]["id"] == payload["id"]
 
     # Dashboard (reads from latest snapshot) must surface the pension
-    dashboard = build_pension_dashboard_payload(
-        [report_snapshot, latest_snapshot], plan
-    )
+    dashboard = build_pension_dashboard_payload([report_snapshot, latest_snapshot], plan)
     account_ids = [a["id"] for a in dashboard["accounts"]]
     assert payload["id"] in account_ids
 
@@ -363,9 +380,11 @@ def test_upload_creates_new_snapshot_when_none_exist() -> None:
     assert session.exec(select(FinanceSnapshot)).first() is None
 
     snapshot = FinanceSnapshot(
+        household_id=TEST_HOUSEHOLD_ID,
         date=target_date,
-        data=copy.deepcopy({"items": [], "total_savings": 0.0, "total_investments": 0.0,
-                            "total_assets": 0.0, "total_liabilities": 0.0}),
+        data=copy.deepcopy(
+            {"items": [], "total_savings": 0.0, "total_investments": 0.0, "total_assets": 0.0, "total_liabilities": 0.0}
+        ),
         net_worth=0.0,
         total_assets=0.0,
         total_liabilities=0.0,

--- a/apps/backend/tests/test_simulation.py
+++ b/apps/backend/tests/test_simulation.py
@@ -1,15 +1,5 @@
-
-from fastapi.testclient import TestClient
-from app.auth.dependencies import get_current_user
-from app.schema.user_models import User
-from main import app
-
-app.dependency_overrides[get_current_user] = lambda: User(
-    id=1, username="testuser", hashed_password="x", is_active=True
-)
-client = TestClient(app)
-
-def test_plan_simulation_structure():
+def test_plan_simulation_structure(client):
+    """Plan simulation returns the expected projection shape."""
     # 1. Define a Mock Plan
     plan_data = {
         "items": [
@@ -17,12 +7,12 @@ def test_plan_simulation_structure():
                 "id": "job1",
                 "name": "My Job",
                 "category": "Income",
-                "sub_category": "Earned Income", 
+                "sub_category": "Earned Income",
                 "owner": "You",
                 "value": 100000,
                 "growth_rate": 0,
                 "start_condition": "Now",
-                "tax_rate": 20
+                "tax_rate": 20,
             },
             {
                 "id": "rent1",
@@ -32,78 +22,75 @@ def test_plan_simulation_structure():
                 "owner": "You",
                 "value": 30000,
                 "growth_rate": 0,
-                "start_condition": "Now"
+                "start_condition": "Now",
             },
-             {
+            {
                 "id": "acc1",
                 "name": "My 401k",
                 "category": "Account",
                 "owner": "You",
                 "value": 50000,
                 "growth_rate": 5,
-                "details": {
-                    "account_settings": { "type": "401k" }
-                }
-            }
+                "details": {"account_settings": {"type": "401k"}},
+            },
         ],
         "milestones": [],
-        "settings": {}
+        "settings": {},
     }
 
     request_payload = {
         "plan": plan_data,
-        "finances": None, # Will use defaults or trigger empty if no DB access, but service handles None
-        "settings": { "primaryUser": { "birthYear": 1990 } }
+        "finances": None,  # Will use defaults or trigger empty if no DB access, but service handles None
+        "settings": {"primaryUser": {"birthYear": 1990}},
     }
 
     # 2. Call the Endpoint
     response = client.post("/api/plans/simulate", json=request_payload)
-    
+
     if response.status_code != 200:
         print(response.json())
 
     # 3. Assertions
     assert response.status_code == 200
     data = response.json()
-    
+
     assert isinstance(data, list)
     assert len(data) > 0
-    
+
     first_year = data[0]
-    
+
     # Check Schema Keys
     assert "income_details" in first_year
     assert "expense_details" in first_year
     assert "savings_details" in first_year
-    
+
     # Check Calculations (Year 1)
     # Income: 100k
     assert first_year["income"] == 100000.0
-    
+
     # Tax: 20% of 100k = 20k
     assert first_year["tax_paid"] == 20000.0
-    
+
     # Expenses: 30k
     assert first_year["expenses"] == 30000.0
-    
+
     # Net Flow = 100k - 20k - 30k = 50k
     # Should flow into savings
     # Expected Net Worth improvement roughly 50k + investment growth
-    
+
     # Check Details
     incomes = first_year["income_details"]
     assert len(incomes) == 1
     assert incomes[0]["name"] == "My Job"
     assert incomes[0]["value"] == 100000.0
-    
+
     expenses = first_year["expense_details"]
     assert len(expenses) == 1
     assert expenses[0]["name"] == "Apartment Rent"
-    
+
     # Savings Breakdown check
     # We expect some savings if Net Flow is positive
     savings = first_year["savings_details"]
     assert len(savings) > 0
     total_savings_flow = sum(s["value"] for s in savings)
     assert total_savings_flow == 50000.0
-

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,0 +1,26 @@
+services:
+  backend:
+    container_name: trading_journal_backend_supabase
+    build:
+      context: ./apps/backend
+      dockerfile: Dockerfile
+    command: ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+    ports:
+      - "8000:8000"
+    environment:
+      DATABASE_URL: ${DIRECT_DATABASE_URL:?Set DIRECT_DATABASE_URL to the Supabase Postgres or pooler connection string}
+      SUPABASE_URL: ${SUPABASE_URL:?Set SUPABASE_URL to https://zvbwgxdgxwgduhhzdwjj.supabase.co}
+      SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}
+      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:-http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-trading-journal-backend-local-docker}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4317}
+    restart: unless-stopped
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()"
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s


### PR DESCRIPTION
## Summary

- Adds the TJ-019 ADR: `.squad/decisions/inbox/kujan-tj019-local-docker-compute.md`.
- Adds `docker-compose.backend.yml` for backend-only local Docker against Supabase via `DIRECT_DATABASE_URL` (no local Postgres dependency).
- Reads `BACKEND_CORS_ORIGINS` in FastAPI with exact origins plus `https://*.vercel.app` wildcard-regex support.
- Adds DB-backed `/health`, Supabase env templates, and the backend runbook for Cloudflare Tunnel + Vercel `NEXT_PUBLIC_API_URL`.
- Aligns finance/plan household IDs with Supabase UUID schema and updates backend tests/fixtures for Supabase auth + household membership.

Previous ADR PR #193 was closed in favor of this local Docker + tunnel decision.

Rabin: please review the CORS allow-list behavior and JWT verification posture.

Closes #189