### PR TITLE
arch(TJ-020): rearchitect backend as Supabase-table worker (no frontend HTTP)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,6 @@
 # FRONTEND — Next.js (🟢 Public — safe in browser bundle; NEXT_PUBLIC_ prefix required)
 # =============================================================================
 
-# Base URL of the FastAPI backend.
-# Production Vercel deployments MUST set this to a public backend URL; localhost/private IPs are rejected.
-NEXT_PUBLIC_API_URL=http://localhost:8000
-
 # Supabase project REST + Auth endpoint (from `supabase status` or Supabase dashboard)
 NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 
@@ -17,8 +13,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 # Canonical app URL for Supabase auth redirects (e.g. http://localhost:3000 locally)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
+# NEXT_PUBLIC_API_URL is intentionally not used. The frontend talks only to
+# Supabase tables, Auth, Storage, and Realtime; it never proxies to the backend.
+# NEXT_PUBLIC_API_URL=
+
 # =============================================================================
-# BACKEND — FastAPI Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
+# BACKEND — Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
 # =============================================================================
 
 # Full PostgreSQL connection string for legacy local-dev compose (includes credentials — treat as secret)
@@ -28,23 +28,21 @@ DATABASE_URL=postgresql://user:password@localhost:5432/trading-journal
 # Include sslmode=require when using Supabase direct Postgres.
 DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
 
-# Supabase project URL for backend JWT/JWKS verification.
-SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
+# Supabase project URL for backend Auth/JWKS checks and Storage access.
+SUPABASE_URL=https://your-project-ref.supabase.co
 
-# Browser origins allowed to call FastAPI. Supports comma-separated exact origins and limited wildcards.
-BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
-
-# HMAC-SHA256 signing key for internal JWT tokens — rotate every 90 days
-JWT_SECRET_KEY=your-jwt-secret-key-min-32-chars-here
-
-# JWT token expiry in minutes (default: 60)
-ACCESS_TOKEN_EXPIRE_MINUTES=60
-
-# Supabase service-role key — NEVER add NEXT_PUBLIC_ prefix — bypasses RLS entirely
+# Supabase service-role key — NEVER add NEXT_PUBLIC_ prefix — bypasses RLS entirely.
+# Server-only worker uses this only for Storage access or privileged writes.
 SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
 
 # Supabase JWT secret — only needed if doing manual JWT verification server-side
 SUPABASE_JWT_SECRET=your-supabase-jwt-secret-here
+
+# HMAC-SHA256 signing key for legacy internal JWT tokens — rotate every 90 days
+JWT_SECRET_KEY=your-jwt-secret-key-min-32-chars-here
+
+# JWT token expiry in minutes (default: 60)
+ACCESS_TOKEN_EXPIRE_MINUTES=60
 
 # =============================================================================
 # BACKEND — IB Gateway connection

--- a/.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md
+++ b/.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md
@@ -1,0 +1,70 @@
+# ADR: TJ-019/TJ-020 frontend Supabase-only compute architecture
+
+## Status
+
+Accepted for Phase A. This replaces the TJ-019 tunnel-based backend exposure plan and becomes the canonical direction for TJ-020 implementation work.
+
+## Decision
+
+The Trading Journal frontend deployed on Vercel will only communicate with Supabase: tables, Auth, Storage, and Realtime. The frontend must not make HTTP calls to the Python backend, and there is no backend `NEXT_PUBLIC_API_URL`, browser CORS allow-list, tunnel, or public laptop endpoint in the target architecture.
+
+The Python backend remains valuable, but its role changes from HTTP API to local worker. It runs in Docker on Jony's laptop, reads inputs from Supabase with a server-only credential or scoped database connection, executes existing compute modules under `apps/backend/app/`, and writes results back to dedicated Supabase result tables. FastAPI may continue to expose `/health` for local liveness checks; business endpoints are not frontend integration points and should be removed or made admin-only as Phase B proceeds.
+
+## Rationale
+
+- No tunnel is required, so Vercel never depends on reaching a laptop over a public URL.
+- No browser CORS allow-list is required for the backend because browsers never call it.
+- Jony's laptop is not publicly exposed, reducing the attack surface for a financial application.
+- Supabase remains the source of truth: the frontend reads authenticated rows, subscribes to result changes, and uses Storage for user files.
+- Existing Python computation code can be retained and moved behind worker orchestration without forcing an immediate rewrite.
+
+## Backend operating modes
+
+### Scheduled batch (default)
+
+For data that can be precomputed, the backend runs on a timer, recomputes the dataset, and upserts/overwrites result tables in Supabase. APScheduler in the backend process is the preferred MVP because it keeps scheduling next to the Python compute code. Cron inside the worker container is acceptable if APScheduler introduces operational issues.
+
+Examples: ticker analysis, growth stories, bond scanner results, price cache refreshes, NDX sync, and broker sync jobs.
+
+### Job queue table (on-demand)
+
+For user-triggered heavy compute, a Next.js Server Action inserts a row into a Supabase queue table such as `compute_jobs` with an input payload and `status = 'pending'`. The backend polls for pending jobs every 10 seconds for the MVP, claims one with a transactional status update, runs the Python computation, writes the result table row, and marks the job `done` or `failed`. The frontend subscribes to the job/result row via Supabase Realtime and never calls the backend directly.
+
+LISTEN/NOTIFY or Supabase Realtime-triggered workers can replace polling later, but polling every 10 seconds is the canonical Phase B MVP.
+
+## Tradeoff
+
+When Jony's laptop is offline, asleep, or Docker is stopped, scheduled result tables become stale and pending jobs queue up. This is acceptable per Jony. The user-facing app continues to load because Vercel reads Supabase tables directly; stale timestamps and pending job statuses are visible data states, not HTTP outages.
+
+## Endpoint classification
+
+CRUD/read paths that have already moved or will move directly to Supabase tables are outside this compute matrix. The rows below classify the remaining FastAPI compute, external-data, and side-effect endpoints that must stop being frontend HTTP dependencies.
+
+| Endpoint | Mode | Result table | Notes |
+|---|---|---|---|
+| `/api/plans/simulate` | Server Action preferred; job queue if profiling shows it is too heavy | n/a or `plan_simulations` | Math-only projection path using plan/finance inputs. Port to TypeScript Server Action first; fall back to queued Python worker if runtime or parity risk is too high. |
+| `/api/options/projection` | Server Action | n/a | Analytics math over options income records. Keep computation colocated with the frontend action that reads Supabase rows. |
+| `/api/tax-condor/*` and `/api/tax_condor/*` | Server Action | n/a | Math/recommendation workflow. If live IB data remains required, split live-data refresh into scheduled broker tables and keep recommendation math in a Server Action. |
+| `/api/backtest` | Job queue (on-demand) | `backtest_runs` | Heavy, per-config compute. Server Action inserts a job; worker writes run status, metrics, and trades to `backtest_runs`. Lightweight metadata such as available years moves to a Server Action or market-data table read. |
+| `/api/analyze/*` (yfinance, growth_story) | Batch (daily) | `analysis_tickers`, `analysis_growth_stories` | External yfinance/news-style data. Worker refreshes known/watchlisted tickers and writes freshness/error state. |
+| `/api/bonds/scanner` | Batch (daily) | `bond_scanner_results` | External/curated bond universe. Worker refreshes daily; frontend filters Supabase rows. |
+| `/api/finances/price` | Batch (hourly) | `price_cache` | External lookup/cache. Frontend reads latest price row and freshness. |
+| `/api/ndx/sync` | Batch (daily after market close) | existing `ndx_*` tables | Worker syncs market data after close. Frontend reads existing NDX tables. |
+| `/api/trading/sync` | Batch (frequent, with IB Gateway) | existing trading tables | IB-dependent laptop worker refreshes account summaries/positions, then propagates dependent dividend syncs as a follow-up worker step. |
+| `/api/pension/upload` | Storage trigger / poll | parsed rows in pension tables | User uploads PDF to Supabase Storage. Worker polls Storage bucket for new files, parses, writes pension tables, and records parse status. |
+
+The wildcard rows above intentionally cover the concrete FastAPI routes currently grouped under those routers, such as `/api/analyze/fundamentals/{ticker}`, `/api/analyze/price-history/{ticker}`, `/api/analyze/technicals/{ticker}`, `/api/analyze/options/{ticker}`, `/api/analyze/synthesis/{ticker}`, `/api/analyze/growth-story/{ticker}`, `/api/backtest/run`, `/api/backtest/years`, and `/api/trading/sync-to-dividends`.
+
+## Phase B implementation requirements
+
+- Every new result table in an exposed schema must have RLS enabled and policies matching its read/write model.
+- Service-role keys remain server-only and must never use a `NEXT_PUBLIC_` prefix.
+- Worker writes should include `refreshed_at`, `source`, and error/status fields so the frontend can represent stale or failed refreshes.
+- Frontend migrations are complete only when no `/api/*` references remain for the endpoint being migrated.
+- FastAPI business routes should become admin-only maintenance affordances or be removed after their worker replacement lands.
+
+## Consequences
+
+- PR #206's tunnel-based pivot is superseded.
+- TJ-020 becomes the umbrella for Phase B scheduler, job queue, result table, and frontend migration work.
+- Rabin should review service-role-key handling before any Phase B worker writes are merged.

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,20 +1,21 @@
 # Database
 DATABASE_URL=postgresql://user:password@localhost/trading_journal
 
-# Supabase-backed local Docker compute mode
+# Supabase-backed local Docker worker mode
 DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
-SUPABASE_URL=https://zvbwgxdgxwgduhhzdwjj.supabase.co
+SUPABASE_URL=https://your-project-ref.supabase.co
+
+# Server-only Supabase key for Storage access or privileged worker writes.
+# NEVER expose this in frontend code and NEVER add a NEXT_PUBLIC_ prefix.
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key-here
+
+# Optional fallback for legacy/manual JWT verification
 SUPABASE_JWT_SECRET=your-supabase-jwt-secret-here
 
-# JWT Authentication
+# Legacy JWT Authentication
 JWT_SECRET_KEY=change-me-to-a-random-secret
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 
-# CORS
-BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
-# Legacy alias still supported for local-only dev
-CORS_ORIGINS=http://localhost:3000
-
 # OpenTelemetry
-OTEL_SERVICE_NAME=trading-journal-backend
+OTEL_SERVICE_NAME=trading-journal-backend-worker
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,74 +1,86 @@
-# Trading Journal Backend
+# Trading Journal Backend Worker
 
-FastAPI compute backend for Trading Journal. CRUD data paths are moving to Supabase; the remaining FastAPI routes provide compute workflows such as simulations, options projection, backtests, pension uploads, analysis, tax-condor tooling, scanners, pricing, and sync jobs.
+The backend is a private Python worker for Trading Journal computations. It is not a public web service and the Vercel frontend must not call it over HTTP. The frontend reads and writes Supabase tables, Auth, Storage, and Realtime only.
 
-## Quick start: backend talking to Supabase locally + tunnel for Vercel
+The worker runs in Docker on Jony's laptop, reads inputs from Supabase, executes the existing Python modules under `apps/backend/app/`, and writes computed outputs back to Supabase result tables. FastAPI may stay running for local `/health` liveness checks, but business routes are legacy/admin-only until Phase B removes or replaces them.
 
-This mode runs only the backend in Docker on Jony's laptop. It does **not** start the legacy local Postgres service from `docker-compose.yml`; the backend connects directly to Supabase Postgres.
+## What this backend does
 
-### Required environment variables
+- **Scheduled batch compute:** refresh pre-computable datasets on a timer and write result tables such as ticker analysis, bond scanner results, price cache rows, NDX data, and broker/trading snapshots.
+- **Job queue compute:** poll Supabase job-request rows for user-triggered heavy work, run the Python computation, write results, and update job status.
+- **Storage processing:** poll or react to Supabase Storage uploads, parse files such as pension PDFs, and write parsed rows/status to Supabase tables.
+- **Local health:** expose `/health` inside the container, and optionally on `127.0.0.1:8000`, so the laptop operator can verify the worker is alive.
 
-Copy the root `.env.example` to `.env` and fill these server-only values:
+## Required environment
 
-| Variable | Purpose | Where to get it |
+Copy the root `.env.example` or `apps/backend/.env.example` to a local `.env` and fill server-only values. Never commit real credentials.
+
+| Variable | Required | Purpose |
 | --- | --- | --- |
-| `DIRECT_DATABASE_URL` | Supabase Postgres or pooler connection string. `docker-compose.backend.yml` passes it through as `DATABASE_URL`. Include `sslmode=require` for direct Supabase Postgres. | Supabase dashboard → project `zvbwgxdgxwgduhhzdwjj` → Database → Connection string |
-| `SUPABASE_URL` | Supabase Auth/JWKS base URL. | `https://zvbwgxdgxwgduhhzdwjj.supabase.co` |
-| `SUPABASE_JWT_SECRET` | Optional HS256 fallback for local/Supabase JWT verification. | Supabase dashboard → Auth → JWT settings |
-| `BACKEND_CORS_ORIGINS` | Comma-separated browser origins allowed to call FastAPI. | Local dev and Vercel deployment URLs |
+| `DATABASE_URL` | Yes | Supabase Postgres direct or pooler connection string used by the worker for reads and writes. Use an elevated role only on the server-side worker and include `sslmode=require` for Supabase-hosted Postgres. |
+| `DIRECT_DATABASE_URL` | Compose convenience | `docker-compose.backend.yml` maps this value into `DATABASE_URL`; set it to the Supabase direct or pooler URL. |
+| `SUPABASE_URL` | Yes | Supabase project URL for Auth/JWKS checks and Storage client access. |
+| `SUPABASE_SERVICE_ROLE_KEY` | Optional, server-only | Required only when worker code needs Supabase Storage access or privileged writes that cannot be performed with the database connection. This key bypasses RLS; never expose it to the browser and never prefix it with `NEXT_PUBLIC_`. |
+| `SUPABASE_JWT_SECRET` | Optional | Fallback for local/manual JWT verification while legacy admin FastAPI routes still exist. Prefer JWKS via `SUPABASE_URL`. |
+| `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional | Local observability settings. |
 
-Recommended local value:
+The frontend does not need `NEXT_PUBLIC_API_URL`, and the backend does not need browser CORS configuration.
 
-```dotenv
-BACKEND_CORS_ORIGINS=http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app
-```
+## Run the worker
 
-Use exact preview URLs instead of `https://*.vercel.app` if you want a tighter allow-list.
-
-### Run backend-only Docker compose
+From the repository root:
 
 ```bash
 docker compose -f docker-compose.backend.yml up -d --build
 docker compose -f docker-compose.backend.yml ps
-curl http://localhost:8000/health
+curl http://127.0.0.1:8000/health
 ```
 
-The compose file uses the production-style image (no source bind mount and no `--reload`) and publishes `8000:8000`. The `/health` endpoint returns 200 only after a database `SELECT 1` succeeds.
-
-To stop it:
+Stop it with:
 
 ```bash
 docker compose -f docker-compose.backend.yml down
 ```
 
-### Cloudflare Tunnel for Vercel
+`docker-compose.backend.yml` binds the optional health endpoint to `127.0.0.1:8000` only. Do not expose this container through a public tunnel, router port, or Vercel rewrite.
 
-Cloudflare Tunnel is the recommended way to expose the laptop backend without opening router ports.
+## Scheduling model
 
-```bash
-cloudflared tunnel login
-cloudflared tunnel create tj-backend
-cloudflared tunnel route dns tj-backend api.your-domain.example
-cloudflared tunnel run tj-backend --url http://localhost:8000
-```
+Phase B should add an in-process scheduler, preferably APScheduler, during backend startup. Each scheduled job should be a small registration entry that declares:
 
-Alternatives: Tailscale Funnel or ngrok can expose the same local `http://localhost:8000` service. Keep the public URL HTTPS and stable enough for Vercel environment variables.
+1. A stable job id, for example `analysis_tickers_daily`.
+2. Its cadence, for example daily after market close or hourly for `price_cache`.
+3. The Python function under `apps/backend/app/` that performs the work.
+4. The Supabase result table(s) it writes.
+5. Freshness/error fields written with every run, such as `refreshed_at`, `status`, and `error_message`.
 
-### Point Vercel at the tunnel
+A new scheduled compute path should not add a frontend HTTP call. Add the job to the scheduler registry, create the result table with RLS in a migration, and update the frontend to read Supabase rows.
 
-1. Open the Vercel dashboard for `https://trading-journal-cohenjos-projects.vercel.app`.
-2. Set `NEXT_PUBLIC_API_URL` to the tunnel URL, for example `https://api.your-domain.example`.
-3. Apply it to Production and Preview environments.
-4. Redeploy the frontend.
+## Job queue table pattern
 
-`apps/frontend/next.config.ts` already proxies `/api/*` to `NEXT_PUBLIC_API_URL` when the variable is set to a public URL. If it is unset in production, `/api/*` remains disabled and unmigrated compute calls fail fast with 404.
+For user-triggered heavy work, Phase B should use a Supabase table such as `compute_jobs`:
 
-### Offline behavior
+1. A Next.js Server Action validates the user input and inserts a job row with `status = 'pending'`, `job_type`, `input_payload`, `requested_by`, and timestamps.
+2. The backend polling worker wakes every 10 seconds, transactionally claims pending rows, and dispatches by `job_type`.
+3. The worker runs the Python compute module, writes a result row such as `backtest_runs`, and marks the job `done` with the result id. Failures set `status = 'failed'` and an error summary.
+4. The frontend subscribes to the job/result row with Supabase Realtime and renders pending, done, failed, or stale states.
 
-If Jony's laptop is offline, asleep, Docker is stopped, or the tunnel is down, Vercel `/api/*` compute calls fail with 5xx/connection errors. This is an accepted TJ-019 tradeoff: the walkthrough allow-list already tolerates the remaining compute endpoints being unavailable while CRUD paths continue through Supabase.
+To register a new job type in Phase B, add it to the worker's dispatch registry, document its payload schema near the worker code, create a result table with RLS, and remove any frontend `/api/*` dependency for that workflow.
 
-## Auth and CORS
+## Offline behavior
 
-All compute routers in `main.py` are registered with `Depends(get_current_user)`, which verifies Supabase JWTs using JWKS from `SUPABASE_URL` or the `SUPABASE_JWT_SECRET` fallback. CORS is a tight allow-list read from `BACKEND_CORS_ORIGINS`; do not use `*` for this financial application.
+When Jony's laptop is offline, asleep, or Docker is stopped:
 
-See also [`README-supabase-auth.md`](./README-supabase-auth.md) for JWT verification details.
+- Scheduled result tables remain readable but become stale.
+- Pending job rows remain queued until the worker is online again.
+- Storage uploads remain in Supabase until the worker parses them.
+- The frontend still loads because it talks only to Supabase; users see stale timestamps or pending statuses instead of backend connection failures.
+
+This offline behavior is intentional and acceptable for the current operating model.
+
+## Security notes
+
+- Keep `SUPABASE_SERVICE_ROLE_KEY` server-only. It bypasses RLS and must never appear in frontend code, logs, screenshots, or committed files.
+- Prefer scoped database roles or tightly scoped worker functions when practical.
+- Enable RLS on every new exposed result table and grant only the roles required by the frontend read model.
+- Business FastAPI endpoints are not a product integration surface. If retained temporarily, treat them as local/admin maintenance endpoints.

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -9,22 +9,21 @@ const PAGES = [
 ];
 
 /**
- * Path prefixes for FastAPI endpoints that have not yet been migrated to
- * Server Actions and therefore 404 in environments without the FastAPI
- * backend deployed (i.e. CI and Vercel). Tracked under TJ-018 (#71); each
- * sub-issue listed below should remove its entry as the migration lands.
- *
- * - /api/plans/simulate    → #173
- * - /api/finances/history  → #177
- * - /api/options/projection → #189 / TJ-019
+ * Temporary safety net for Phase A only. The frontend end-state is that no
+ * compute route calls FastAPI over `/api/*`; this array goes to `[]` once the
+ * TJ-020 Phase B migrations in #208-#217 land.
  */
-const UNMIGRATED_FASTAPI_PATHS = [
+const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/plans/simulate',
-  '/api/finances/history',
   '/api/options/projection',
+  '/api/tax-condor',
   '/api/backtest',
+  '/api/analyze',
+  '/api/bonds/scanner',
+  '/api/finances/price',
+  '/api/ndx/sync',
+  '/api/trading/sync',
   '/api/pension',
-  '/api/holdings',
 ];
 
 /**
@@ -35,8 +34,13 @@ function isKnownAcceptableApiError(url: string, status: number): boolean {
   // Telemetry 401s — tracked in #125, not a product bug
   if (url.includes('/metrics/page-load') && status === 401) return true;
 
-  // Un-migrated FastAPI endpoints — see UNMIGRATED_FASTAPI_PATHS above
-  if (status === 404 && UNMIGRATED_FASTAPI_PATHS.some(p => url.includes(p))) return true;
+  if (
+    TEMPORARILY_ALLOWED_COMPUTE_API_PATHS.length > 0 &&
+    status === 404 &&
+    TEMPORARILY_ALLOWED_COMPUTE_API_PATHS.some(p => url.includes(p))
+  ) {
+    return true;
+  }
 
   return false;
 }
@@ -48,18 +52,17 @@ function isKnownAcceptableConsoleError(text: string): boolean {
   // Telemetry 401 noise — tracked in #125
   if (text.includes('/metrics/page-load')) return true;
 
-  // Un-migrated FastAPI endpoints — see UNMIGRATED_FASTAPI_PATHS above
-  if (UNMIGRATED_FASTAPI_PATHS.some(p => text.includes(p))) return true;
+  if (
+    TEMPORARILY_ALLOWED_COMPUTE_API_PATHS.length > 0 &&
+    TEMPORARILY_ALLOWED_COMPUTE_API_PATHS.some(p => text.includes(p))
+  ) {
+    return true;
+  }
 
-  // App-level downstream errors caused by the same un-migrated endpoints
   if (text.includes('Simulation failed') || text.includes('Simulation error')) return true;
   if (text.includes('Failed to fetch history')) return true;
   if (text.includes('Failed to fetch summary data')) return true;
   if (text.includes('Failed to fetch years')) return true;
-
-  // Generic browser console companion of the 404s we already allow-list above.
-  // The browser logs "Failed to load resource: ... 404" without the URL, so we
-  // filter the bare message; specific URL noise is filtered by the network handler.
   if (text.includes('Failed to load resource: the server responded with a status of 404')) return true;
 
   // React dev-mode warnings / hydration hints

--- a/apps/frontend/next.config.ts
+++ b/apps/frontend/next.config.ts
@@ -1,42 +1,5 @@
 import type { NextConfig } from "next";
 
-function isPrivateBackendHost(hostname: string): boolean {
-  const normalizedHostname = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  const ipv4Match = normalizedHostname.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-
-  if (ipv4Match) {
-    const octets = ipv4Match.slice(1).map(Number);
-    if (octets.some((octet) => octet > 255)) {
-      return false;
-    }
-
-    const [first, second] = octets;
-    return (
-      first === 10 ||
-      first === 127 ||
-      first === 0 ||
-      (first === 172 && second >= 16 && second <= 31) ||
-      (first === 192 && second === 168) ||
-      (first === 169 && second === 254)
-    );
-  }
-
-  if (normalizedHostname === "localhost" || normalizedHostname === "::1") {
-    return true;
-  }
-
-  if (!normalizedHostname.includes(":")) {
-    return false;
-  }
-
-  const firstHextet = normalizedHostname.split(":")[0];
-  return (
-    firstHextet.startsWith("fc") ||
-    firstHextet.startsWith("fd") ||
-    normalizedHostname.startsWith("fe80:")
-  );
-}
-
 const nextConfig: NextConfig = {
   /* config options here */
   eslint: {
@@ -55,62 +18,6 @@ const nextConfig: NextConfig = {
         pathname: "/storage/v1/object/public/**",
       },
     ],
-  },
-  async rewrites() {
-    // Rewrite /api/* to a backend — this is an opt-in escape hatch for self-hosted backends.
-    // Per architecture directive, the default is for the frontend to talk to Supabase directly
-    // via Server Actions; any `/api/*` call sites that aren't migrated will get a 404 at
-    // runtime (fail-fast behavior, which is desirable).
-    //
-    // Dev environment: falls back to http://127.0.0.1:8000 (Docker Compose or Aspire).
-    // Production/Preview on Vercel: only registers rewrites if NEXT_PUBLIC_API_URL is set
-    // to a valid public URL. If missing/private/localhost, logs a warning and returns empty
-    // rewrites (so /api/* calls will 404 rather than silently failing to reach an invalid URL).
-    const isProduction = process.env.NODE_ENV === "production";
-    const envUrl = process.env.NEXT_PUBLIC_API_URL?.trim();
-
-    if (isProduction) {
-      if (!envUrl) {
-        console.warn(
-          "[next.config] NEXT_PUBLIC_API_URL is not set in production. /api/* rewrites are disabled. " +
-          "This is expected: the frontend talks to Supabase directly via Server Actions. " +
-          "If you have unmigrated /api/* call sites, they will return 404 at runtime.",
-        );
-        return [];
-      }
-
-      // Validate that the URL is public before registering rewrites
-      try {
-        const backendUrl = new URL(envUrl);
-        if (isPrivateBackendHost(backendUrl.hostname)) {
-          console.warn(
-            `[next.config] NEXT_PUBLIC_API_URL points to a private address (${envUrl}) in production. ` +
-            "/api/* rewrites are disabled. Vercel cannot reach private addresses. " +
-            "If you need an /api/* proxy, set NEXT_PUBLIC_API_URL to a public URL.",
-          );
-          return [];
-        }
-
-        if (!/^https?:$/.test(backendUrl.protocol)) {
-          throw new Error(
-            `NEXT_PUBLIC_API_URL must use http or https in production (got ${envUrl}).`,
-          );
-        }
-      } catch (err) {
-        throw new Error(
-          `NEXT_PUBLIC_API_URL must be a valid absolute URL in production (got ${envUrl}).`,
-        );
-      }
-    }
-
-    const backendUrl = envUrl || "http://127.0.0.1:8000";
-
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${backendUrl}/api/:path*`,
-      },
-    ];
   },
 };
 

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,18 +1,20 @@
 services:
   backend:
+    # Worker container: reads from Supabase, computes locally, writes result tables.
+    # This is not a public web service; only /health is bound to localhost for debugging.
     container_name: trading_journal_backend_supabase
     build:
       context: ./apps/backend
       dockerfile: Dockerfile
     command: ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       DATABASE_URL: ${DIRECT_DATABASE_URL:?Set DIRECT_DATABASE_URL to the Supabase Postgres or pooler connection string}
-      SUPABASE_URL: ${SUPABASE_URL:?Set SUPABASE_URL to https://zvbwgxdgxwgduhhzdwjj.supabase.co}
+      SUPABASE_URL: ${SUPABASE_URL:?Set SUPABASE_URL to your Supabase project URL}
+      SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
       SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}
-      BACKEND_CORS_ORIGINS: ${BACKEND_CORS_ORIGINS:-http://localhost:3000,https://trading-journal-cohenjos-projects.vercel.app,https://*.vercel.app}
-      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-trading-journal-backend-local-docker}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-trading-journal-backend-worker-local-docker}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4317}
     restart: unless-stopped
     healthcheck:


### PR DESCRIPTION
## Summary

This PR pivots TJ-019 a second time: away from a laptop FastAPI backend exposed over HTTP and toward a private backend worker that writes compute outputs to Supabase tables.

The new rule is definitive: the Vercel frontend only talks to Supabase tables, Auth, Storage, and Realtime. It does not proxy `/api/*`, does not use `NEXT_PUBLIC_API_URL`, and does not require browser CORS to the backend.

## Architecture changes

- Adds ADR: `.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md`
- Rewrites `apps/backend/README.md` around worker, scheduled batch, job queue, Storage polling, and offline behavior.
- Removes frontend backend rewrites from `apps/frontend/next.config.ts`.
- Updates backend compose/env examples for a private worker with server-only Supabase credentials.
- Updates walkthrough safety comments so FastAPI compute allow-list is empty in the end-state.

## Roadmap issues

Umbrella: #207

Sub-issues:
- #208 — `/api/plans/simulate`
- #209 — `/api/options/projection`
- #210 — `/api/tax-condor/*`
- #211 — `/api/backtest`
- #212 — `/api/analyze/*`
- #213 — `/api/bonds/scanner`
- #214 — `/api/finances/price`
- #215 — `/api/ndx/sync`
- #216 — `/api/trading/sync`
- #217 — `/api/pension/upload`

## Supersedes

PR #206, the previous tunnel-based pivot, is superseded by this Supabase-table worker approach.

## Review request

Please request Rabin (security) review for the service-role-key handling and the Phase B guardrails around RLS, privileged worker writes, and server-only environment variables.

## Validation

- Frontend build: passed
- Frontend tests: 202 passed
- Backend pytest: 272 passed