### PR TITLE
feat(TJ-020): worker foundation (APScheduler + compute_jobs table)

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -19,4 +19,4 @@ RUN uv pip install alembic
 COPY . .
 
 # Command to run the application
-CMD ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+CMD ["uv", "run", "python", "-m", "app.worker.runtime"]

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -2,14 +2,7 @@
 
 The backend is a private Python worker for Trading Journal computations. It is not a public web service and the Vercel frontend must not call it over HTTP. The frontend reads and writes Supabase tables, Auth, Storage, and Realtime only.
 
-The worker runs in Docker on Jony's laptop, reads inputs from Supabase, executes the existing Python modules under `apps/backend/app/`, and writes computed outputs back to Supabase result tables. FastAPI may stay running for local `/health` liveness checks, but business routes are legacy/admin-only until Phase B removes or replaces them.
-
-## What this backend does
-
-- **Scheduled batch compute:** refresh pre-computable datasets on a timer and write result tables such as ticker analysis, bond scanner results, price cache rows, NDX data, and broker/trading snapshots.
-- **Job queue compute:** poll Supabase job-request rows for user-triggered heavy work, run the Python computation, write results, and update job status.
-- **Storage processing:** poll or react to Supabase Storage uploads, parse files such as pension PDFs, and write parsed rows/status to Supabase tables.
-- **Local health:** expose `/health` inside the container, and optionally on `127.0.0.1:8000`, so the laptop operator can verify the worker is alive.
+The worker runs in Docker on Jony's laptop, reads inputs from Supabase with a server-only privileged database connection, executes Python modules under `apps/backend/app/`, and writes computed outputs back to Supabase result tables.
 
 ## Required environment
 
@@ -21,19 +14,84 @@ Copy the root `.env.example` or `apps/backend/.env.example` to a local `.env` an
 | `DIRECT_DATABASE_URL` | Compose convenience | `docker-compose.backend.yml` maps this value into `DATABASE_URL`; set it to the Supabase direct or pooler URL. |
 | `SUPABASE_URL` | Yes | Supabase project URL for Auth/JWKS checks and Storage client access. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Optional, server-only | Required only when worker code needs Supabase Storage access or privileged writes that cannot be performed with the database connection. This key bypasses RLS; never expose it to the browser and never prefix it with `NEXT_PUBLIC_`. |
-| `SUPABASE_JWT_SECRET` | Optional | Fallback for local/manual JWT verification while legacy admin FastAPI routes still exist. Prefer JWKS via `SUPABASE_URL`. |
+| `WORKER_TIMEZONE` | Optional | APScheduler timezone. Defaults to `Asia/Jerusalem`. |
+| `WORKER_POLL_INTERVAL_SECONDS` | Optional | `compute_jobs` polling interval. Defaults to `5`. |
 | `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional | Local observability settings. |
 
-The frontend does not need `NEXT_PUBLIC_API_URL`, and the backend does not need browser CORS configuration.
+## Adding a scheduled batch job
 
-## Run the worker
+Scheduled jobs live beside the compute code. Register a `JobSchedule` in `app.worker.registry.JOB_SCHEDULES`, point it at a zero-argument handler, and have the handler read/write Supabase through the worker's privileged database connection. Result tables should include freshness fields such as `refreshed_at`, `source`, `status`, and `error`.
+
+```python
+from app.worker.registry import JOB_SCHEDULES, JobSchedule
+from app.services.analysis.refresh import refresh_growth_stories
+
+
+def refresh_growth_stories_job() -> None:
+    """Refresh known ticker stories and upsert result rows."""
+    refresh_growth_stories()
+
+
+JOB_SCHEDULES.append(
+    JobSchedule(
+        job_id="analysis_growth_stories_daily",
+        kind="cron",
+        cron_expr="30 18 * * 0-4",
+        handler=refresh_growth_stories_job,
+    )
+)
+```
+
+## Adding an on-demand job
+
+On-demand jobs use `public.compute_jobs`. Pick a stable `job_type`, register a handler in `registry.JOB_HANDLERS`, and return a JSON-serializable result. The frontend inserts a job and subscribes to Realtime changes; it never calls the Python worker over HTTP.
+
+```python
+from app.services.backtester.runner import run_backtest
+from app.worker.registry import JOB_HANDLERS, JobPayload, JobResult
+
+
+def handle_backtest(payload: JobPayload) -> JobResult:
+    """Run one user-requested backtest and return the result row id."""
+    strategy_id = str(payload["strategy_id"])
+    start_year = int(payload["start_year"])
+    end_year = int(payload["end_year"])
+    run_id = run_backtest(
+        strategy_id=strategy_id,
+        start_year=start_year,
+        end_year=end_year,
+    )
+    return {"backtest_run_id": str(run_id)}
+
+
+JOB_HANDLERS["backtest"] = handle_backtest
+```
+
+```ts
+const jobId = await enqueueComputeJob('backtest', {
+  strategy_id: strategyId,
+  start_year: 2024,
+  end_year: 2026,
+});
+
+const unsubscribe = subscribeToComputeJob(jobId, (job) => {
+  if (job.status === 'done') {
+    router.push(`/backtests/${job.result?.backtest_run_id}`);
+  }
+  if (job.status === 'failed') {
+    setError(job.error ?? 'Backtest failed');
+  }
+});
+```
+
+## Local development
 
 From the repository root:
 
 ```bash
 docker compose -f docker-compose.backend.yml up -d --build
 docker compose -f docker-compose.backend.yml ps
-curl http://127.0.0.1:8000/health
+docker compose -f docker-compose.backend.yml logs -f backend
 ```
 
 Stop it with:
@@ -42,30 +100,7 @@ Stop it with:
 docker compose -f docker-compose.backend.yml down
 ```
 
-`docker-compose.backend.yml` binds the optional health endpoint to `127.0.0.1:8000` only. Do not expose this container through a public tunnel, router port, or Vercel rewrite.
-
-## Scheduling model
-
-Phase B should add an in-process scheduler, preferably APScheduler, during backend startup. Each scheduled job should be a small registration entry that declares:
-
-1. A stable job id, for example `analysis_tickers_daily`.
-2. Its cadence, for example daily after market close or hourly for `price_cache`.
-3. The Python function under `apps/backend/app/` that performs the work.
-4. The Supabase result table(s) it writes.
-5. Freshness/error fields written with every run, such as `refreshed_at`, `status`, and `error_message`.
-
-A new scheduled compute path should not add a frontend HTTP call. Add the job to the scheduler registry, create the result table with RLS in a migration, and update the frontend to read Supabase rows.
-
-## Job queue table pattern
-
-For user-triggered heavy work, Phase B should use a Supabase table such as `compute_jobs`:
-
-1. A Next.js Server Action validates the user input and inserts a job row with `status = 'pending'`, `job_type`, `input_payload`, `requested_by`, and timestamps.
-2. The backend polling worker wakes every 10 seconds, transactionally claims pending rows, and dispatches by `job_type`.
-3. The worker runs the Python compute module, writes a result row such as `backtest_runs`, and marks the job `done` with the result id. Failures set `status = 'failed'` and an error summary.
-4. The frontend subscribes to the job/result row with Supabase Realtime and renders pending, done, failed, or stale states.
-
-To register a new job type in Phase B, add it to the worker's dispatch registry, document its payload schema near the worker code, create a result table with RLS, and remove any frontend `/api/*` dependency for that workflow.
+The compose worker publishes no ports. Do not expose this container through a public tunnel, router port, or Vercel rewrite.
 
 ## Offline behavior
 
@@ -75,8 +110,6 @@ When Jony's laptop is offline, asleep, or Docker is stopped:
 - Pending job rows remain queued until the worker is online again.
 - Storage uploads remain in Supabase until the worker parses them.
 - The frontend still loads because it talks only to Supabase; users see stale timestamps or pending statuses instead of backend connection failures.
-
-This offline behavior is intentional and acceptable for the current operating model.
 
 ## Security notes
 

--- a/apps/backend/app/worker/__init__.py
+++ b/apps/backend/app/worker/__init__.py
@@ -1,0 +1,1 @@
+"""Worker runtime package for scheduled and on-demand compute jobs."""

--- a/apps/backend/app/worker/job_queue.py
+++ b/apps/backend/app/worker/job_queue.py
@@ -1,0 +1,192 @@
+"""Supabase-backed compute job queue poller."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+import logging
+from typing import Any, Protocol, cast
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.worker.registry import JOB_HANDLERS, JobHandler, JobPayload, JobResult
+
+logger = logging.getLogger(__name__)
+MAX_ATTEMPTS = 3
+DEFAULT_BATCH_SIZE = 10
+
+
+class SessionFactory(Protocol):
+    """Callable protocol for creating worker database sessions."""
+
+    def __call__(self) -> AbstractContextManager[Session]:
+        """Return a database session context manager."""
+
+
+@dataclass(frozen=True)
+class ComputeJob:
+    """Pending compute job row claimed by the worker."""
+
+    id: UUID
+    job_type: str
+    payload: JobPayload
+    attempts: int
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a SQLModel session using the configured privileged DB engine."""
+
+    return Session(engine)
+
+
+class JobQueuePoller:
+    """Poll, claim, dispatch, and finalize rows in public.compute_jobs."""
+
+    def __init__(
+        self,
+        handlers: dict[str, JobHandler] | None = None,
+        session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+        batch_size: int = DEFAULT_BATCH_SIZE,
+    ) -> None:
+        """Initialize a poller for the configured handler registry."""
+
+        self.handlers = handlers if handlers is not None else JOB_HANDLERS
+        self.session_factory = session_factory or _default_session_factory
+        self.batch_size = batch_size
+
+    def poll_once(self) -> int:
+        """Claim and process one batch of pending jobs.
+
+        Returns:
+            Number of jobs claimed for processing.
+        """
+
+        with self.session_factory() as session:
+            jobs = self._claim_pending_jobs(session)
+            for job in jobs:
+                self._process_job(session, job)
+            session.commit()
+            return len(jobs)
+
+    def _claim_pending_jobs(self, session: Session) -> list[ComputeJob]:
+        """Mark pending jobs running and return their payloads."""
+
+        rows = session.execute(
+            text(
+                """
+                update public.compute_jobs
+                   set status = 'running',
+                       started_at = now(),
+                       finished_at = null,
+                       error = null
+                 where id in (
+                   select id
+                     from public.compute_jobs
+                    where status = 'pending'
+                      and attempts < :max_attempts
+                    order by created_at
+                    limit :batch_size
+                    for update skip locked
+                 )
+                returning id, job_type, payload, attempts
+                """
+            ),
+            {"max_attempts": MAX_ATTEMPTS, "batch_size": self.batch_size},
+        ).mappings()
+
+        return [
+            ComputeJob(
+                id=cast(UUID, row["id"]),
+                job_type=cast(str, row["job_type"]),
+                payload=cast(JobPayload, row["payload"] or {}),
+                attempts=cast(int, row["attempts"]),
+            )
+            for row in rows
+        ]
+
+    def _process_job(self, session: Session, job: ComputeJob) -> None:
+        """Dispatch one claimed job and persist its terminal or retry state."""
+
+        handler = self.handlers.get(job.job_type)
+        if handler is None:
+            self._record_failure(
+                session,
+                job,
+                ValueError(f"No handler registered for job_type '{job.job_type}'"),
+                permanent=True,
+            )
+            return
+
+        try:
+            result = handler(job.payload)
+        except Exception as exc:  # noqa: BLE001 - queue must capture handler failures
+            logger.exception("Compute job %s failed", job.id)
+            self._record_failure(session, job, exc)
+            return
+
+        self._record_success(session, job.id, result)
+
+    def _record_success(self, session: Session, job_id: UUID, result: JobResult) -> None:
+        """Mark a job done with its JSON result."""
+
+        session.execute(
+            text(
+                """
+                update public.compute_jobs
+                   set status = 'done',
+                       result = cast(:result as jsonb),
+                       error = null,
+                       finished_at = now()
+                 where id = :job_id
+                """
+            ),
+            {"job_id": job_id, "result": _json_safe(result)},
+        )
+
+    def _record_failure(
+        self,
+        session: Session,
+        job: ComputeJob,
+        exc: Exception,
+        permanent: bool = False,
+    ) -> None:
+        """Record a failed attempt and requeue until the retry cap is reached."""
+
+        next_attempts = min(job.attempts + 1, MAX_ATTEMPTS)
+        next_status = "failed" if permanent or next_attempts >= MAX_ATTEMPTS else "pending"
+        session.execute(
+            text(
+                """
+                update public.compute_jobs
+                   set status = :status,
+                       error = :error,
+                       attempts = :attempts,
+                       finished_at = case when :status = 'failed' then now() else null end
+                 where id = :job_id
+                """
+            ),
+            {
+                "job_id": job.id,
+                "status": next_status,
+                "error": str(exc),
+                "attempts": next_attempts,
+            },
+        )
+
+
+def _json_safe(value: dict[str, Any]) -> str:
+    """Serialize a handler result to JSON for jsonb binding."""
+
+    import json
+
+    return json.dumps(value, default=str)
+
+
+def poll_compute_jobs() -> int:
+    """Run one compute-job polling pass using the global registry."""
+
+    return JobQueuePoller().poll_once()

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -1,0 +1,25 @@
+"""Job handler and schedule registry for the backend worker."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+JobHandler = Callable[[JobPayload], JobResult]
+ScheduleKind = Literal["cron", "interval"]
+
+
+@dataclass(frozen=True)
+class JobSchedule:
+    """Declarative schedule entry registered by follow-up compute migrations."""
+
+    job_id: str
+    kind: ScheduleKind
+    handler: Callable[[], None]
+    cron_expr: str | None = None
+    seconds: int | None = None
+
+
+JOB_HANDLERS: dict[str, JobHandler] = {}
+JOB_SCHEDULES: list[JobSchedule] = []

--- a/apps/backend/app/worker/runtime.py
+++ b/apps/backend/app/worker/runtime.py
@@ -1,0 +1,75 @@
+"""Executable backend worker runtime."""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import time
+
+from app.worker.job_queue import poll_compute_jobs
+from app.worker.registry import JOB_SCHEDULES
+from app.worker.scheduler import get_scheduler, register_cron, register_interval
+
+logger = logging.getLogger(__name__)
+DEFAULT_POLL_INTERVAL_SECONDS = 5
+
+
+def _poll_interval_seconds() -> int:
+    """Return the queue polling interval in seconds."""
+
+    raw_value = os.getenv("WORKER_POLL_INTERVAL_SECONDS", str(DEFAULT_POLL_INTERVAL_SECONDS))
+    try:
+        value = int(raw_value)
+    except ValueError:
+        logger.warning("Invalid WORKER_POLL_INTERVAL_SECONDS=%s; using default", raw_value)
+        return DEFAULT_POLL_INTERVAL_SECONDS
+    return max(1, value)
+
+
+def start_worker() -> None:
+    """Start the scheduler, register all jobs, and block until interrupted."""
+
+    logging.basicConfig(level=os.getenv("WORKER_LOG_LEVEL", "INFO"))
+    scheduler = get_scheduler()
+
+    for schedule in JOB_SCHEDULES:
+        if schedule.kind == "cron":
+            if not schedule.cron_expr:
+                raise ValueError(f"Schedule {schedule.job_id} is missing cron_expr")
+            register_cron(schedule.job_id, schedule.cron_expr, schedule.handler)
+        elif schedule.kind == "interval":
+            if schedule.seconds is None:
+                raise ValueError(f"Schedule {schedule.job_id} is missing seconds")
+            register_interval(schedule.job_id, schedule.seconds, schedule.handler)
+        else:
+            raise ValueError(f"Unsupported schedule kind: {schedule.kind}")
+
+    register_interval(
+        "compute_jobs_poller",
+        _poll_interval_seconds(),
+        poll_compute_jobs,
+    )
+
+    scheduler.start()
+    logger.info("Worker scheduler started with %d job(s)", len(scheduler.get_jobs()))
+
+    should_stop = False
+
+    def _request_shutdown(_signum: int, _frame: object) -> None:
+        nonlocal should_stop
+        should_stop = True
+
+    signal.signal(signal.SIGTERM, _request_shutdown)
+    signal.signal(signal.SIGINT, _request_shutdown)
+
+    try:
+        while not should_stop:
+            time.sleep(1)
+    finally:
+        scheduler.shutdown(wait=False)
+        logger.info("Worker scheduler stopped")
+
+
+if __name__ == "__main__":
+    start_worker()

--- a/apps/backend/app/worker/scheduler.py
+++ b/apps/backend/app/worker/scheduler.py
@@ -1,0 +1,55 @@
+"""APScheduler singleton and registration helpers for worker jobs."""
+
+from collections.abc import Callable
+import os
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.interval import IntervalTrigger
+
+
+def _worker_timezone() -> str:
+    """Return the configured worker timezone."""
+
+    return os.getenv("WORKER_TIMEZONE", "Asia/Jerusalem")
+
+
+_scheduler: BackgroundScheduler | None = None
+
+
+def get_scheduler() -> BackgroundScheduler:
+    """Return the process-wide APScheduler instance."""
+
+    global _scheduler
+    if _scheduler is None:
+        _scheduler = BackgroundScheduler(timezone=_worker_timezone())
+    return _scheduler
+
+
+def register_cron(job_id: str, cron_expr: str, func: Callable[[], None]) -> None:
+    """Register or replace a cron-scheduled function.
+
+    Args:
+        job_id: Stable id used by APScheduler for replacement and logs.
+        cron_expr: Five-field crontab expression in the worker timezone.
+        func: Zero-argument callable to execute on schedule.
+    """
+
+    trigger = CronTrigger.from_crontab(cron_expr, timezone=_worker_timezone())
+    get_scheduler().add_job(func, trigger=trigger, id=job_id, replace_existing=True)
+
+
+def register_interval(job_id: str, seconds: int, func: Callable[[], None]) -> None:
+    """Register or replace a fixed-interval function."""
+
+    if seconds <= 0:
+        raise ValueError("Interval seconds must be positive")
+    trigger = IntervalTrigger(seconds=seconds, timezone=_worker_timezone())
+    get_scheduler().add_job(
+        func,
+        trigger=trigger,
+        id=job_id,
+        max_instances=1,
+        coalesce=True,
+        replace_existing=True,
+    )

--- a/apps/backend/pyproject.toml
+++ b/apps/backend/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "bcrypt<5.1",
     "pydantic-settings>=2.7.0",
     "pydantic[email]>=2.11.7",
+    "apscheduler>=3.11.2",
 ]
 requires-python = ">=3.10"
 

--- a/apps/backend/tests/test_worker_job_queue.py
+++ b/apps/backend/tests/test_worker_job_queue.py
@@ -1,0 +1,124 @@
+"""Unit tests for the Supabase compute job queue poller."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Any
+from uuid import UUID
+
+from app.worker.job_queue import JobQueuePoller
+
+
+class FakeMappings:
+    """Result wrapper that mimics SQLAlchemy's mappings() API."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class FakeSession(AbstractContextManager["FakeSession"]):
+    """Minimal SQLAlchemy session fake for queue transition assertions."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.executions: list[dict[str, Any]] = []
+        self.committed = False
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        sql = str(statement)
+        self.executions.append({"sql": sql, "params": params or {}})
+        if "returning id, job_type, payload, attempts" in sql:
+            return FakeMappings(self.rows)
+        return FakeMappings([])
+
+    def commit(self) -> None:
+        """Record that the poller committed its batch."""
+
+        self.committed = True
+
+
+def test_poller_dispatches_handler_and_marks_done() -> None:
+    """The poller claims pending jobs, calls the handler, and stores results."""
+
+    job_id = UUID("00000000-0000-0000-0000-000000000001")
+    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 0}])
+    seen_payloads: list[dict[str, object]] = []
+
+    def handler(payload: dict[str, object]) -> dict[str, object]:
+        seen_payloads.append(payload)
+        return {"ok": True}
+
+    poller = JobQueuePoller(handlers={"fake": handler}, session_factory=lambda: session)
+
+    assert poller.poll_once() == 1
+    assert seen_payloads == [{"x": 1}]
+    assert session.committed is True
+    assert any(call["params"].get("result") == '{"ok": true}' for call in session.executions)
+    assert any("status = 'done'" in call["sql"] for call in session.executions)
+
+
+def test_poller_requeues_failed_job_until_retry_cap() -> None:
+    """Handler exceptions increment attempts and keep retryable jobs pending."""
+
+    job_id = UUID("00000000-0000-0000-0000-000000000002")
+    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 1}])
+
+    def handler(_payload: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("boom")
+
+    poller = JobQueuePoller(handlers={"fake": handler}, session_factory=lambda: session)
+
+    assert poller.poll_once() == 1
+    failure_params = session.executions[-1]["params"]
+    assert failure_params["status"] == "pending"
+    assert failure_params["attempts"] == 2
+    assert failure_params["error"] == "boom"
+
+
+def test_poller_marks_failed_at_retry_cap() -> None:
+    """The third failed attempt permanently marks the job failed."""
+
+    job_id = UUID("00000000-0000-0000-0000-000000000003")
+    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 2}])
+
+    def handler(_payload: dict[str, object]) -> dict[str, object]:
+        raise RuntimeError("still broken")
+
+    poller = JobQueuePoller(handlers={"fake": handler}, session_factory=lambda: session)
+
+    assert poller.poll_once() == 1
+    failure_params = session.executions[-1]["params"]
+    assert failure_params["status"] == "failed"
+    assert failure_params["attempts"] == 3
+    assert failure_params["error"] == "still broken"
+
+
+def test_poller_marks_unknown_job_type_failed() -> None:
+    """Unknown job types fail permanently so the queue cannot spin forever."""
+
+    job_id = UUID("00000000-0000-0000-0000-000000000004")
+    session = FakeSession([{"id": job_id, "job_type": "missing", "payload": {}, "attempts": 0}])
+    poller = JobQueuePoller(handlers={}, session_factory=lambda: session)
+
+    assert poller.poll_once() == 1
+    failure_params = session.executions[-1]["params"]
+    assert failure_params["status"] == "failed"
+    assert failure_params["attempts"] == 1
+    assert "No handler registered" in failure_params["error"]

--- a/apps/backend/uv.lock
+++ b/apps/backend/uv.lock
@@ -61,6 +61,18 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439 },
+]
+
+[[package]]
 name = "asgiref"
 version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -103,6 +115,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "apscheduler" },
     { name = "bcrypt" },
     { name = "cachetools" },
     { name = "fastapi" },
@@ -151,6 +164,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic" },
+    { name = "apscheduler", specifier = ">=3.11.2" },
     { name = "bcrypt", specifier = "<5.1" },
     { name = "cachetools", specifier = ">=7.0.6" },
     { name = "fastapi" },
@@ -2689,6 +2703,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026 },
 ]
 
 [[package]]

--- a/apps/backend/worker_main.py
+++ b/apps/backend/worker_main.py
@@ -1,0 +1,7 @@
+"""Compatibility entrypoint for running the backend worker."""
+
+from app.worker.runtime import start_worker
+
+
+if __name__ == "__main__":
+    start_worker()

--- a/apps/frontend/src/lib/__tests__/compute-jobs.test.ts
+++ b/apps/frontend/src/lib/__tests__/compute-jobs.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __setComputeJobsTestClient,
+  enqueueComputeJob,
+  getComputeJob,
+  subscribeToComputeJob,
+  type ComputeJob,
+} from '../compute-jobs';
+
+const getUser = vi.fn();
+
+function chain(result: unknown) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue(result),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  __setComputeJobsTestClient(null);
+  getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+});
+
+describe('compute job helpers', () => {
+  it('enqueues compute jobs scoped to the active household', async () => {
+    const householdChain = chain({ data: { household_id: 'hh-1' }, error: null });
+    const insertChain = chain({ data: { id: 'job-1' }, error: null });
+    const from = vi.fn((table: string) => {
+      if (table === 'household_members') return householdChain;
+      if (table === 'compute_jobs') return insertChain;
+      throw new Error(`Unexpected table ${table}`);
+    });
+    __setComputeJobsTestClient({ auth: { getUser }, from } as never);
+
+    await expect(enqueueComputeJob('backtest', { years: [2025] })).resolves.toBe('job-1');
+    expect(insertChain.insert).toHaveBeenCalledWith({
+      household_id: 'hh-1',
+      job_type: 'backtest',
+      payload: { years: [2025] },
+    });
+  });
+
+  it('fetches and normalizes one compute job', async () => {
+    const jobRow: ComputeJob = {
+      id: 'job-1',
+      household_id: 'hh-1',
+      job_type: 'backtest',
+      payload: { years: [2025] },
+      status: 'done',
+      result: { run_id: 'run-1' },
+      error: null,
+      attempts: 1,
+      created_at: '2026-05-03T00:00:00Z',
+      started_at: '2026-05-03T00:00:01Z',
+      finished_at: '2026-05-03T00:00:02Z',
+    };
+    const jobChain = chain({ data: jobRow, error: null });
+    __setComputeJobsTestClient({ auth: { getUser }, from: vi.fn(() => jobChain) } as never);
+
+    await expect(getComputeJob('job-1')).resolves.toEqual(jobRow);
+    expect(jobChain.eq).toHaveBeenCalledWith('id', 'job-1');
+  });
+
+  it('subscribes to realtime job changes and unsubscribes', () => {
+    const callback = vi.fn();
+    const removeChannel = vi.fn();
+    const channel = {
+      on: vi.fn((_event, _filter, handler) => {
+        handler({
+          new: {
+            id: 'job-1',
+            household_id: 'hh-1',
+            job_type: 'backtest',
+            payload: {},
+            status: 'running',
+            result: null,
+            error: null,
+            attempts: 0,
+            created_at: '2026-05-03T00:00:00Z',
+            started_at: null,
+            finished_at: null,
+          },
+        });
+        return channel;
+      }),
+      subscribe: vi.fn(() => channel),
+    };
+    const supabase = {
+      auth: { getUser },
+      from: vi.fn(),
+      channel: vi.fn(() => channel),
+      removeChannel,
+    };
+    __setComputeJobsTestClient(supabase as never);
+
+    const unsubscribe = subscribeToComputeJob('job-1', callback);
+    expect(supabase.channel).toHaveBeenCalledWith('compute-job:job-1');
+    expect(callback).toHaveBeenCalledWith(expect.objectContaining({ id: 'job-1', status: 'running' }));
+
+    unsubscribe();
+    expect(removeChannel).toHaveBeenCalledWith(channel);
+  });
+});

--- a/apps/frontend/src/lib/compute-jobs.ts
+++ b/apps/frontend/src/lib/compute-jobs.ts
@@ -1,0 +1,152 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database';
+
+export type ComputeJobStatus = 'pending' | 'running' | 'done' | 'failed';
+
+export interface ComputeJob {
+  id: string;
+  household_id: string;
+  job_type: string;
+  payload: unknown;
+  status: ComputeJobStatus;
+  result: unknown | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+type SupabaseLike = Pick<SupabaseClient<Database>, 'auth' | 'from' | 'channel' | 'removeChannel'>;
+
+let testClient: SupabaseLike | null = null;
+
+/** Override the Supabase client in unit tests. */
+export function __setComputeJobsTestClient(client: SupabaseLike | null): void {
+  testClient = client;
+}
+
+async function createServerSupabase(): Promise<SupabaseLike> {
+  if (testClient) return testClient;
+  const { createClient } = await import('@/lib/supabase/server');
+  return createClient();
+}
+
+function createBrowserSupabase(): SupabaseLike {
+  if (testClient) return testClient;
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+async function requireActiveHouseholdId(supabase: SupabaseLike): Promise<string> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    throw new Error('Authentication is required to enqueue compute jobs.');
+  }
+
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', user.id)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data?.household_id) {
+    throw new Error(error?.message ?? 'No active household found for the current user.');
+  }
+
+  return String(data.household_id);
+}
+
+function normalizeComputeJob(row: Record<string, unknown>): ComputeJob {
+  return {
+    id: String(row.id),
+    household_id: String(row.household_id),
+    job_type: String(row.job_type),
+    payload: row.payload,
+    status: row.status as ComputeJobStatus,
+    result: row.result ?? null,
+    error: row.error == null ? null : String(row.error),
+    attempts: Number(row.attempts ?? 0),
+    created_at: String(row.created_at),
+    started_at: row.started_at == null ? null : String(row.started_at),
+    finished_at: row.finished_at == null ? null : String(row.finished_at),
+  };
+}
+
+/** Enqueue an on-demand backend compute job for the current household. */
+export async function enqueueComputeJob(jobType: string, payload: unknown): Promise<string> {
+  if (!jobType.trim()) {
+    throw new Error('jobType is required.');
+  }
+
+  const supabase = await createServerSupabase();
+  const householdId = await requireActiveHouseholdId(supabase);
+
+  const { data, error } = await supabase
+    .from('compute_jobs')
+    .insert({
+      household_id: householdId,
+      job_type: jobType,
+      payload,
+    })
+    .select('id')
+    .single();
+
+  if (error || !data?.id) {
+    throw new Error(error?.message ?? 'Failed to enqueue compute job.');
+  }
+
+  return String(data.id);
+}
+
+/** Fetch one compute job visible to the current household/session. */
+export async function getComputeJob(jobId: string): Promise<ComputeJob | null> {
+  const supabase = await createServerSupabase();
+  const { data, error } = await supabase
+    .from('compute_jobs')
+    .select('*')
+    .eq('id', jobId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ? normalizeComputeJob(data as Record<string, unknown>) : null;
+}
+
+/** Subscribe to status changes for one compute job. Returns an unsubscribe callback. */
+export function subscribeToComputeJob(
+  jobId: string,
+  onUpdate: (job: ComputeJob) => void,
+): () => void {
+  const supabase = createBrowserSupabase();
+  const channel: RealtimeChannel = supabase
+    .channel(`compute-job:${jobId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: '*',
+        schema: 'public',
+        table: 'compute_jobs',
+        filter: `id=eq.${jobId}`,
+      },
+      (event: { new: Record<string, unknown> }) => {
+        if (event.new) onUpdate(normalizeComputeJob(event.new));
+      },
+    )
+    .subscribe();
+
+  return () => {
+    void supabase.removeChannel(channel);
+  };
+}

--- a/docker-compose.backend.yml
+++ b/docker-compose.backend.yml
@@ -1,28 +1,19 @@
 services:
   backend:
-    # Worker container: reads from Supabase, computes locally, writes result tables.
-    # This is not a public web service; only /health is bound to localhost for debugging.
+    # Private worker container: reads from Supabase, computes locally, writes result tables.
+    # This is not a public web service and publishes no HTTP ports.
     container_name: trading_journal_backend_supabase
     build:
       context: ./apps/backend
       dockerfile: Dockerfile
-    command: ["uv", "run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
-    ports:
-      - "127.0.0.1:8000:8000"
+    command: ["uv", "run", "python", "-m", "app.worker.runtime"]
     environment:
       DATABASE_URL: ${DIRECT_DATABASE_URL:?Set DIRECT_DATABASE_URL to the Supabase Postgres or pooler connection string}
       SUPABASE_URL: ${SUPABASE_URL:?Set SUPABASE_URL to your Supabase project URL}
       SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY:-}
       SUPABASE_JWT_SECRET: ${SUPABASE_JWT_SECRET:-}
+      WORKER_TIMEZONE: ${WORKER_TIMEZONE:-Asia/Jerusalem}
+      WORKER_POLL_INTERVAL_SECONDS: ${WORKER_POLL_INTERVAL_SECONDS:-5}
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-trading-journal-backend-worker-local-docker}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://127.0.0.1:4317}
     restart: unless-stopped
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - >-
-          python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()"
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s

--- a/supabase/migrations/20260503161310_add_compute_jobs.sql
+++ b/supabase/migrations/20260503161310_add_compute_jobs.sql
@@ -1,0 +1,59 @@
+-- Migration: 20260503161310_add_compute_jobs
+-- Purpose: Add Supabase-backed worker queue table for TJ-020 compute jobs.
+
+create table if not exists public.compute_jobs (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  job_type text not null,
+  payload jsonb not null,
+  status text not null default 'pending' check (status in ('pending', 'running', 'done', 'failed')),
+  result jsonb,
+  error text,
+  attempts integer not null default 0 check (attempts >= 0 and attempts <= 3),
+  created_at timestamptz not null default now(),
+  started_at timestamptz,
+  finished_at timestamptz
+);
+
+create index if not exists compute_jobs_status_created_at_idx
+  on public.compute_jobs (status, created_at);
+
+create index if not exists compute_jobs_household_type_created_at_idx
+  on public.compute_jobs (household_id, job_type, created_at desc);
+
+alter table public.compute_jobs enable row level security;
+
+revoke all on table public.compute_jobs from anon;
+revoke all on table public.compute_jobs from authenticated;
+grant select, insert on table public.compute_jobs to authenticated;
+grant select, insert, update on table public.compute_jobs to service_role;
+
+drop policy if exists compute_jobs_member_select on public.compute_jobs;
+create policy compute_jobs_member_select
+  on public.compute_jobs
+  for select
+  to authenticated
+  using (public.is_household_member(household_id));
+
+drop policy if exists compute_jobs_member_insert on public.compute_jobs;
+create policy compute_jobs_member_insert
+  on public.compute_jobs
+  for insert
+  to authenticated
+  with check (public.is_household_member(household_id));
+
+drop policy if exists compute_jobs_service_update on public.compute_jobs;
+create policy compute_jobs_service_update
+  on public.compute_jobs
+  for update
+  to service_role
+  using (true)
+  with check (true);
+
+do $$
+begin
+  alter publication supabase_realtime add table public.compute_jobs;
+exception
+  when duplicate_object then null;
+  when undefined_object then null;
+end $$;


### PR DESCRIPTION
## Summary
- Closes #207.
- Adds the TJ-020 backend worker foundation: APScheduler runtime, compute_jobs poller, handler/schedule registries, compose worker command, and frontend Supabase helpers.
- Adds Supabase migration `20260503161310_add_compute_jobs.sql` for `public.compute_jobs` with RLS, indexes, service-role update policy, and Realtime publication.
- References ADR: `.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md`.

## Patterns for subsequent agents
1. Scheduled batch jobs: add a zero-argument handler and register a `JobSchedule(kind='cron')` in `app.worker.registry.JOB_SCHEDULES`.
2. Interval batch jobs: add a zero-argument handler and register `JobSchedule(kind='interval')` for frequent local refreshes.
3. On-demand jobs: register `JOB_HANDLERS['your_type']`, have the frontend call `enqueueComputeJob('your_type', payload)`, then write result tables from the worker.
4. Realtime status UX: use `getComputeJob(id)` for initial state and `subscribeToComputeJob(id, ...)` for pending/running/done/failed updates.

## Scope note
No compute endpoint migrations are done in this PR. Those follow in #211-#216.

## Validation
- Supabase MCP `apply_migration` succeeded for `add_compute_jobs` (remote migration version `20260503161310`).
- Verified `compute_jobs` columns, RLS policies, and `supabase_realtime` publication membership with Supabase MCP SQL queries.
- `cd apps/backend && uv run ruff check app/worker tests/test_worker_job_queue.py && uv run pytest -q` (276 passed).
- `cd apps/frontend && npm test` (219 passed).
- `cd apps/frontend && npm run build` (passed).

## Review notes
- Worker DB writes are server-side through the backend `DATABASE_URL` / service role path and are not subject to browser RLS.
- Supabase advisors were run; reported warnings are existing broader-project advisories, not introduced by `compute_jobs`.