### PR TITLE
feat(TJ-020): migrate ndx/sync to scheduled batch (#215)

### DIFF
--- a/apps/backend/app/api/ndx.py
+++ b/apps/backend/app/api/ndx.py
@@ -7,19 +7,25 @@ from app.utils.ndx_data import sync_ndx_data
 
 router = APIRouter()
 
-@router.post("/ndx/sync/{date}")
+
+@router.post("/ndx/sync/{date}", deprecated=True)
 def sync_ndx_data_for_date(date: date_type):
-    """Trigger NDX 1-minute data sync for the given date."""
+    """Deprecated maintenance hook; NDX sync now runs as a scheduled batch."""
     return sync_ndx_data(date.strftime("%Y-%m-%d"))
 
 
 @router.get("/ndx/{date}", response_model=list[Ndx1mChartData])
 def get_ndx_data_for_day(date: date_type, session: Session = Depends(get_session)):
     """Return NDX 1-minute OHLC chart data for the given date."""
-    statement = select(Ndx1m).where(Ndx1m.timestamp >= date).where(Ndx1m.timestamp < date + timedelta(days=1)).order_by(Ndx1m.timestamp)
+    statement = (
+        select(Ndx1m)
+        .where(Ndx1m.timestamp >= date)
+        .where(Ndx1m.timestamp < date + timedelta(days=1))
+        .order_by(Ndx1m.timestamp)
+    )
     results = session.exec(statement)
     data = results.all()
-    
+
     chart_data = [
         Ndx1mChartData(
             time=item.timestamp.timestamp(),

--- a/apps/backend/app/utils/ndx_data.py
+++ b/apps/backend/app/utils/ndx_data.py
@@ -1,50 +1,99 @@
+"""NDX market data synchronization helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import date as date_type
+from datetime import datetime, timedelta
+from decimal import Decimal
+import logging
+from typing import Any
+
 import yfinance as yf
-import sys
-import os
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
-from sqlmodel import Session, select
+from sqlmodel import Session
+
 from app.dal.database import engine
 from app.schema.models import Ndx1m
-from datetime import datetime, timedelta
 
-def sync_ndx_data(date_str: str):
+logger = logging.getLogger(__name__)
+NDX_SYMBOL = "^NDX"
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a database session using the configured worker engine."""
+
+    return Session(engine)
+
+
+def _decimal_from_market_value(value: object) -> Decimal:
+    """Convert yfinance numeric values to Decimal for financial precision."""
+
+    return Decimal(str(value))
+
+
+def _to_python_datetime(timestamp: Any) -> datetime:
+    """Convert a pandas/yfinance timestamp object to a Python datetime."""
+
+    if hasattr(timestamp, "to_pydatetime"):
+        return timestamp.to_pydatetime()
+    if isinstance(timestamp, datetime):
+        return timestamp
+    raise TypeError(f"Unsupported timestamp value: {timestamp!r}")
+
+
+def sync_ndx_data(
+    target_date: str | date_type,
+    *,
+    ticker_factory: Callable[[str], Any] = yf.Ticker,
+    session_factory: Callable[[], AbstractContextManager[Session]] = _default_session_factory,
+) -> dict[str, object]:
+    """Download 1-minute NDX data for a date and upsert it into ``ndx1m``.
+
+    yfinance failures are logged and returned as skipped results so scheduled
+    worker runs do not crash on transient market-data errors.
     """
-    Downloads 1-minute NDX data for a given date and stores it in the database.
-    """
-    start_date = datetime.strptime(date_str, "%Y-%m-%d")
+
+    if isinstance(target_date, str):
+        start_date = datetime.strptime(target_date, "%Y-%m-%d")
+        date_str = target_date
+    else:
+        start_date = datetime.combine(target_date, datetime.min.time())
+        date_str = target_date.isoformat()
     end_date = start_date + timedelta(days=1)
 
-    # Download data
-    ndx_ticker = yf.Ticker("^NDX")
-    hist = ndx_ticker.history(start=start_date.strftime("%Y-%m-%d"), end=end_date.strftime("%Y-%m-%d"), interval="1m")
+    try:
+        ndx_ticker = ticker_factory(NDX_SYMBOL)
+        hist = ndx_ticker.history(
+            start=start_date.strftime("%Y-%m-%d"),
+            end=end_date.strftime("%Y-%m-%d"),
+            interval="1m",
+        )
+    except Exception as exc:  # noqa: BLE001 - scheduled market-data sync must skip on provider failures
+        logger.warning("Skipping NDX sync for %s after yfinance error: %s", date_str, exc)
+        return {"status": "skipped", "rows": 0, "date": date_str, "error": str(exc)}
 
     if hist.empty:
-        return {"message": f"No data found for {date_str}"}
+        logger.info("No NDX data returned for %s", date_str)
+        return {"status": "skipped", "rows": 0, "date": date_str, "message": f"No data found for {date_str}"}
 
-    # Store data in the database
-    with Session(engine) as session:
-        # Use a transaction to ensure atomicity
+    rows_written = 0
+    with session_factory() as session:
         with session.begin():
-            # Delete existing data for the given date
-            # Delete existing data for the given date
-            # Delete existing data for the given date
-            statement = select(Ndx1m).where(Ndx1m.timestamp >= start_date).where(Ndx1m.timestamp < end_date)
-            results = session.exec(statement)
-            for record in results:
-                session.delete(record)
-
-            # Insert new data
             for i in range(len(hist)):
                 row = hist.iloc[i]
-                timestamp = hist.index[i]
-                db_record = Ndx1m(
-                    timestamp=timestamp.to_pydatetime(),
-                    open=float(row['Open']),
-                    high=float(row['High']),
-                    low=float(row['Low']),
-                    close=float(row['Close']),
-                    volume=int(row['Volume'])
+                timestamp = _to_python_datetime(hist.index[i])
+                session.merge(
+                    Ndx1m(
+                        timestamp=timestamp,
+                        open=_decimal_from_market_value(row["Open"]),
+                        high=_decimal_from_market_value(row["High"]),
+                        low=_decimal_from_market_value(row["Low"]),
+                        close=_decimal_from_market_value(row["Close"]),
+                        volume=int(row["Volume"]),
+                    )
                 )
-                session.add(db_record)
+                rows_written += 1
 
-    return {"message": f"Successfully synced NDX data for {date_str}"}
+    logger.info("Synced %d NDX row(s) for %s", rows_written, date_str)
+    return {"status": "success", "rows": rows_written, "date": date_str}

--- a/apps/backend/app/worker/ndx_daily_sync.py
+++ b/apps/backend/app/worker/ndx_daily_sync.py
@@ -1,0 +1,48 @@
+"""Scheduled NDX daily market data sync."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from zoneinfo import ZoneInfo
+
+from app.utils.ndx_data import sync_ndx_data
+from app.worker.registry import JOB_SCHEDULES, JobSchedule
+from app.worker.scheduler import _worker_timezone
+
+logger = logging.getLogger(__name__)
+NDX_DAILY_SYNC_JOB_ID = "ndx_daily_sync"
+NDX_DAILY_SYNC_CRON = "30 23 * * *"
+
+
+def _trading_day() -> str:
+    """Return the US trading date to sync from the worker timezone."""
+
+    return datetime.now(ZoneInfo(_worker_timezone())).date().isoformat()
+
+
+def sync_ndx_daily_job() -> None:
+    """Run the idempotent daily NDX sync and log failures without raising."""
+
+    target_date = _trading_day()
+    try:
+        result = sync_ndx_data(target_date)
+    except Exception:  # noqa: BLE001 - scheduler must keep running if one sync fails
+        logger.exception("NDX daily sync failed for %s", target_date)
+        return
+
+    if result.get("status") == "skipped":
+        logger.info("NDX daily sync skipped: %s", result)
+    else:
+        logger.info("NDX daily sync completed: %s", result)
+
+
+if not any(schedule.job_id == NDX_DAILY_SYNC_JOB_ID for schedule in JOB_SCHEDULES):
+    JOB_SCHEDULES.append(
+        JobSchedule(
+            job_id=NDX_DAILY_SYNC_JOB_ID,
+            kind="cron",
+            cron_expr=NDX_DAILY_SYNC_CRON,
+            handler=sync_ndx_daily_job,
+        )
+    )

--- a/apps/backend/app/worker/runtime.py
+++ b/apps/backend/app/worker/runtime.py
@@ -7,6 +7,7 @@ import os
 import signal
 import time
 
+from app.worker import ndx_daily_sync  # noqa: F401 - imports schedule registration side effect
 from app.worker.job_queue import poll_compute_jobs
 from app.worker.registry import JOB_SCHEDULES
 from app.worker.scheduler import get_scheduler, register_cron, register_interval

--- a/apps/backend/tests/test_ndx_daily_sync.py
+++ b/apps/backend/tests/test_ndx_daily_sync.py
@@ -1,0 +1,111 @@
+"""Tests for scheduled NDX market data synchronization."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pandas as pd
+from sqlmodel import Session, select
+
+from app.schema.models import Ndx1m
+from app.utils.ndx_data import NDX_SYMBOL, sync_ndx_data
+from app.worker.ndx_daily_sync import NDX_DAILY_SYNC_CRON, NDX_DAILY_SYNC_JOB_ID, sync_ndx_daily_job
+from app.worker.registry import JOB_SCHEDULES
+
+
+class FakeTicker:
+    """Minimal yfinance ticker fake for deterministic history responses."""
+
+    def __init__(self, frame: pd.DataFrame | None = None, exc: Exception | None = None) -> None:
+        self.frame = frame
+        self.exc = exc
+
+    def history(self, **_kwargs: Any) -> pd.DataFrame:
+        """Return the configured frame or raise the configured exception."""
+
+        if self.exc is not None:
+            raise self.exc
+        assert self.frame is not None
+        return self.frame
+
+
+def _history(close: str) -> pd.DataFrame:
+    """Build one yfinance-style OHLCV row."""
+
+    return pd.DataFrame(
+        [
+            {
+                "Open": "100.125",
+                "High": "101.250",
+                "Low": "99.750",
+                "Close": close,
+                "Volume": 12345,
+            }
+        ],
+        index=pd.DatetimeIndex(["2026-05-04T13:30:00"]),
+    )
+
+
+def test_sync_ndx_data_upserts_decimal_rows(engine) -> None:
+    """NDX sync writes Decimal prices and updates existing timestamp rows."""
+
+    seen_symbols: list[str] = []
+
+    def ticker_factory(symbol: str) -> FakeTicker:
+        seen_symbols.append(symbol)
+        return FakeTicker(_history("100.500"))
+
+    result = sync_ndx_data(
+        "2026-05-04",
+        ticker_factory=ticker_factory,
+        session_factory=lambda: Session(engine),
+    )
+
+    assert result == {"status": "success", "rows": 1, "date": "2026-05-04"}
+    assert seen_symbols == [NDX_SYMBOL]
+
+    with Session(engine) as session:
+        row = session.exec(select(Ndx1m)).one()
+        assert row.open == Decimal("100.125000")
+        assert row.close == Decimal("100.500000")
+
+    sync_ndx_data(
+        "2026-05-04",
+        ticker_factory=lambda _symbol: FakeTicker(_history("102.750")),
+        session_factory=lambda: Session(engine),
+    )
+
+    with Session(engine) as session:
+        rows = session.exec(select(Ndx1m)).all()
+        assert len(rows) == 1
+        assert rows[0].close == Decimal("102.750000")
+
+
+def test_sync_ndx_data_skips_and_logs_yfinance_errors(engine, caplog) -> None:
+    """Provider errors are skipped so scheduler runs do not crash."""
+
+    result = sync_ndx_data(
+        "2026-05-04",
+        ticker_factory=lambda _symbol: FakeTicker(exc=RuntimeError("provider down")),
+        session_factory=lambda: Session(engine),
+    )
+
+    assert result["status"] == "skipped"
+    assert result["rows"] == 0
+    assert result["error"] == "provider down"
+    assert "Skipping NDX sync" in caplog.text
+
+    with Session(engine) as session:
+        assert session.exec(select(Ndx1m)).all() == []
+
+
+def test_ndx_daily_sync_schedule_is_registered() -> None:
+    """The worker registers the daily NDX cron schedule."""
+
+    matches = [schedule for schedule in JOB_SCHEDULES if schedule.job_id == NDX_DAILY_SYNC_JOB_ID]
+
+    assert len(matches) == 1
+    assert matches[0].kind == "cron"
+    assert matches[0].cron_expr == NDX_DAILY_SYNC_CRON
+    assert matches[0].handler is sync_ndx_daily_job

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -20,7 +20,6 @@ const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/analyze',
   '/api/bonds/scanner',
   '/api/finances/price',
-  '/api/ndx/sync',
   '/api/trading/sync',
   '/api/pension',
 ];

--- a/apps/frontend/src/app/ndx/actions.ts
+++ b/apps/frontend/src/app/ndx/actions.ts
@@ -23,7 +23,7 @@ function nextDate(date: string): string {
 /**
  * Returns stored NDX 1-minute OHLC rows for the given day.
  *
- * NDX sync remains on FastAPI because it calls yfinance/external market data;
+ * NDX sync is performed by the private backend worker's scheduled batch;
  * this action is intentionally read-only over Supabase RLS-protected data.
  */
 export async function getNdxChartData(date: string): Promise<NdxChartData[]> {


### PR DESCRIPTION
Closes #215

Umbrella: #207
Related: #219
ADR: .squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md
Working as Hockney (Backend Dev)

## Summary
- Registers `ndx_daily_sync` as a daily APScheduler cron at `30 23 * * *` in the worker timezone (default `Asia/Jerusalem`).
- Reuses existing `ndx1m` storage and upserts yfinance 1-minute NDX rows with Decimal prices.
- Logs and skips yfinance provider errors so scheduler runs do not crash.
- Marks the legacy `/api/ndx/sync/{date}` route deprecated and removes `/api/ndx/sync` from the walkthrough allow-list.

## Validation
- `cd apps/backend && uv run pytest tests/test_ndx_daily_sync.py tests/test_worker_job_queue.py -q`
- `cd apps/backend && uv run ruff check app/utils/ndx_data.py app/worker/ndx_daily_sync.py app/worker/runtime.py app/api/ndx.py tests/test_ndx_daily_sync.py`
- `cd apps/frontend && npm test -- src/app/ndx/actions.test.ts`