### PR TITLE
feat(TJ-020): migrate finances/price to scheduled cache (#214)

### DIFF
--- a/apps/backend/app/api/finances.py
+++ b/apps/backend/app/api/finances.py
@@ -9,48 +9,33 @@ from app.dal.database import get_session
 from app.dependencies import get_current_user_id
 from app.schema.finance_models import FinanceSnapshot, SnapshotData
 from app.services.household_service import get_user_household_id
+from app.services.price_cache import fetch_external_price
 
 router = APIRouter(prefix="/api/finances", tags=["finances"])
 
 
-@router.get("/price/{symbol}")
+@router.get("/price/{symbol}", deprecated=True)
 def get_stock_price(symbol: str):
+    """Deprecated live lookup retained for local maintenance only.
+
+    TJ-020 moved frontend reads to ``public.price_cache`` populated by the
+    scheduled ``prices_refresh`` worker. New callers should read that cache.
     """
-    Get real-time stock price from Yahoo Finance.
-    """
-    import yfinance as yf
+
     try:
-        ticker = yf.Ticker(symbol)
-        # fast_info is often faster than history(period='1d')
-        price = ticker.fast_info.last_price
-        
-        # Fallback if fast_info fails or returns None
-        if not price:
-            history = ticker.history(period="1d")
-            if not history.empty:
-                price = history['Close'].iloc[-1]
-        
-        if not price:
-             raise HTTPException(status_code=404, detail=f"Could not fetch price for {symbol}")
+        quote = fetch_external_price(symbol)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001 - deprecated endpoint preserves legacy 500s
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-        # Try to get dividend yield from info (slower but more detailed)
-        dividend_yield = 0
-        try:
-            info = ticker.info
-            # dividendYield is returned as percentage (e.g. 0.77 for 0.77% or 6.97 for 6.97%)
-            if 'dividendYield' in info and info['dividendYield']:
-                dividend_yield = round(info['dividendYield'], 2)
-        except:
-            pass # Ignore info fetch failures
-
-        return {
-            "symbol": symbol.upper(),
-            "price": round(price, 2),
-            "currency": ticker.fast_info.currency or "USD",
-            "dividend_yield": dividend_yield
-        }
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return {
+        "symbol": quote.symbol,
+        "price": str(quote.price),
+        "currency": quote.currency,
+        "as_of": quote.as_of.isoformat(),
+        "deprecated": True,
+    }
 
 
 @router.get("/latest", response_model=FinanceSnapshot)

--- a/apps/backend/app/services/price_cache.py
+++ b/apps/backend/app/services/price_cache.py
@@ -1,0 +1,218 @@
+"""Price-cache refresh service for TJ-020 scheduled workers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+import logging
+from typing import Protocol, cast
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+
+logger = logging.getLogger(__name__)
+DEFAULT_CURRENCY = "USD"
+
+
+class SessionFactory(Protocol):
+    """Callable protocol for creating worker database sessions."""
+
+    def __call__(self) -> AbstractContextManager[Session]:
+        """Return a database session context manager."""
+
+
+@dataclass(frozen=True)
+class PriceSymbol:
+    """A market symbol and target display currency referenced by user data."""
+
+    symbol: str
+    currency: str
+
+
+@dataclass(frozen=True)
+class PriceQuote:
+    """External market price quote represented with Decimal precision."""
+
+    symbol: str
+    currency: str
+    price: Decimal
+    as_of: datetime
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a SQLModel session using the configured privileged DB engine."""
+
+    return Session(engine)
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Normalize ticker symbols before lookup/cache writes."""
+
+    return symbol.strip().upper()
+
+
+def normalize_currency(currency: str | None) -> str:
+    """Normalize currency codes, defaulting blank values to USD."""
+
+    normalized = (currency or DEFAULT_CURRENCY).strip().upper()
+    return normalized or DEFAULT_CURRENCY
+
+
+def _to_decimal(value: object) -> Decimal | None:
+    """Convert yfinance numeric values to Decimal without retaining binary floats."""
+
+    if value is None:
+        return None
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+    if not amount.is_finite() or amount <= 0:
+        return None
+    return amount
+
+
+def fetch_external_price(symbol: str) -> PriceQuote:
+    """Fetch one symbol from Yahoo Finance for the scheduled cache refresh."""
+
+    import yfinance as yf
+
+    normalized_symbol = normalize_symbol(symbol)
+    ticker = yf.Ticker(normalized_symbol)
+    fast_info = ticker.fast_info
+    price = _to_decimal(getattr(fast_info, "last_price", None))
+
+    if price is None:
+        history = ticker.history(period="1d")
+        if not history.empty:
+            price = _to_decimal(history["Close"].iloc[-1])
+
+    if price is None:
+        raise ValueError(f"Could not fetch price for {normalized_symbol}")
+
+    currency = normalize_currency(getattr(fast_info, "currency", None))
+    return PriceQuote(
+        symbol=normalized_symbol,
+        currency=currency,
+        price=price,
+        as_of=datetime.now(UTC),
+    )
+
+
+class PriceCacheRefresher:
+    """Refresh public.price_cache from all symbols referenced by holdings."""
+
+    def __init__(
+        self,
+        session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+        price_fetcher: Callable[[str], PriceQuote] = fetch_external_price,
+    ) -> None:
+        """Initialize the refresher with injectable DB and market-data adapters."""
+
+        self.session_factory = session_factory or _default_session_factory
+        self.price_fetcher = price_fetcher
+
+    def refresh_once(self) -> dict[str, int]:
+        """Refresh every referenced symbol, isolating external errors per symbol."""
+
+        refreshed = 0
+        failed = 0
+        with self.session_factory() as session:
+            symbols = self._load_symbols(session)
+            for symbol_ref in symbols:
+                try:
+                    quote = self.price_fetcher(symbol_ref.symbol)
+                    self._upsert_quote(session, quote)
+                    session.commit()
+                    refreshed += 1
+                except Exception:  # noqa: BLE001 - one bad ticker must not stop the batch
+                    session.rollback()
+                    failed += 1
+                    logger.exception("Failed to refresh price for %s", symbol_ref.symbol)
+        return {"symbols": len(symbols), "refreshed": refreshed, "failed": failed}
+
+    def _load_symbols(self, session: Session) -> list[PriceSymbol]:
+        """Return distinct symbols from holdings, positions, snapshots, and plans."""
+
+        rows = session.execute(
+            text(
+                """
+                with referenced_symbols as (
+                  select symbol, currency
+                    from public.trading_positions
+                   where nullif(trim(symbol), '') is not null
+                  union
+                  select ticker as symbol, 'USD' as currency
+                    from public.dividend_positions
+                   where nullif(trim(ticker), '') is not null
+                  union
+                  select ticker as symbol, currency
+                    from public.bond_holdings
+                   where nullif(trim(ticker), '') is not null
+                     and deleted_at is null
+                  union
+                  select item->'account_settings'->>'stock_symbol' as symbol,
+                         coalesce(item->>'currency', 'USD') as currency
+                    from public.finance_snapshots fs
+                    cross join lateral jsonb_array_elements(
+                      case when jsonb_typeof(fs.data->'items') = 'array' then fs.data->'items' else '[]'::jsonb end
+                    ) item
+                   where nullif(trim(item->'account_settings'->>'stock_symbol'), '') is not null
+                  union
+                  select item->'account_settings'->>'stock_symbol' as symbol,
+                         coalesce(item->>'currency', 'USD') as currency
+                    from public.plans p
+                    cross join lateral jsonb_array_elements(
+                      case when jsonb_typeof(p.data->'items') = 'array' then p.data->'items' else '[]'::jsonb end
+                    ) item
+                   where nullif(trim(item->'account_settings'->>'stock_symbol'), '') is not null
+                )
+                select distinct upper(trim(symbol)) as symbol,
+                       coalesce(nullif(upper(trim(currency)), ''), 'USD') as currency
+                  from referenced_symbols
+                 where nullif(trim(symbol), '') is not null
+                 order by symbol, currency
+                """
+            )
+        ).mappings()
+
+        return [
+            PriceSymbol(
+                symbol=normalize_symbol(cast(str, row["symbol"])),
+                currency=normalize_currency(cast(str | None, row["currency"])),
+            )
+            for row in rows
+        ]
+
+    def _upsert_quote(self, session: Session, quote: PriceQuote) -> None:
+        """Upsert a fetched quote into public.price_cache using quote currency."""
+
+        session.execute(
+            text(
+                """
+                insert into public.price_cache (symbol, currency, price, as_of, refreshed_at)
+                values (:symbol, :currency, :price, :as_of, now())
+                on conflict (symbol, currency) do update
+                   set price = excluded.price,
+                       as_of = excluded.as_of,
+                       refreshed_at = now()
+                """
+            ),
+            {
+                "symbol": quote.symbol,
+                "currency": quote.currency,
+                "price": quote.price,
+                "as_of": quote.as_of,
+            },
+        )
+
+
+def refresh_price_cache() -> dict[str, int]:
+    """Run one scheduled price-cache refresh using the global DB engine."""
+
+    return PriceCacheRefresher().refresh_once()

--- a/apps/backend/app/worker/price_cache.py
+++ b/apps/backend/app/worker/price_cache.py
@@ -1,0 +1,15 @@
+"""Scheduled price-cache worker registration."""
+
+from app.services.price_cache import refresh_price_cache
+from app.worker.registry import JOB_SCHEDULES, JobSchedule
+
+PRICES_REFRESH_INTERVAL_SECONDS = 60 * 60
+
+JOB_SCHEDULES.append(
+    JobSchedule(
+        job_id="prices_refresh",
+        kind="interval",
+        seconds=PRICES_REFRESH_INTERVAL_SECONDS,
+        handler=refresh_price_cache,
+    )
+)

--- a/apps/backend/app/worker/runtime.py
+++ b/apps/backend/app/worker/runtime.py
@@ -7,6 +7,7 @@ import os
 import signal
 import time
 
+from app.worker import price_cache as _price_cache  # noqa: F401 - registers scheduled jobs
 from app.worker.job_queue import poll_compute_jobs
 from app.worker.registry import JOB_SCHEDULES
 from app.worker.scheduler import get_scheduler, register_cron, register_interval

--- a/apps/backend/tests/test_price_cache_worker.py
+++ b/apps/backend/tests/test_price_cache_worker.py
@@ -1,0 +1,133 @@
+"""Tests for TJ-020 scheduled price-cache refresh."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+from app.services.price_cache import PriceCacheRefresher, PriceQuote
+from app.worker.registry import JOB_SCHEDULES
+from app.worker.runtime import start_worker  # noqa: F401 - imports schedule registration
+
+
+class FakeMappings:
+    """Result wrapper that mimics SQLAlchemy's mappings() API."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class FakeSession(AbstractContextManager["FakeSession"]):
+    """Minimal SQLAlchemy session fake for refresh assertions."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.executions: list[dict[str, Any]] = []
+        self.commits = 0
+        self.rollbacks = 0
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(self, *_args: object) -> bool:
+        return False
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        sql = str(statement)
+        self.executions.append({"sql": sql, "params": params or {}})
+        if "with referenced_symbols as" in sql:
+            return FakeMappings(self.rows)
+        return FakeMappings([])
+
+    def commit(self) -> None:
+        """Record a successful per-symbol commit."""
+
+        self.commits += 1
+
+    def rollback(self) -> None:
+        """Record isolated per-symbol failure rollback."""
+
+        self.rollbacks += 1
+
+
+def test_prices_refresh_schedule_registered() -> None:
+    """The backend worker registers the hourly price refresh interval."""
+
+    schedule = next(s for s in JOB_SCHEDULES if s.job_id == "prices_refresh")
+    assert schedule.kind == "interval"
+    assert schedule.seconds == 60 * 60
+
+
+def test_price_refresher_fetches_and_upserts_symbols() -> None:
+    """The refresher loads referenced symbols, fetches prices, and upserts cache rows."""
+
+    session = FakeSession(
+        [
+            {"symbol": "aapl", "currency": "usd"},
+            {"symbol": "msft", "currency": "USD"},
+        ]
+    )
+    seen_symbols: list[str] = []
+
+    def fetcher(symbol: str) -> PriceQuote:
+        seen_symbols.append(symbol)
+        return PriceQuote(
+            symbol=symbol,
+            currency="USD",
+            price=Decimal("123.45"),
+            as_of=datetime(2026, 5, 3, 12, tzinfo=UTC),
+        )
+
+    refresher = PriceCacheRefresher(session_factory=lambda: session, price_fetcher=fetcher)
+
+    result = refresher.refresh_once()
+
+    assert result == {"symbols": 2, "refreshed": 2, "failed": 0}
+    assert seen_symbols == ["AAPL", "MSFT"]
+    upserts = [call for call in session.executions if "insert into public.price_cache" in call["sql"]]
+    assert len(upserts) == 2
+    assert upserts[0]["params"] == {
+        "symbol": "AAPL",
+        "currency": "USD",
+        "price": Decimal("123.45"),
+        "as_of": datetime(2026, 5, 3, 12, tzinfo=UTC),
+    }
+    assert "on conflict (symbol, currency) do update" in upserts[0]["sql"]
+    assert session.commits == 2
+
+
+def test_price_refresher_continues_after_symbol_failure() -> None:
+    """External lookup failures are isolated per symbol."""
+
+    session = FakeSession(
+        [
+            {"symbol": "bad", "currency": "USD"},
+            {"symbol": "good", "currency": "USD"},
+        ]
+    )
+
+    def fetcher(symbol: str) -> PriceQuote:
+        if symbol == "BAD":
+            raise RuntimeError("lookup failed")
+        return PriceQuote(
+            symbol=symbol,
+            currency="USD",
+            price=Decimal("10.00"),
+            as_of=datetime(2026, 5, 3, 12, tzinfo=UTC),
+        )
+
+    refresher = PriceCacheRefresher(session_factory=lambda: session, price_fetcher=fetcher)
+
+    result = refresher.refresh_once()
+
+    assert result == {"symbols": 2, "refreshed": 1, "failed": 1}
+    assert session.rollbacks == 1
+    assert session.commits == 1
+    assert any(call["params"].get("symbol") == "GOOD" for call in session.executions)

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -19,7 +19,6 @@ const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/backtest',
   '/api/analyze',
   '/api/bonds/scanner',
-  '/api/finances/price',
   '/api/ndx/sync',
   '/api/trading/sync',
   '/api/pension',

--- a/apps/frontend/src/app/finances/__tests__/actions.test.ts
+++ b/apps/frontend/src/app/finances/__tests__/actions.test.ts
@@ -11,7 +11,7 @@
  *  6. Returns null when not authenticated.
  *  7. Returns null when user has no active household.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Supabase mock infrastructure ──────────────────────────────────────────────
 
@@ -25,6 +25,7 @@ import {
   deleteFinanceSnapshot,
   getFinanceHistory,
   getLatestFinanceSnapshot,
+  getPrice,
   saveFinanceSnapshot,
 } from '../actions';
 import { createClient } from '@/lib/supabase/server';
@@ -71,6 +72,10 @@ function fluentChain(result: unknown) {
 
 beforeEach(() => {
   vi.resetAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 // ── Auth / access control ─────────────────────────────────────────────────────
@@ -175,6 +180,54 @@ describe('getLatestFinanceSnapshot — snapshot retrieval', () => {
 });
 
 // ── History / write actions ───────────────────────────────────────────────────
+
+describe('getPrice', () => {
+  it('returns a cached price with stale status', async () => {
+    authOk();
+    vi.setSystemTime(new Date('2026-05-03T18:30:00Z'));
+    const priceChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: {
+          price: '123.450000',
+          as_of: '2026-05-03T12:00:00Z',
+          refreshed_at: '2026-05-03T13:00:00Z',
+        },
+        error: null,
+      }),
+    };
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'price_cache') return priceChain;
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getPrice(' aapl ', ' usd ');
+
+    expect(result).toEqual({
+      price: '123.45',
+      as_of: '2026-05-03T12:00:00Z',
+      refreshed_at: '2026-05-03T13:00:00Z',
+      isStale: true,
+    });
+    expect(priceChain.eq).toHaveBeenNthCalledWith(1, 'symbol', 'AAPL');
+    expect(priceChain.eq).toHaveBeenNthCalledWith(2, 'currency', 'USD');
+  });
+
+  it('returns null when no cache row exists', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSupabaseMock({
+        price_cache: () => fluentChain({ data: null, error: null }),
+      }),
+    );
+
+    await expect(getPrice('MSFT', 'USD')).resolves.toBeNull();
+  });
+});
 
 describe('getFinanceHistory', () => {
   it('returns snapshots ordered by date desc with the requested limit', async () => {

--- a/apps/frontend/src/app/finances/actions.ts
+++ b/apps/frontend/src/app/finances/actions.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import Decimal from 'decimal.js';
 import { createClient } from '@/lib/supabase/server';
 import { convertCurrency } from '@/lib/currency';
 import type { FinanceItem } from '@/components/CurrentFinances/FinanceTabs';
@@ -35,6 +36,21 @@ export type SaveFinanceSnapshotResult =
 export type DeleteFinanceSnapshotResult =
   | { success: true }
   | { success: false; error: string };
+
+export interface PriceCacheResult {
+  price: string;
+  as_of: string;
+  refreshed_at: string;
+  isStale: boolean;
+}
+
+interface PriceCacheRow {
+  price: string | number;
+  as_of: string;
+  refreshed_at: string;
+}
+
+const PRICE_CACHE_STALE_MS = 4 * 60 * 60 * 1000;
 
 // Raw rows from dividend tables — typed narrowly to avoid over-fetching
 interface DividendAccountRow {
@@ -181,6 +197,52 @@ async function enrichWithDividends(items: FinanceItem[]): Promise<void> {
 }
 
 // ── Server Action ─────────────────────────────────────────────────────────────
+
+/**
+ * Reads the latest scheduled price-cache row for an authenticated user.
+ *
+ * Prices remain strings to preserve Postgres numeric precision; callers that
+ * need arithmetic should construct a Decimal from the returned value.
+ */
+export async function getPrice(symbol: string, currency = 'USD'): Promise<PriceCacheResult | null> {
+  const normalizedSymbol = symbol.trim().toUpperCase();
+  const normalizedCurrency = currency.trim().toUpperCase() || 'USD';
+  if (!normalizedSymbol) return null;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+
+  const { data, error } = await supabase
+    .from('price_cache')
+    .select('price, as_of, refreshed_at')
+    .eq('symbol', normalizedSymbol)
+    .eq('currency', normalizedCurrency)
+    .maybeSingle();
+
+  if (error || !data) {
+    if (error) console.error('[getPrice] query error:', error.message);
+    return null;
+  }
+
+  const row = data as PriceCacheRow;
+  const price = new Decimal(String(row.price));
+  if (!price.isFinite() || price.lte(0)) return null;
+
+  const refreshedAtMs = new Date(row.refreshed_at).getTime();
+  const isStale = !Number.isFinite(refreshedAtMs) || Date.now() - refreshedAtMs > PRICE_CACHE_STALE_MS;
+
+  return {
+    price: price.toString(),
+    as_of: row.as_of,
+    refreshed_at: row.refreshed_at,
+    isStale,
+  };
+}
 
 /**
  * Returns the most-recent finance snapshot for the authenticated user's

--- a/apps/frontend/src/components/Plan/PlanAccountDetails.tsx
+++ b/apps/frontend/src/components/Plan/PlanAccountDetails.tsx
@@ -1,5 +1,6 @@
-import { apiFetch } from '@/lib/api-client';
+import Decimal from 'decimal.js';
 import React from 'react';
+import { getPrice } from '@/app/finances/actions';
 import { PlanItem, PlanMilestone } from './types';
 import { CurrencySelector } from '../Common/CurrencySelector';
 
@@ -10,7 +11,11 @@ interface Props {
     milestones?: PlanMilestone[];
 }
 
+type AccountType = NonNullable<PlanItem['account_settings']>['type'];
+type DividendPayoutStartCondition = NonNullable<NonNullable<PlanItem['account_settings']>['dividend_payout_start_condition']>;
+
 export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'planning', milestones = [] }) => {
+    const [priceCacheStatus, setPriceCacheStatus] = React.useState<string | null>(null);
 
     const defaults = {
         type: 'Taxable' as const,
@@ -48,21 +53,27 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
         return (settings.rsu_grants || []).reduce((sum, g) => sum + (g.vested || 0), 0);
     }, [settings.rsu_grants, settings.type]);
 
-    // Helper to fetch data
-    const fetchMarketData = async (symbol: string, type: 'price' | 'yield') => {
+    // Helper to read the scheduled Supabase price cache.
+    const fetchMarketData = async (symbol: string) => {
         try {
-            const res = await apiFetch(`/api/finances/price/${symbol}`);
-            if (!res.ok) throw new Error('Failed to fetch');
-            const data = await res.json();
+            setPriceCacheStatus('Loading cached price…');
+            const data = await getPrice(symbol, item.currency || 'USD');
+            if (!data) {
+                setPriceCacheStatus('No cached price yet. It refreshes hourly when the worker is running.');
+                return;
+            }
 
-            if (type === 'price' && data.price) {
-                updateSettings({ current_price: data.price });
-            }
-            if (type === 'yield' && data.dividend_yield !== undefined) {
-                updateSettings({ dividend_yield: data.dividend_yield });
-            }
+            const price = new Decimal(data.price);
+            updateSettings({ current_price: price.toNumber() });
+            const refreshedAt = new Date(data.refreshed_at).toLocaleString();
+            setPriceCacheStatus(
+                data.isStale
+                    ? `Cached price is stale (last refreshed ${refreshedAt}).`
+                    : `Cached price refreshed ${refreshedAt}.`,
+            );
         } catch (e) {
             console.error(e);
+            setPriceCacheStatus('Failed to read cached price.');
         }
     };
 
@@ -70,18 +81,11 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
     React.useEffect(() => {
         if (mode === 'snapshot' && settings.type === 'RSU' && settings.stock_symbol && settings.stock_symbol.length > 1) {
             const timer = setTimeout(() => {
-                fetchMarketData(settings.stock_symbol!, 'price');
+                fetchMarketData(settings.stock_symbol!);
             }, 800);
             return () => clearTimeout(timer);
         }
     }, [settings.stock_symbol, mode, settings.type]);
-
-    // Auto-fetch Yield in Planning Mode on mount
-    React.useEffect(() => {
-        if (mode === 'planning' && settings.type === 'RSU' && settings.stock_symbol) {
-            fetchMarketData(settings.stock_symbol, 'yield');
-        }
-    }, [mode, settings.type, settings.stock_symbol]);
 
     return (
         <div className="space-y-4">
@@ -131,7 +135,7 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
                         <select
                             className="w-full bg-slate-900 border-slate-700 rounded p-2 text-white"
                             value={settings.type}
-                            onChange={e => updateSettings({ type: e.target.value as any })}
+                            onChange={e => updateSettings({ type: e.target.value as AccountType })}
                         >
                             <option value="Taxable">Taxable (Generic)</option>
                             <option value="Broker">Brokerage</option>
@@ -147,6 +151,11 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
                         </select>
                     </div>
                 </div>
+                {settings.type === 'RSU' && priceCacheStatus && (
+                    <p className={`text-xs ${priceCacheStatus.includes('stale') ? 'text-amber-300' : 'text-slate-400'}`}>
+                        {priceCacheStatus}
+                    </p>
+                )}
             </div>
 
             {/* SAVINGS SPECIFIC FIELDS */}
@@ -581,7 +590,7 @@ export const PlanAccountDetails: React.FC<Props> = ({ item, onChange, mode = 'pl
                                             <select
                                                 className="w-full bg-slate-900 border-slate-700 rounded p-2 text-white text-sm"
                                                 value={settings.dividend_payout_start_condition || 'Immediate'}
-                                                onChange={e => updateSettings({ dividend_payout_start_condition: e.target.value as any })}
+                                                onChange={e => updateSettings({ dividend_payout_start_condition: e.target.value as DividendPayoutStartCondition })}
                                             >
                                                 <option value="Immediate">Immediate</option>
                                                 <option value="Age">At Age...</option>

--- a/supabase/migrations/20260503170000_add_price_cache.sql
+++ b/supabase/migrations/20260503170000_add_price_cache.sql
@@ -1,0 +1,51 @@
+-- Migration: add_price_cache
+-- Purpose: TJ-020 scheduled price cache for frontend Supabase-only reads.
+
+create table if not exists public.price_cache (
+  symbol text not null,
+  currency text not null,
+  price numeric not null,
+  as_of timestamptz not null,
+  refreshed_at timestamptz not null default now(),
+  constraint price_cache_pkey primary key (symbol, currency),
+  constraint price_cache_symbol_not_blank check (length(btrim(symbol)) > 0),
+  constraint price_cache_currency_not_blank check (length(btrim(currency)) > 0),
+  constraint price_cache_price_positive check (price > 0)
+);
+
+alter table public.price_cache enable row level security;
+
+revoke all on table public.price_cache from anon;
+revoke all on table public.price_cache from authenticated;
+grant select on table public.price_cache to authenticated;
+grant select, insert, update on table public.price_cache to service_role;
+
+drop policy if exists price_cache_authenticated_select on public.price_cache;
+create policy price_cache_authenticated_select
+  on public.price_cache
+  for select
+  to authenticated
+  using (true);
+
+drop policy if exists price_cache_service_insert on public.price_cache;
+create policy price_cache_service_insert
+  on public.price_cache
+  for insert
+  to service_role
+  with check (true);
+
+drop policy if exists price_cache_service_update on public.price_cache;
+create policy price_cache_service_update
+  on public.price_cache
+  for update
+  to service_role
+  using (true)
+  with check (true);
+
+do $$
+begin
+  alter publication supabase_realtime add table public.price_cache;
+exception
+  when duplicate_object then null;
+  when undefined_object then null;
+end $$;


### PR DESCRIPTION
Closes #214
Refs #207, #219
ADR: .squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md

Working as Hockney (Backend Dev).

## Summary
- Adds public.price_cache with numeric price, RLS authenticated reads, service-role writes, and Realtime publication.
- Registers hourly APScheduler interval job prices_refresh to collect referenced holdings/position symbols and upsert cached prices.
- Adds getPrice(symbol, currency) Server Action with 4h stale detection using Decimal.js.
- Replaces the Plan RSU /api/finances/price read with the Server Action and surfaces stale cache status.
- Marks the FastAPI /api/finances/price route deprecated and removes the walkthrough allow-list entry.

## Validation
- Supabase MCP migration applied and verified price_cache columns/RLS policies.
- uv run ruff check app/services/price_cache.py app/worker/price_cache.py app/worker/runtime.py app/api/finances.py tests/test_price_cache_worker.py
- uv run pytest tests/test_price_cache_worker.py
- npm test -- src/app/finances/__tests__/actions.test.ts
- npm run lint -- --file src/app/finances/actions.ts --file src/components/Plan/PlanAccountDetails.tsx (passes with pre-existing hook warnings)
- npx tsc --noEmit has unrelated existing errors; filtered output shows no errors for changed files.
- npm run build compiles but prerender fails without Supabase env vars.