### PR TITLE
feat(TJ-020): migrate analyze to scheduled batch (#212)

### DIFF
--- a/apps/backend/app/api/analyze.py
+++ b/apps/backend/app/api/analyze.py
@@ -36,12 +36,13 @@ from app.services.growth_story import generate_growth_story
 
 logger = logging.getLogger("trading_journal.analyze")
 
-router = APIRouter(prefix="/api/analyze", tags=["analyze"])
+router = APIRouter(prefix="/api/analyze", tags=["analyze"], deprecated=True)
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _safe_get(d: dict, key: str, default=None):
     """Get a value from a dict, returning default if missing or None."""
@@ -94,6 +95,7 @@ def _latest_value(df, row_label: str, default: float = 0.0) -> float:
 # 1. GET /api/analyze/fundamentals/{ticker}
 # ---------------------------------------------------------------------------
 
+
 @router.get("/fundamentals/{ticker}")
 async def get_fundamentals(ticker: str):
     """Company fundamentals with calculated financial metrics."""
@@ -124,9 +126,7 @@ async def get_fundamentals(ticker: str):
 
     # --- Extract raw data from info ---
     market_cap = _safe_float(info.get("marketCap"))
-    current_price = _safe_float(
-        info.get("currentPrice", info.get("regularMarketPrice"))
-    )
+    current_price = _safe_float(info.get("currentPrice", info.get("regularMarketPrice")))
     forward_eps = _safe_float(info.get("forwardEps"))
     trailing_eps = _safe_float(info.get("trailingEps"))
     dividend_yield = _safe_float(info.get("dividendYield"))
@@ -163,13 +163,16 @@ async def get_fundamentals(ticker: str):
         cost_of_debt = (interest_expense / total_debt_val) if total_debt_val > 0 else 0.0
 
         if market_cap > 0:
-            wacc = calculate_wacc(
-                market_cap=market_cap,
-                total_debt=total_debt_val,
-                cost_of_equity=cost_of_equity,
-                cost_of_debt=cost_of_debt,
-                tax_rate=tax_rate if 'tax_rate' in dir() else 0.21,
-            ) / 100.0  # Convert pct to ratio
+            wacc = (
+                calculate_wacc(
+                    market_cap=market_cap,
+                    total_debt=total_debt_val,
+                    cost_of_equity=cost_of_equity,
+                    cost_of_debt=cost_of_debt,
+                    tax_rate=tax_rate if "tax_rate" in dir() else 0.21,
+                )
+                / 100.0
+            )  # Convert pct to ratio
     except Exception as e:
         logger.debug(f"WACC calculation failed for {ticker}: {e}")
 
@@ -228,6 +231,7 @@ async def get_fundamentals(ticker: str):
         "sector": info.get("sector"),
         "market_cap": market_cap,
         "currency": info.get("currency", "USD"),
+        "current_price": current_price,
         "financials": {
             "roic": roic,
             "wacc": wacc,
@@ -259,6 +263,7 @@ async def get_fundamentals(ticker: str):
 # 2. GET /api/analyze/price-history/{ticker}
 # ---------------------------------------------------------------------------
 
+
 @router.get("/price-history/{ticker}")
 async def get_price_history(
     ticker: str,
@@ -286,14 +291,16 @@ async def get_price_history(
     data = []
     for idx, row in hist.iterrows():
         time_str = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)
-        data.append({
-            "time": time_str,
-            "open": round(_safe_float(row.get("Open")), 2),
-            "high": round(_safe_float(row.get("High")), 2),
-            "low": round(_safe_float(row.get("Low")), 2),
-            "close": round(_safe_float(row.get("Close")), 2),
-            "volume": int(_safe_float(row.get("Volume"))),
-        })
+        data.append(
+            {
+                "time": time_str,
+                "open": round(_safe_float(row.get("Open")), 2),
+                "high": round(_safe_float(row.get("High")), 2),
+                "low": round(_safe_float(row.get("Low")), 2),
+                "close": round(_safe_float(row.get("Close")), 2),
+                "volume": int(_safe_float(row.get("Volume"))),
+            }
+        )
 
     result = {
         "ticker": ticker,
@@ -309,6 +316,7 @@ async def get_price_history(
 # ---------------------------------------------------------------------------
 # 3. GET /api/analyze/technicals/{ticker}
 # ---------------------------------------------------------------------------
+
 
 @router.get("/technicals/{ticker}")
 async def get_technicals(ticker: str):
@@ -414,6 +422,7 @@ def _last_valid(values: list[float]) -> Optional[float]:
 # 4. GET /api/analyze/options/{ticker}
 # ---------------------------------------------------------------------------
 
+
 @router.get("/options/{ticker}")
 async def get_option_chain(
     ticker: str,
@@ -447,9 +456,7 @@ async def get_option_chain(
         raise HTTPException(status_code=502, detail=f"Failed to fetch option chain for {ticker}")
 
     info = t.info or {}
-    current_price = _safe_float(
-        info.get("currentPrice", info.get("regularMarketPrice"))
-    )
+    current_price = _safe_float(info.get("currentPrice", info.get("regularMarketPrice")))
 
     # --- Format calls ---
     calls = []
@@ -526,6 +533,7 @@ def _get_atm_iv(calls_df, current_price: float) -> Optional[float]:
 # 5. GET /api/analyze/synthesis/{ticker}
 # ---------------------------------------------------------------------------
 
+
 @router.get("/synthesis/{ticker}")
 async def get_synthesis(ticker: str):
     """
@@ -559,18 +567,12 @@ async def get_synthesis(ticker: str):
     growth_engine: list[str] = []
 
     if revenue_growth > 0.10:
-        growth_engine.append(
-            f"Revenue growing {revenue_growth:.0%} YoY, indicating strong top-line momentum"
-        )
+        growth_engine.append(f"Revenue growing {revenue_growth:.0%} YoY, indicating strong top-line momentum")
     elif revenue_growth > 0:
-        growth_engine.append(
-            f"Moderate revenue growth at {revenue_growth:.0%} YoY"
-        )
+        growth_engine.append(f"Moderate revenue growth at {revenue_growth:.0%} YoY")
 
     if earnings_growth > 0.15:
-        growth_engine.append(
-            f"Earnings expanding {earnings_growth:.0%} YoY, outpacing revenue growth"
-        )
+        growth_engine.append(f"Earnings expanding {earnings_growth:.0%} YoY, outpacing revenue growth")
 
     if profit_margins > 0.20:
         growth_engine.append(
@@ -578,9 +580,7 @@ async def get_synthesis(ticker: str):
         )
 
     if dividend_yield > 0.02:
-        growth_engine.append(
-            f"Attractive dividend yield of {dividend_yield:.1%} provides income component"
-        )
+        growth_engine.append(f"Attractive dividend yield of {dividend_yield:.1%} provides income component")
 
     if sector:
         growth_engine.append(f"Positioned in {sector} sector")
@@ -592,28 +592,18 @@ async def get_synthesis(ticker: str):
     bear_case: list[str] = []
 
     if forward_pe > 30:
-        bear_case.append(
-            f"Premium valuation at {forward_pe:.1f}x forward P/E leaves limited margin of safety"
-        )
+        bear_case.append(f"Premium valuation at {forward_pe:.1f}x forward P/E leaves limited margin of safety")
     elif forward_pe > 0 and forward_pe < 8:
-        bear_case.append(
-            f"Low {forward_pe:.1f}x forward P/E may signal market concerns about future earnings"
-        )
+        bear_case.append(f"Low {forward_pe:.1f}x forward P/E may signal market concerns about future earnings")
 
     if revenue_growth < 0:
-        bear_case.append(
-            f"Revenue declining {revenue_growth:.0%} YoY — growth story may be deteriorating"
-        )
+        bear_case.append(f"Revenue declining {revenue_growth:.0%} YoY — growth story may be deteriorating")
 
     if beta > 1.5:
-        bear_case.append(
-            f"High beta of {beta:.2f} implies elevated volatility relative to the broader market"
-        )
+        bear_case.append(f"High beta of {beta:.2f} implies elevated volatility relative to the broader market")
 
     if profit_margins < 0.05 and profit_margins > 0:
-        bear_case.append(
-            f"Thin profit margins at {profit_margins:.0%} leave little room for execution errors"
-        )
+        bear_case.append(f"Thin profit margins at {profit_margins:.0%} leave little room for execution errors")
 
     if profit_margins < 0:
         bear_case.append(f"Currently unprofitable with {profit_margins:.0%} margins")
@@ -622,14 +612,16 @@ async def get_synthesis(ticker: str):
         bear_case.append("No significant red flags identified from available data")
 
     # --- Price action summary (simple template) ---
-    current_price = _safe_float(
-        info.get("currentPrice", info.get("regularMarketPrice"))
-    )
+    current_price = _safe_float(info.get("currentPrice", info.get("regularMarketPrice")))
     fifty_two_high = _safe_float(info.get("fiftyTwoWeekHigh"))
     fifty_two_low = _safe_float(info.get("fiftyTwoWeekLow"))
 
     if fifty_two_high > 0 and fifty_two_low > 0 and current_price > 0:
-        range_position = (current_price - fifty_two_low) / (fifty_two_high - fifty_two_low) if (fifty_two_high - fifty_two_low) > 0 else 0.5
+        range_position = (
+            (current_price - fifty_two_low) / (fifty_two_high - fifty_two_low)
+            if (fifty_two_high - fifty_two_low) > 0
+            else 0.5
+        )
         if range_position > 0.8:
             setup_quality = "Trading near 52-week highs — momentum is strong but entry risk is elevated"
         elif range_position < 0.3:
@@ -656,6 +648,7 @@ async def get_synthesis(ticker: str):
 # ---------------------------------------------------------------------------
 # Cache Stats
 # ---------------------------------------------------------------------------
+
 
 @router.get("/cache-stats")
 async def cache_stats():
@@ -722,6 +715,7 @@ async def post_growth_story(ticker: str, body: Optional[GrowthStoryRequest] = No
         # get_synthesis returns a dict or JSONResponse; normalize
         if hasattr(template_response, "body"):
             import json as _json
+
             fallback = _json.loads(template_response.body)
         elif isinstance(template_response, dict):
             fallback = template_response
@@ -729,9 +723,7 @@ async def post_growth_story(ticker: str, body: Optional[GrowthStoryRequest] = No
             fallback = template_response
 
         fallback["source"] = "template"
-        fallback["analysis_duration_seconds"] = round(
-            time.monotonic() - start_time, 1
-        )
+        fallback["analysis_duration_seconds"] = round(time.monotonic() - start_time, 1)
         return fallback
     except HTTPException:
         raise

--- a/apps/backend/app/services/analyze_batch.py
+++ b/apps/backend/app/services/analyze_batch.py
@@ -1,0 +1,311 @@
+"""Scheduled analysis refresh jobs for TJ-020.
+
+The frontend reads analysis results from Supabase. These helpers let the local
+backend worker refresh yfinance-backed ticker analysis and growth stories on a
+schedule without exposing FastAPI business routes to the browser.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.api.analyze import (
+    get_fundamentals,
+    get_option_chain,
+    get_price_history,
+    get_synthesis,
+    get_technicals,
+    post_growth_story,
+)
+from app.dal.database import engine
+
+logger = logging.getLogger(__name__)
+STALE_AFTER_HOURS = 24
+
+
+@dataclass(frozen=True)
+class TickerInput:
+    """A household-scoped ticker discovered from tracked portfolio tables."""
+
+    ticker: str
+    household_id: UUID | None
+
+
+SessionFactory = Callable[[], Session]
+
+
+def _default_session_factory() -> Session:
+    """Return a privileged SQLModel session for worker writes."""
+
+    return Session(engine)
+
+
+def _normalize_response(value: Any) -> dict[str, Any]:
+    """Convert FastAPI route return values into plain dictionaries."""
+
+    if isinstance(value, JSONResponse):
+        decoded = json.loads(value.body.decode("utf-8"))
+        return decoded if isinstance(decoded, dict) else {"data": decoded}
+    if isinstance(value, dict):
+        return value
+    return {"data": value}
+
+
+def _json_dumps(value: dict[str, Any]) -> str:
+    """Serialize data for jsonb binds, preserving unsupported values as strings."""
+
+    return json.dumps(value, default=str, allow_nan=False)
+
+
+async def build_ticker_analysis(ticker: str) -> dict[str, Any]:
+    """Build the combined yfinance analysis payload stored in analysis_tickers."""
+
+    normalized = ticker.upper().strip()
+    sections: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+
+    async def required_section(name: str, loader: Callable[[], Any]) -> None:
+        sections[name] = _normalize_response(await loader())
+
+    async def optional_section(name: str, loader: Callable[[], Any]) -> None:
+        try:
+            sections[name] = _normalize_response(await loader())
+        except HTTPException as exc:
+            errors[name] = str(exc.detail)
+            logger.info("Optional analysis section skipped ticker=%s section=%s error=%s", normalized, name, exc.detail)
+        except Exception as exc:  # noqa: BLE001 - a section failure should not abort all tickers
+            errors[name] = str(exc)
+            logger.exception("Optional analysis section failed ticker=%s section=%s", normalized, name)
+
+    await required_section("fundamentals", lambda: get_fundamentals(normalized))
+    await optional_section("price_history_1y_1d", lambda: get_price_history(normalized, "1y", "1d"))
+    await optional_section("price_history_5y_1wk", lambda: get_price_history(normalized, "5y", "1wk"))
+    await optional_section("technicals", lambda: get_technicals(normalized))
+    await optional_section("options", lambda: get_option_chain(normalized))
+    await optional_section("synthesis", lambda: get_synthesis(normalized))
+
+    return {
+        "ticker": normalized,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sections": sections,
+        "errors": errors,
+        "source": "backend_batch",
+    }
+
+
+async def build_growth_story(ticker: str, ticker_analysis: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Generate or fetch a growth-story payload for a ticker."""
+
+    normalized = ticker.upper().strip()
+    fundamentals = (ticker_analysis or {}).get("sections", {}).get("fundamentals", {})
+    company_name = str(fundamentals.get("name") or "")
+    sector = str(fundamentals.get("sector") or "")
+    return _normalize_response(
+        await post_growth_story(
+            normalized, None if not company_name and not sector else _GrowthStoryBody(company_name, sector)
+        )
+    )
+
+
+class _GrowthStoryBody:
+    """Small duck-typed body compatible with the FastAPI route helper."""
+
+    def __init__(self, company_name: str, sector: str) -> None:
+        self.company_name = company_name
+        self.sector = sector
+
+
+class AnalyzeBatchRefresher:
+    """Refresh analysis result tables idempotently."""
+
+    def __init__(self, session_factory: Callable[[], Session] | None = None) -> None:
+        self.session_factory = session_factory or _default_session_factory
+
+    def discover_tickers(self, session: Session) -> list[TickerInput]:
+        """Find tickers from tracked household portfolio tables."""
+
+        rows = session.execute(
+            text(
+                """
+                with candidates as (
+                  select household_id, upper(btrim(symbol)) as ticker
+                    from public.trading_positions
+                   where household_id is not null
+                     and nullif(btrim(symbol), '') is not null
+                     and coalesce(sec_type, '') in ('STK', 'ETF', '')
+                  union
+                  select household_id, upper(btrim(ticker)) as ticker
+                    from public.dividend_positions
+                   where household_id is not null
+                     and nullif(btrim(ticker), '') is not null
+                  union
+                  select household_id, upper(btrim(ticker)) as ticker
+                    from public.bond_holdings
+                   where household_id is not null
+                     and deleted_at is null
+                     and nullif(btrim(ticker), '') is not null
+                  union
+                  select household_id, upper(btrim(symbol)) as ticker
+                    from public.trade
+                   where household_id is not null
+                     and nullif(btrim(symbol), '') is not null
+                     and coalesce("assetCategory", '') in ('STK', 'ETF')
+                )
+                select household_id, ticker
+                  from candidates
+                 where ticker ~ '^[A-Z][A-Z0-9.-]{0,14}$'
+                 order by household_id, ticker
+                """
+            )
+        ).mappings()
+        return [TickerInput(ticker=str(row["ticker"]), household_id=row["household_id"]) for row in rows]
+
+    def refresh_ticker_analyses(self) -> int:
+        """Refresh all discovered ticker-analysis rows; failures skip only one ticker."""
+
+        with self.session_factory() as session:
+            ticker_inputs = self.discover_tickers(session)
+            refreshed = self.refresh_specific_tickers(session, ticker_inputs)
+            session.commit()
+            return refreshed
+
+    def refresh_growth_stories(self) -> int:
+        """Refresh growth-story rows for all discovered tickers."""
+
+        with self.session_factory() as session:
+            ticker_inputs = self.discover_tickers(session)
+            refreshed = 0
+            for ticker_input in ticker_inputs:
+                try:
+                    existing_analysis = self._latest_ticker_analysis(session, ticker_input)
+                    story = asyncio.run(build_growth_story(ticker_input.ticker, existing_analysis))
+                    self._upsert_growth_story(session, ticker_input, story)
+                    refreshed += 1
+                except Exception:  # noqa: BLE001 - one bad ticker must not abort the batch
+                    logger.exception("Growth-story refresh skipped ticker=%s", ticker_input.ticker)
+            session.commit()
+            return refreshed
+
+    def refresh_specific_tickers(self, session: Session, ticker_inputs: Iterable[TickerInput]) -> int:
+        """Refresh a supplied ticker set into analysis_tickers."""
+
+        refreshed = 0
+        for ticker_input in ticker_inputs:
+            try:
+                data = asyncio.run(build_ticker_analysis(ticker_input.ticker))
+                self._upsert_ticker_analysis(session, ticker_input, data)
+                refreshed += 1
+            except Exception:  # noqa: BLE001 - one bad ticker must not abort the batch
+                logger.exception("Ticker analysis refresh skipped ticker=%s", ticker_input.ticker)
+        return refreshed
+
+    def should_refresh(self, table_name: str) -> bool:
+        """Return true when a result table is empty or older than the stale threshold."""
+
+        if table_name not in {"analysis_tickers", "analysis_growth_stories"}:
+            raise ValueError(f"Unsupported analysis table: {table_name}")
+        with self.session_factory() as session:
+            row = (
+                session.execute(
+                    text(
+                        f"""
+                    select coalesce(max(refreshed_at) < now() - interval '{STALE_AFTER_HOURS} hours', true) as stale
+                      from public.{table_name}
+                    """
+                    )
+                )
+                .mappings()
+                .first()
+            )
+            return bool(row is None or row["stale"])
+
+    def _latest_ticker_analysis(self, session: Session, ticker_input: TickerInput) -> dict[str, Any] | None:
+        row = (
+            session.execute(
+                text(
+                    """
+                select data
+                  from public.analysis_tickers
+                 where ticker = :ticker
+                   and household_scope = coalesce(:household_id, '00000000-0000-0000-0000-000000000000'::uuid)
+                 limit 1
+                """
+                ),
+                {"ticker": ticker_input.ticker, "household_id": ticker_input.household_id},
+            )
+            .mappings()
+            .first()
+        )
+        return row["data"] if row else None
+
+    def _upsert_ticker_analysis(self, session: Session, ticker_input: TickerInput, data: dict[str, Any]) -> None:
+        session.execute(
+            text(
+                """
+                insert into public.analysis_tickers (ticker, household_id, data, refreshed_at, updated_at)
+                values (:ticker, :household_id, cast(:data as jsonb), now(), now())
+                on conflict (household_scope, ticker) do update
+                   set data = excluded.data,
+                       refreshed_at = excluded.refreshed_at,
+                       updated_at = excluded.updated_at
+                """
+            ),
+            {"ticker": ticker_input.ticker, "household_id": ticker_input.household_id, "data": _json_dumps(data)},
+        )
+
+    def _upsert_growth_story(self, session: Session, ticker_input: TickerInput, story: dict[str, Any]) -> None:
+        session.execute(
+            text(
+                """
+                insert into public.analysis_growth_stories (ticker, household_id, story, refreshed_at, updated_at)
+                values (:ticker, :household_id, cast(:story as jsonb), now(), now())
+                on conflict (household_scope, ticker) do update
+                   set story = excluded.story,
+                       refreshed_at = excluded.refreshed_at,
+                       updated_at = excluded.updated_at
+                """
+            ),
+            {"ticker": ticker_input.ticker, "household_id": ticker_input.household_id, "story": _json_dumps(story)},
+        )
+
+
+def refresh_ticker_analyses() -> int:
+    """Refresh ticker analyses using the default database session."""
+
+    return AnalyzeBatchRefresher().refresh_ticker_analyses()
+
+
+def refresh_growth_stories() -> int:
+    """Refresh growth stories using the default database session."""
+
+    return AnalyzeBatchRefresher().refresh_growth_stories()
+
+
+def refresh_ticker_analyses_if_stale() -> int:
+    """Refresh ticker analyses on startup when stored results are stale."""
+
+    refresher = AnalyzeBatchRefresher()
+    if not refresher.should_refresh("analysis_tickers"):
+        return 0
+    return refresher.refresh_ticker_analyses()
+
+
+def refresh_growth_stories_if_stale() -> int:
+    """Refresh growth stories on startup when stored results are stale."""
+
+    refresher = AnalyzeBatchRefresher()
+    if not refresher.should_refresh("analysis_growth_stories"):
+        return 0
+    return refresher.refresh_growth_stories()

--- a/apps/backend/app/worker/analyze_schedules.py
+++ b/apps/backend/app/worker/analyze_schedules.py
@@ -1,0 +1,63 @@
+"""Schedule registration for TJ-020 analysis batch jobs."""
+
+from __future__ import annotations
+
+import logging
+
+from app.services.analyze_batch import (
+    refresh_growth_stories,
+    refresh_growth_stories_if_stale,
+    refresh_ticker_analyses,
+    refresh_ticker_analyses_if_stale,
+)
+from app.worker.registry import JOB_SCHEDULES, JobSchedule
+
+logger = logging.getLogger(__name__)
+
+ANALYZE_TICKERS_JOB_ID = "analyze_tickers_refresh"
+ANALYZE_GROWTH_STORIES_JOB_ID = "analyze_growth_stories_refresh"
+
+
+def run_analyze_tickers_refresh() -> None:
+    """Refresh ticker analysis rows for all tracked tickers."""
+
+    refreshed = refresh_ticker_analyses()
+    logger.info("%s refreshed %d ticker(s)", ANALYZE_TICKERS_JOB_ID, refreshed)
+
+
+def run_analyze_growth_stories_refresh() -> None:
+    """Refresh growth-story rows for all tracked tickers."""
+
+    refreshed = refresh_growth_stories()
+    logger.info("%s refreshed %d ticker(s)", ANALYZE_GROWTH_STORIES_JOB_ID, refreshed)
+
+
+def run_startup_analyze_refreshes() -> None:
+    """Run stale analysis jobs once on worker startup."""
+
+    ticker_count = refresh_ticker_analyses_if_stale()
+    story_count = refresh_growth_stories_if_stale()
+    if ticker_count or story_count:
+        logger.info(
+            "startup analysis refresh completed tickers=%d growth_stories=%d",
+            ticker_count,
+            story_count,
+        )
+
+
+JOB_SCHEDULES.extend(
+    [
+        JobSchedule(
+            job_id=ANALYZE_TICKERS_JOB_ID,
+            kind="cron",
+            cron_expr="0 3 * * *",
+            handler=run_analyze_tickers_refresh,
+        ),
+        JobSchedule(
+            job_id=ANALYZE_GROWTH_STORIES_JOB_ID,
+            kind="cron",
+            cron_expr="30 3 * * *",
+            handler=run_analyze_growth_stories_refresh,
+        ),
+    ]
+)

--- a/apps/backend/app/worker/runtime.py
+++ b/apps/backend/app/worker/runtime.py
@@ -7,6 +7,7 @@ import os
 import signal
 import time
 
+from app.worker import analyze_schedules
 from app.worker import ndx_daily_sync  # noqa: F401 - imports schedule registration side effect
 from app.worker import price_cache as _price_cache  # noqa: F401 - registers scheduled jobs
 from app.worker.job_queue import poll_compute_jobs
@@ -52,6 +53,8 @@ def start_worker() -> None:
         _poll_interval_seconds(),
         poll_compute_jobs,
     )
+
+    analyze_schedules.run_startup_analyze_refreshes()
 
     scheduler.start()
     logger.info("Worker scheduler started with %d job(s)", len(scheduler.get_jobs()))

--- a/apps/backend/tests/test_analyze_batch.py
+++ b/apps/backend/tests/test_analyze_batch.py
@@ -1,0 +1,119 @@
+"""Tests for scheduled analyze batch jobs."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from types import TracebackType
+from typing import Any
+from uuid import UUID
+
+import pytest
+
+from app.services import analyze_batch
+from app.services.analyze_batch import AnalyzeBatchRefresher, TickerInput
+from app.worker import analyze_schedules
+from app.worker.registry import JOB_SCHEDULES
+
+
+class FakeMappings:
+    """Result wrapper that mimics SQLAlchemy's mappings API."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> "FakeMappings":
+        return self
+
+    def first(self) -> dict[str, Any] | None:
+        return self.rows[0] if self.rows else None
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class FakeSession(AbstractContextManager["FakeSession"]):
+    """Minimal SQLAlchemy session fake for batch assertions."""
+
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = rows or []
+        self.executions: list[dict[str, Any]] = []
+        self.committed = False
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        sql = str(statement)
+        self.executions.append({"sql": sql, "params": params or {}})
+        if "from public.trading_positions" in sql:
+            return FakeMappings(self.rows)
+        return FakeMappings([])
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def test_analyze_schedules_register_daily_crons() -> None:
+    """The worker registry includes both TJ-020 daily analyze schedules."""
+
+    schedule_by_id = {schedule.job_id: schedule for schedule in JOB_SCHEDULES}
+
+    assert schedule_by_id[analyze_schedules.ANALYZE_TICKERS_JOB_ID].cron_expr == "0 3 * * *"
+    assert schedule_by_id[analyze_schedules.ANALYZE_GROWTH_STORIES_JOB_ID].cron_expr == "30 3 * * *"
+
+
+def test_refresh_specific_ticker_upserts_mocked_yfinance(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fake ticker run writes one idempotent analysis_tickers upsert."""
+
+    session = FakeSession()
+
+    async def fake_build_ticker_analysis(ticker: str) -> dict[str, Any]:
+        return {"ticker": ticker, "sections": {"fundamentals": {"ticker": ticker, "market_cap": "123.45"}}}
+
+    monkeypatch.setattr(analyze_batch, "build_ticker_analysis", fake_build_ticker_analysis)
+
+    refresher = AnalyzeBatchRefresher(session_factory=lambda: session)  # type: ignore[arg-type]
+    refreshed = refresher.refresh_specific_tickers(
+        session,
+        [TickerInput(ticker="MSFT", household_id=UUID("00000000-0000-0000-0000-000000000101"))],
+    )
+
+    assert refreshed == 1
+    upsert = session.executions[-1]
+    assert "insert into public.analysis_tickers" in upsert["sql"]
+    assert "on conflict (household_scope, ticker) do update" in upsert["sql"]
+    assert upsert["params"]["ticker"] == "MSFT"
+    assert '"market_cap": "123.45"' in upsert["params"]["data"]
+
+
+def test_refresh_ticker_analyses_skips_failed_ticker(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One failing yfinance ticker is logged and skipped without aborting the batch."""
+
+    household_id = UUID("00000000-0000-0000-0000-000000000101")
+    session = FakeSession(
+        [
+            {"ticker": "GOOD", "household_id": household_id},
+            {"ticker": "BAD", "household_id": household_id},
+        ]
+    )
+
+    async def fake_build_ticker_analysis(ticker: str) -> dict[str, Any]:
+        if ticker == "BAD":
+            raise RuntimeError("yfinance down")
+        return {"ticker": ticker, "sections": {}}
+
+    monkeypatch.setattr(analyze_batch, "build_ticker_analysis", fake_build_ticker_analysis)
+
+    refreshed = AnalyzeBatchRefresher(session_factory=lambda: session).refresh_ticker_analyses()  # type: ignore[arg-type]
+
+    assert refreshed == 1
+    assert session.committed is True
+    assert sum("insert into public.analysis_tickers" in call["sql"] for call in session.executions) == 1

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -16,7 +16,7 @@ const PAGES = [
 const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/tax-condor',
   '/api/backtest',
-  '/api/analyze',
+  '/api/bonds/scanner',
   '/api/ndx/sync',
   '/api/trading/sync',
   '/api/pension',

--- a/apps/frontend/src/app/analyze/actions.test.ts
+++ b/apps/frontend/src/app/analyze/actions.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import { getTickerAnalysis, listGrowthStories } from './actions';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('getTickerAnalysis', () => {
+  it('returns the freshest household-scoped row before global rows', async () => {
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({
+        data: [
+          {
+            ticker: 'MSFT',
+            household_id: null,
+            data: { sections: { fundamentals: { ticker: 'MSFT', market_cap: 1 } } },
+            refreshed_at: '2026-01-01T00:00:00.000Z',
+          },
+          {
+            ticker: 'MSFT',
+            household_id: 'household-1',
+            data: { sections: { fundamentals: { ticker: 'MSFT', market_cap: 2 } } },
+            refreshed_at: new Date().toISOString(),
+          },
+        ],
+        error: null,
+      }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      from: vi.fn((table: string) => {
+        expect(table).toBe('analysis_tickers');
+        return query;
+      }),
+    });
+
+    const result = await getTickerAnalysis('msft');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data?.household_id).toBe('household-1');
+      expect(result.data?.data.sections?.fundamentals).toMatchObject({ market_cap: 2 });
+    }
+    expect(query.eq).toHaveBeenCalledWith('ticker', 'MSFT');
+  });
+
+  it('rejects invalid ticker symbols before querying', async () => {
+    const result = await getTickerAnalysis('../bad');
+
+    expect(result).toEqual({ ok: false, error: 'Invalid ticker symbol' });
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});
+
+describe('listGrowthStories', () => {
+  it('reads growth stories from Supabase with an optional ticker filter', async () => {
+    const query = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({
+        data: [
+          {
+            id: 'story-1',
+            ticker: 'NVDA',
+            household_id: null,
+            story: { ticker: 'NVDA', value_driver: 'AI demand' },
+            refreshed_at: new Date().toISOString(),
+          },
+        ],
+        error: null,
+      }),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      from: vi.fn((table: string) => {
+        expect(table).toBe('analysis_growth_stories');
+        return query;
+      }),
+    });
+
+    const result = await listGrowthStories({ ticker: 'nvda', limit: 1 });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data[0].story).toMatchObject({ value_driver: 'AI demand' });
+    expect(query.eq).toHaveBeenCalledWith('ticker', 'NVDA');
+    expect(query.limit).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/frontend/src/app/analyze/actions.ts
+++ b/apps/frontend/src/app/analyze/actions.ts
@@ -1,0 +1,127 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+const STALE_AFTER_MS = 36 * 60 * 60 * 1000;
+
+export interface AnalysisTickerRow {
+  ticker: string;
+  household_id: string | null;
+  data: AnalysisTickerPayload;
+  refreshed_at: string;
+  isStale: boolean;
+}
+
+export interface AnalysisTickerPayload {
+  ticker?: string;
+  generated_at?: string;
+  sections?: Record<string, unknown>;
+  errors?: Record<string, string>;
+  source?: string;
+}
+
+export interface AnalysisGrowthStoryRow {
+  id: string;
+  ticker: string;
+  household_id: string | null;
+  story: Record<string, unknown>;
+  refreshed_at: string;
+  isStale: boolean;
+}
+
+export interface GrowthStoryFilters {
+  ticker?: string;
+  limit?: number;
+}
+
+export type AnalysisActionResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+function normalizeTicker(ticker: string): string {
+  return ticker.trim().toUpperCase();
+}
+
+function isValidTicker(ticker: string): boolean {
+  return /^[A-Z][A-Z0-9.-]{0,14}$/.test(ticker);
+}
+
+function isStale(refreshedAt: string): boolean {
+  const refreshedMs = Date.parse(refreshedAt);
+  return Number.isNaN(refreshedMs) || Date.now() - refreshedMs > STALE_AFTER_MS;
+}
+
+function normalizeTickerRow(row: Record<string, unknown>): AnalysisTickerRow {
+  const refreshedAt = String(row.refreshed_at ?? '');
+  return {
+    ticker: String(row.ticker ?? ''),
+    household_id: typeof row.household_id === 'string' ? row.household_id : null,
+    data: (row.data ?? {}) as AnalysisTickerPayload,
+    refreshed_at: refreshedAt,
+    isStale: isStale(refreshedAt),
+  };
+}
+
+function normalizeGrowthStoryRow(row: Record<string, unknown>): AnalysisGrowthStoryRow {
+  const refreshedAt = String(row.refreshed_at ?? '');
+  return {
+    id: String(row.id ?? ''),
+    ticker: String(row.ticker ?? ''),
+    household_id: typeof row.household_id === 'string' ? row.household_id : null,
+    story: (row.story ?? {}) as Record<string, unknown>,
+    refreshed_at: refreshedAt,
+    isStale: isStale(refreshedAt),
+  };
+}
+
+function preferHouseholdThenFreshest<T extends { household_id: string | null; refreshed_at: string }>(rows: T[]): T[] {
+  return [...rows].sort((left, right) => {
+    if (left.household_id && !right.household_id) return -1;
+    if (!left.household_id && right.household_id) return 1;
+    return Date.parse(right.refreshed_at) - Date.parse(left.refreshed_at);
+  });
+}
+
+export async function getTickerAnalysis(ticker: string): Promise<AnalysisActionResult<AnalysisTickerRow | null>> {
+  const normalized = normalizeTicker(ticker);
+  if (!isValidTicker(normalized)) return { ok: false, error: 'Invalid ticker symbol' };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('analysis_tickers')
+    .select('ticker, household_id, data, refreshed_at')
+    .eq('ticker', normalized);
+
+  if (error) {
+    console.error('[getTickerAnalysis] query error:', error.message);
+    return { ok: false, error: 'Failed to load ticker analysis' };
+  }
+
+  const rows = ((data ?? []) as Record<string, unknown>[]).map(normalizeTickerRow);
+  return { ok: true, data: preferHouseholdThenFreshest(rows)[0] ?? null };
+}
+
+export async function listGrowthStories(
+  filters: GrowthStoryFilters = {},
+): Promise<AnalysisActionResult<AnalysisGrowthStoryRow[]>> {
+  const normalizedTicker = filters.ticker ? normalizeTicker(filters.ticker) : null;
+  if (normalizedTicker && !isValidTicker(normalizedTicker)) return { ok: false, error: 'Invalid ticker symbol' };
+
+  const supabase = await createClient();
+  let query = supabase
+    .from('analysis_growth_stories')
+    .select('id, ticker, household_id, story, refreshed_at')
+    .order('refreshed_at', { ascending: false })
+    .limit(Math.max(1, Math.min(filters.limit ?? 20, 100)));
+
+  if (normalizedTicker) query = query.eq('ticker', normalizedTicker);
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('[listGrowthStories] query error:', error.message);
+    return { ok: false, error: 'Failed to load growth stories' };
+  }
+
+  const rows = ((data ?? []) as Record<string, unknown>[]).map(normalizeGrowthStoryRow);
+  return { ok: true, data: preferHouseholdThenFreshest(rows) };
+}

--- a/apps/frontend/src/components/Analyze/ShortTermView.tsx
+++ b/apps/frontend/src/components/Analyze/ShortTermView.tsx
@@ -16,6 +16,14 @@ interface ShortTermViewProps {
     ticker: string;
 }
 
+function formatRefresh(refreshedAt: string | null): string {
+    if (!refreshedAt) return "Analysis not refreshed yet";
+    const diffMs = Date.now() - Date.parse(refreshedAt);
+    if (!Number.isFinite(diffMs)) return "Analysis not refreshed yet";
+    const hours = Math.max(0, Math.round(diffMs / (60 * 60 * 1000)));
+    return hours < 1 ? "Last refreshed less than 1 hour ago" : `Last refreshed ${hours}h ago`;
+}
+
 export default function ShortTermView({ ticker }: ShortTermViewProps) {
     const technicals = useTechnicals(ticker);
     const options = useOptionChain(ticker);
@@ -24,9 +32,14 @@ export default function ShortTermView({ ticker }: ShortTermViewProps) {
 
     return (
         <div className="space-y-6">
-            <h2 className="text-lg font-semibold text-slate-300">
-                Short-Term Analysis — <span className="text-white font-mono">{ticker}</span>
-            </h2>
+            <div className="flex flex-col gap-1">
+                <h2 className="text-lg font-semibold text-slate-300">
+                    Short-Term Analysis — <span className="text-white font-mono">{ticker}</span>
+                </h2>
+                <p className={technicals.isStale ? "text-sm text-amber-300" : "text-sm text-slate-500"}>
+                    {formatRefresh(technicals.refreshedAt)}{technicals.isStale ? " · Backend offline or stale" : ""}
+                </p>
+            </div>
 
             {/* Per-section errors with retry */}
             {technicals.error && <ErrorBanner message={technicals.error} onRetry={technicals.refetch} />}

--- a/apps/frontend/src/components/Analyze/longterm/GrowthStory.tsx
+++ b/apps/frontend/src/components/Analyze/longterm/GrowthStory.tsx
@@ -20,13 +20,12 @@ function LoadingState({ elapsedSeconds }: { elapsedSeconds: number }) {
           <span className="relative inline-flex rounded-full h-4 w-4 bg-blue-500" />
         </span>
         <span className="text-lg font-semibold text-white">
-          Analyzing...{" "}
+          Loading cached story...{" "}
           <span className="text-blue-400 font-mono">{elapsedSeconds}s</span>
         </span>
       </div>
       <p className="text-sm text-slate-400 max-w-md mx-auto">
-        Reading SEC filings, scanning news &amp; social sentiment, building
-        scenario models. This typically takes 30–60 seconds.
+        Reading the latest scheduled backend analysis from Supabase.
       </p>
       <div className="mt-6 w-full max-w-xs mx-auto h-1.5 bg-slate-800 rounded-full overflow-hidden">
         <div
@@ -46,11 +45,10 @@ function GenerateButton({ onGenerate }: { onGenerate: () => void }) {
         onClick={onGenerate}
         className="px-6 py-3 bg-blue-600 hover:bg-blue-500 text-white font-semibold rounded-xl transition-colors text-lg"
       >
-        Generate Growth Story
+        Load Growth Story
       </button>
       <p className="text-sm text-slate-400 mt-3 max-w-sm mx-auto">
-        Uses AI to analyze news, social sentiment, and financial data to build a
-        three-scenario outlook.
+        Shows the latest daily backend-generated AI story from Supabase.
       </p>
     </div>
   );

--- a/apps/frontend/src/components/Analyze/longterm/LongTermView.tsx
+++ b/apps/frontend/src/components/Analyze/longterm/LongTermView.tsx
@@ -19,6 +19,14 @@ interface LongTermViewProps {
   ticker: string;
 }
 
+function formatRefresh(refreshedAt: string | null): string {
+  if (!refreshedAt) return "Analysis not refreshed yet";
+  const diffMs = Date.now() - Date.parse(refreshedAt);
+  if (!Number.isFinite(diffMs)) return "Analysis not refreshed yet";
+  const hours = Math.max(0, Math.round(diffMs / (60 * 60 * 1000)));
+  return hours < 1 ? "Last refreshed less than 1 hour ago" : `Last refreshed ${hours}h ago`;
+}
+
 export default function LongTermView({ ticker }: LongTermViewProps) {
   const [period, setPeriod] = useState("1y");
   const [showGrowthStory, setShowGrowthStory] = useState(false);
@@ -76,14 +84,19 @@ export default function LongTermView({ ticker }: LongTermViewProps) {
 
   return (
     <div className="space-y-6">
-      <h2 className="text-lg font-semibold text-slate-300">
-        Long-Term Analysis — <span className="text-white font-mono">{ticker}</span>
-        {fundamentals.data?.name && (
-          <span className="text-slate-500 font-normal text-base ml-2">
-            {fundamentals.data.name} · {fundamentals.data.sector}
-          </span>
-        )}
-      </h2>
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold text-slate-300">
+          Long-Term Analysis — <span className="text-white font-mono">{ticker}</span>
+          {fundamentals.data?.name && (
+            <span className="text-slate-500 font-normal text-base ml-2">
+              {fundamentals.data.name} · {fundamentals.data.sector}
+            </span>
+          )}
+        </h2>
+        <p className={fundamentals.isStale ? "text-sm text-amber-300" : "text-sm text-slate-500"}>
+          {formatRefresh(fundamentals.refreshedAt)}{fundamentals.isStale ? " · Backend offline or stale" : ""}
+        </p>
+      </div>
 
       {/* Per-section errors for non-critical data */}
       {priceHistory.error && <ErrorBanner message={priceHistory.error} onRetry={priceHistory.refetch} />}

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useCompanyFundamentals.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useCompanyFundamentals.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface DcfInputs {
@@ -38,30 +38,36 @@ interface UseFundamentalsReturn {
   data: FundamentalsData | null;
   loading: boolean;
   error: string | null;
+  refreshedAt: string | null;
+  isStale: boolean;
   refetch: () => void;
 }
-
-const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
 
 export function useCompanyFundamentals(ticker: string): UseFundamentalsReturn {
   const [data, setData] = useState<FundamentalsData | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [refreshedAt, setRefreshedAt] = useState<string | null>(null);
+  const [isStale, setIsStale] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!ticker) return;
     setLoading(true);
     setError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/api/analyze/fundamentals/${ticker}`);
-      if (!res.ok) {
-        throw new Error(res.status === 404 ? `Ticker "${ticker}" not found` : `API error (${res.status})`);
-      }
-      const json = await res.json();
-      setData(json);
+      const result = await getTickerAnalysis(ticker);
+      if (!result.ok) throw new Error(result.error);
+      const row = result.data;
+      const fundamentals = row?.data.sections?.fundamentals as FundamentalsData | undefined;
+      if (!row || !fundamentals) throw new Error(`No cached analysis for "${ticker}" yet`);
+      setData(fundamentals);
+      setRefreshedAt(row.refreshed_at);
+      setIsStale(row.isStale);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch fundamentals");
       setData(null);
+      setRefreshedAt(null);
+      setIsStale(false);
     } finally {
       setLoading(false);
     }
@@ -71,5 +77,5 @@ export function useCompanyFundamentals(ticker: string): UseFundamentalsReturn {
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  return { data, loading, error, refreshedAt, isStale, refetch: fetchData };
 }

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useGrowthStory.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useGrowthStory.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { listGrowthStories } from "@/app/analyze/actions";
 import { useState, useCallback, useRef, useEffect } from "react";
 
 export interface ScenarioData {
@@ -38,8 +38,6 @@ interface UseGrowthStoryReturn {
   generate: () => void;
 }
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
-
 export function useGrowthStory(ticker: string): UseGrowthStoryReturn {
   const [data, setData] = useState<GrowthStoryData | null>(null);
   const [loading, setLoading] = useState(false);
@@ -71,14 +69,11 @@ export function useGrowthStory(ticker: string): UseGrowthStoryReturn {
     }, 1000);
 
     try {
-      const res = await apiFetch(`${apiUrl}/api/analyze/growth-story/${ticker}`, {
-        method: "POST",
-      });
-      if (!res.ok) {
-        throw new Error(`API error (${res.status})`);
-      }
-      const json: GrowthStoryData = await res.json();
-      setData(json);
+      const result = await listGrowthStories({ ticker, limit: 1 });
+      if (!result.ok) throw new Error(result.error);
+      const story = result.data[0]?.story as unknown as GrowthStoryData | undefined;
+      if (!story) throw new Error(`No cached growth story for "${ticker}" yet`);
+      setData(story);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : "Failed to generate growth story"

--- a/apps/frontend/src/components/Analyze/longterm/hooks/usePriceHistory.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/usePriceHistory.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface PricePoint {
@@ -19,8 +19,6 @@ interface UsePriceHistoryReturn {
   refetch: () => void;
 }
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
-
 export function usePriceHistory(
   ticker: string,
   period: string = "1y",
@@ -35,14 +33,12 @@ export function usePriceHistory(
     setLoading(true);
     setError(null);
     try {
-      const res = await apiFetch(
-        `${apiUrl}/api/analyze/price-history/${ticker}?period=${period}&interval=${interval}`
-      );
-      if (!res.ok) {
-        throw new Error(res.status === 404 ? `No price data for "${ticker}"` : `API error (${res.status})`);
-      }
-      const json = await res.json();
-      setData(json.data ?? []);
+      const result = await getTickerAnalysis(ticker);
+      if (!result.ok) throw new Error(result.error);
+      const sectionKey = `price_history_${period}_${interval}`;
+      const priceHistory = result.data?.data.sections?.[sectionKey] as { data?: PricePoint[] } | undefined;
+      if (!priceHistory?.data) throw new Error(`No cached price history for "${ticker}" yet`);
+      setData(priceHistory.data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch price history");
       setData([]);

--- a/apps/frontend/src/components/Analyze/longterm/hooks/useSynthesis.ts
+++ b/apps/frontend/src/components/Analyze/longterm/hooks/useSynthesis.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface SynthesisData {
@@ -15,8 +15,6 @@ interface UseSynthesisReturn {
   refetch: () => void;
 }
 
-const apiUrl = process.env.NEXT_PUBLIC_API_URL || "";
-
 export function useSynthesis(ticker: string): UseSynthesisReturn {
   const [data, setData] = useState<SynthesisData | null>(null);
   const [loading, setLoading] = useState(false);
@@ -27,12 +25,11 @@ export function useSynthesis(ticker: string): UseSynthesisReturn {
     setLoading(true);
     setError(null);
     try {
-      const res = await apiFetch(`${apiUrl}/api/analyze/synthesis/${ticker}`);
-      if (!res.ok) {
-        throw new Error(`API error (${res.status})`);
-      }
-      const json = await res.json();
-      setData(json);
+      const result = await getTickerAnalysis(ticker);
+      if (!result.ok) throw new Error(result.error);
+      const synthesis = result.data?.data.sections?.synthesis as SynthesisData | undefined;
+      if (!synthesis) throw new Error(`No cached synthesis for "${ticker}" yet`);
+      setData(synthesis);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to fetch synthesis");
       setData(null);

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useOptionChain.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface PutOption {
@@ -44,26 +44,16 @@ export function useOptionChain(ticker: string): UseOptionChainResult {
     setLoading(true);
     setError(null);
 
-    const url = expiry
-      ? `/api/analyze/options/${ticker}?expiry=${expiry}`
-      : `/api/analyze/options/${ticker}`;
-
-    apiFetch(url)
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to fetch options for ${ticker}`);
-        return res.json();
+    getTickerAnalysis(ticker)
+      .then((result) => {
+        if (!result.ok) throw new Error(result.error);
+        const options = result.data?.data.sections?.options as OptionChainData | undefined;
+        if (!options) throw new Error(`No cached options for ${ticker} yet`);
+        setData(options);
+        if (!expiry && options.expirations.length > 0) setExpiry(options.expirations[0]);
       })
-      .then((json: OptionChainData) => {
-        setData(json);
-        if (!expiry && json.expirations.length > 0) {
-          setExpiry(json.expirations[0]);
-        }
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : "Failed to load options"))
+      .finally(() => setLoading(false));
   }, [ticker, expiry]);
 
   useEffect(() => {

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/usePriceHistory.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface OHLCVBar {
@@ -30,19 +30,15 @@ export function usePriceHistory(ticker: string): UsePriceHistoryResult {
     setLoading(true);
     setError(null);
 
-    apiFetch(`/api/analyze/price-history/${ticker}?period=1y&interval=1d`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to fetch price history for ${ticker}`);
-        return res.json();
+    getTickerAnalysis(ticker)
+      .then((result) => {
+        if (!result.ok) throw new Error(result.error);
+        const priceHistory = result.data?.data.sections?.price_history_1y_1d as { data?: OHLCVBar[] } | undefined;
+        if (!priceHistory?.data) throw new Error(`No cached price history for ${ticker} yet`);
+        setData(priceHistory.data);
       })
-      .then((json: OHLCVBar[]) => {
-        setData(json);
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : "Failed to load price history"))
+      .finally(() => setLoading(false));
   }, [ticker]);
 
   useEffect(() => {

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useSynthesis.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 export interface PriceActionSummary {
@@ -30,19 +30,15 @@ export function useSynthesis(ticker: string): UseSynthesisResult {
     setLoading(true);
     setError(null);
 
-    apiFetch(`/api/analyze/synthesis/${ticker}`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to fetch synthesis for ${ticker}`);
-        return res.json();
+    getTickerAnalysis(ticker)
+      .then((result) => {
+        if (!result.ok) throw new Error(result.error);
+        const synthesis = result.data?.data.sections?.synthesis as SynthesisData | undefined;
+        if (!synthesis) throw new Error(`No cached synthesis for ${ticker} yet`);
+        setData(synthesis);
       })
-      .then((json: SynthesisData) => {
-        setData(json);
-        setLoading(false);
-      })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : "Failed to load synthesis"))
+      .finally(() => setLoading(false));
   }, [ticker]);
 
   useEffect(() => {

--- a/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
+++ b/apps/frontend/src/components/Analyze/shortterm/hooks/useTechnicals.ts
@@ -1,6 +1,6 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
+import { getTickerAnalysis } from "@/app/analyze/actions";
 import { useState, useEffect, useCallback } from "react";
 
 interface MacdData {
@@ -38,6 +38,8 @@ interface UseTechnicalsResult {
   data: TechnicalsData | null;
   loading: boolean;
   error: string | null;
+  refreshedAt: string | null;
+  isStale: boolean;
   refetch: () => void;
 }
 
@@ -45,6 +47,8 @@ export function useTechnicals(ticker: string): UseTechnicalsResult {
   const [data, setData] = useState<TechnicalsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshedAt, setRefreshedAt] = useState<string | null>(null);
+  const [isStale, setIsStale] = useState(false);
 
   const fetchData = useCallback(() => {
     if (!ticker) return;
@@ -52,24 +56,27 @@ export function useTechnicals(ticker: string): UseTechnicalsResult {
     setLoading(true);
     setError(null);
 
-    apiFetch(`/api/analyze/technicals/${ticker}`)
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to fetch technicals for ${ticker}`);
-        return res.json();
+    getTickerAnalysis(ticker)
+      .then((result) => {
+        if (!result.ok) throw new Error(result.error);
+        const row = result.data;
+        const technicals = row?.data.sections?.technicals as TechnicalsData | undefined;
+        if (!row || !technicals) throw new Error(`No cached technicals for ${ticker} yet`);
+        setData(technicals);
+        setRefreshedAt(row.refreshed_at);
+        setIsStale(row.isStale);
       })
-      .then((json: TechnicalsData) => {
-        setData(json);
-        setLoading(false);
+      .catch((err: unknown) => {
+        setError(err instanceof Error ? err.message : "Failed to load technicals");
+        setRefreshedAt(null);
+        setIsStale(false);
       })
-      .catch((err) => {
-        setError(err.message);
-        setLoading(false);
-      });
+      .finally(() => setLoading(false));
   }, [ticker]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  return { data, loading, error, refetch: fetchData };
+  return { data, loading, error, refreshedAt, isStale, refetch: fetchData };
 }

--- a/supabase/migrations/20260503162944_analyze_batch_results.sql
+++ b/supabase/migrations/20260503162944_analyze_batch_results.sql
@@ -1,0 +1,89 @@
+-- Migration: analyze_batch_results
+-- Purpose: Store TJ-020 scheduled backend analysis results for frontend Supabase reads.
+
+create table if not exists public.analysis_tickers (
+  id uuid primary key default gen_random_uuid(),
+  ticker text not null,
+  household_id uuid references public.households(id) on delete cascade,
+  household_scope uuid generated always as (coalesce(household_id, '00000000-0000-0000-0000-000000000000'::uuid)) stored,
+  data jsonb not null default '{}'::jsonb,
+  refreshed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint analysis_tickers_ticker_upper_chk check (ticker = upper(btrim(ticker)))
+);
+
+create unique index if not exists analysis_tickers_household_scope_ticker_key
+  on public.analysis_tickers (household_scope, ticker);
+
+create index if not exists analysis_tickers_refreshed_at_idx
+  on public.analysis_tickers (refreshed_at desc);
+
+create index if not exists analysis_tickers_household_id_idx
+  on public.analysis_tickers (household_id)
+  where household_id is not null;
+
+create table if not exists public.analysis_growth_stories (
+  id uuid primary key default gen_random_uuid(),
+  ticker text not null,
+  household_id uuid references public.households(id) on delete cascade,
+  household_scope uuid generated always as (coalesce(household_id, '00000000-0000-0000-0000-000000000000'::uuid)) stored,
+  story jsonb not null default '{}'::jsonb,
+  refreshed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint analysis_growth_stories_ticker_upper_chk check (ticker = upper(btrim(ticker)))
+);
+
+create index if not exists analysis_growth_stories_household_ticker_refreshed_idx
+  on public.analysis_growth_stories (household_id, ticker, refreshed_at desc);
+
+create index if not exists analysis_growth_stories_global_ticker_refreshed_idx
+  on public.analysis_growth_stories (ticker, refreshed_at desc)
+  where household_id is null;
+
+create unique index if not exists analysis_growth_stories_household_scope_ticker_key
+  on public.analysis_growth_stories (household_scope, ticker);
+
+alter table public.analysis_tickers enable row level security;
+alter table public.analysis_growth_stories enable row level security;
+
+drop policy if exists analysis_tickers_select on public.analysis_tickers;
+create policy analysis_tickers_select on public.analysis_tickers
+  for select to authenticated
+  using (household_id is null or public.is_household_member(household_id));
+
+drop policy if exists analysis_growth_stories_select on public.analysis_growth_stories;
+create policy analysis_growth_stories_select on public.analysis_growth_stories
+  for select to authenticated
+  using (household_id is null or public.is_household_member(household_id));
+
+revoke all on public.analysis_tickers from anon, authenticated;
+revoke all on public.analysis_growth_stories from anon, authenticated;
+grant select on public.analysis_tickers to authenticated;
+grant select on public.analysis_growth_stories to authenticated;
+grant all on public.analysis_tickers to service_role;
+grant all on public.analysis_growth_stories to service_role;
+
+do $$
+begin
+  if exists (select 1 from pg_publication where pubname = 'supabase_realtime') then
+    if not exists (
+      select 1 from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'analysis_tickers'
+    ) then
+      alter publication supabase_realtime add table public.analysis_tickers;
+    end if;
+
+    if not exists (
+      select 1 from pg_publication_tables
+      where pubname = 'supabase_realtime'
+        and schemaname = 'public'
+        and tablename = 'analysis_growth_stories'
+    ) then
+      alter publication supabase_realtime add table public.analysis_growth_stories;
+    end if;
+  end if;
+end $$;


### PR DESCRIPTION
Closes #212
Umbrella: #207
Related: #219
ADR: .squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md

## Summary
- Adds Supabase result tables: public.analysis_tickers and public.analysis_growth_stories with household/global RLS, service-role writes, idempotent upsert keys, and Realtime publication.
- Registers APScheduler jobs analyze_tickers_refresh (03:00 Asia/Jerusalem) and analyze_growth_stories_refresh (03:30), plus stale-on-startup refresh.
- Moves Analyze frontend reads to Server Actions backed by Supabase and displays freshness / stale backend state.
- Removes /api/analyze from the walkthrough temporary FastAPI allow-list while keeping FastAPI routes deprecated for local/admin compatibility.

## Validation
- cd apps/backend && uv run pytest tests/test_analyze_batch.py -q
- cd apps/backend && uv run ruff check app/services/analyze_batch.py app/worker/analyze_schedules.py app/worker/runtime.py app/api/analyze.py tests/test_analyze_batch.py
- cd apps/frontend && npm test -- --run src/app/analyze/actions.test.ts
- cd apps/frontend && npm run build
- Supabase MCP: verified tables, SELECT RLS policies, and realtime publication entries.

Working as Hockney (Backend Dev).
⚠️ This task touches RLS/service-role worker writes; Rabin should review before merge.