### PR TITLE
feat(TJ-020): migrate bonds/scanner to scheduled batch (#213)

### DIFF
--- a/apps/backend/app/api/bonds.py
+++ b/apps/backend/app/api/bonds.py
@@ -1,14 +1,19 @@
-from fastapi import APIRouter
-from typing import List, Optional
 from datetime import date
+from decimal import Decimal
+from typing import List, Optional
+
+from fastapi import APIRouter
 from sqlmodel import SQLModel
+
+from app.services.bond_scanner import fetch_bond_universe, filter_bond_candidates
 
 router = APIRouter()
 
-class BondCandidate(SQLModel):
-    """Simple DTO for bond scanner/search results (mocked for now)."""
 
-    id: str  # CUSIP for USD bonds in this mock
+class BondCandidate(SQLModel):
+    """Deprecated DTO for legacy bond scanner/search results."""
+
+    id: str
     issuer: str
     coupon_rate: float
     maturity_date: date
@@ -17,7 +22,8 @@ class BondCandidate(SQLModel):
     currency: str
     price: float
 
-@router.get("/bonds/scanner", response_model=List[BondCandidate])
+
+@router.get("/bonds/scanner", response_model=List[BondCandidate], deprecated=True)
 def scan_bonds(
     min_maturity: Optional[date] = None,
     max_maturity: Optional[date] = None,
@@ -25,78 +31,30 @@ def scan_bonds(
     min_rating: Optional[str] = None,
     currency: Optional[str] = None,
 ):
-    """Mock bond scanner endpoint backed by a curated in-memory list.
+    """Deprecated FastAPI scanner retained for local/admin compatibility.
 
-    This is intentionally simple and does not hit any real market data
-    source yet; it exists so the frontend can build a realistic search
-    and selection flow.
+    TJ-020 moved the production frontend path to the scheduled
+    ``bonds_scanner_refresh`` worker and ``public.bond_scanner_results``.
     """
 
-    # Very small curated mock universe for now.
-    universe: list[BondCandidate] = [
+    candidates = filter_bond_candidates(
+        fetch_bond_universe(),
+        min_maturity=min_maturity,
+        max_maturity=max_maturity,
+        min_yield=Decimal(str(min_yield)) if min_yield is not None else None,
+        min_rating=min_rating,
+        currency=currency,
+    )
+    return [
         BondCandidate(
-            id="91282CEZ7",  # matches US Treasury holding CUSIP
-            issuer="US Treasury 4.00% 06/30/2037",
-            coupon_rate=0.04,
-            maturity_date=date(2037, 6, 30),
-            yield_to_maturity=0.041,
-            rating="AAA",
-            currency="USD",
-            price=99.2,
-        ),
-        BondCandidate(
-            id="12345CORB",  # matches Corp B holding CUSIP
-            issuer="Corp B 3.50% 03/15/2040",
-            coupon_rate=0.035,
-            maturity_date=date(2040, 3, 15),
-            yield_to_maturity=0.036,
-            rating="AAA",
-            currency="USD",
-            price=101.3,
-        ),
-        BondCandidate(
-            id="12345CORA",  # matches Corp A holding CUSIP
-            issuer="Corp A 5.00% 01/01/2038",
-            coupon_rate=0.05,
-            maturity_date=date(2038, 1, 1),
-            yield_to_maturity=0.052,
-            rating="A",
-            currency="USD",
-            price=100.5,
-        ),
-        BondCandidate(
-            id="EUROISIN1",  # placeholder ISIN-style id for EUR bond
-            issuer="EU Gov 3.00% 09/30/2037",
-            coupon_rate=0.03,
-            maturity_date=date(2037, 9, 30),
-            yield_to_maturity=0.031,
-            rating="AA",
-            currency="EUR",
-            price=100.0,
-        ),
+            id=candidate.symbol,
+            issuer=candidate.issuer,
+            coupon_rate=float(candidate.coupon_rate),
+            maturity_date=candidate.maturity_date,
+            yield_to_maturity=float(candidate.yield_to_maturity),
+            rating=candidate.rating,
+            currency=candidate.currency,
+            price=float(candidate.price),
+        )
+        for candidate in candidates
     ]
-
-    def rating_at_least(candidate_rating: str, threshold: str) -> bool:
-        # Extremely crude ordering for demo purposes.
-        order = ["AAA", "AA", "A", "BBB", "BB", "B", "CCC", "CC", "C", "D"]
-        try:
-            return order.index(candidate_rating) <= order.index(threshold)
-        except ValueError:
-            # Unknown ratings are treated as worst.
-            return False
-
-    results: list[BondCandidate] = []
-    for c in universe:
-        if min_maturity and c.maturity_date < min_maturity:
-            continue
-        if max_maturity and c.maturity_date > max_maturity:
-            continue
-        if min_yield is not None and c.yield_to_maturity < min_yield:
-            continue
-        if currency and c.currency != currency:
-            continue
-        if min_rating and not rating_at_least(c.rating, min_rating):
-            continue
-        results.append(c)
-
-    return results

--- a/apps/backend/app/services/bond_scanner.py
+++ b/apps/backend/app/services/bond_scanner.py
@@ -1,0 +1,144 @@
+"""Bond scanner data source and filtering helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+
+
+@dataclass(frozen=True)
+class BondScannerCandidate:
+    """One bond scanner candidate using Decimal for financial values."""
+
+    symbol: str
+    issuer: str
+    coupon_rate: Decimal
+    maturity_date: date
+    yield_to_maturity: Decimal
+    rating: str
+    currency: str
+    price: Decimal
+
+    def to_result_data(self) -> dict[str, object]:
+        """Return JSONB-safe candidate data with decimal values preserved as text."""
+
+        return {
+            "id": self.symbol,
+            "issuer": self.issuer,
+            "coupon_rate": str(self.coupon_rate),
+            "maturity_date": self.maturity_date.isoformat(),
+            "yield_to_maturity": str(self.yield_to_maturity),
+            "rating": self.rating,
+            "currency": self.currency,
+            "price": str(self.price),
+        }
+
+
+CURATED_BOND_SYMBOLS: tuple[str, ...] = (
+    "91282CEZ7",
+    "12345CORB",
+    "12345CORA",
+    "EUROISIN1",
+)
+
+_CURATED_BOND_DATA: dict[str, BondScannerCandidate] = {
+    "91282CEZ7": BondScannerCandidate(
+        symbol="91282CEZ7",
+        issuer="US Treasury 4.00% 06/30/2037",
+        coupon_rate=Decimal("0.04"),
+        maturity_date=date(2037, 6, 30),
+        yield_to_maturity=Decimal("0.041"),
+        rating="AAA",
+        currency="USD",
+        price=Decimal("99.2"),
+    ),
+    "12345CORB": BondScannerCandidate(
+        symbol="12345CORB",
+        issuer="Corp B 3.50% 03/15/2040",
+        coupon_rate=Decimal("0.035"),
+        maturity_date=date(2040, 3, 15),
+        yield_to_maturity=Decimal("0.036"),
+        rating="AAA",
+        currency="USD",
+        price=Decimal("101.3"),
+    ),
+    "12345CORA": BondScannerCandidate(
+        symbol="12345CORA",
+        issuer="Corp A 5.00% 01/01/2038",
+        coupon_rate=Decimal("0.05"),
+        maturity_date=date(2038, 1, 1),
+        yield_to_maturity=Decimal("0.052"),
+        rating="A",
+        currency="USD",
+        price=Decimal("100.5"),
+    ),
+    "EUROISIN1": BondScannerCandidate(
+        symbol="EUROISIN1",
+        issuer="EU Gov 3.00% 09/30/2037",
+        coupon_rate=Decimal("0.03"),
+        maturity_date=date(2037, 9, 30),
+        yield_to_maturity=Decimal("0.031"),
+        rating="AA",
+        currency="EUR",
+        price=Decimal("100.0"),
+    ),
+}
+
+
+def fetch_bond_candidate(symbol: str) -> BondScannerCandidate:
+    """Fetch one candidate from the configured bond data provider."""
+
+    return _CURATED_BOND_DATA[symbol]
+
+
+def fetch_bond_universe(
+    symbols: tuple[str, ...] = CURATED_BOND_SYMBOLS,
+    fetcher: Callable[[str], BondScannerCandidate] = fetch_bond_candidate,
+) -> list[BondScannerCandidate]:
+    """Fetch scanner candidates, skipping symbols that fail individually."""
+
+    candidates: list[BondScannerCandidate] = []
+    for symbol in symbols:
+        try:
+            candidates.append(fetcher(symbol))
+        except Exception:
+            continue
+    return candidates
+
+
+def rating_at_least(candidate_rating: str, threshold: str) -> bool:
+    """Return whether a bond rating is at least the requested threshold."""
+
+    order = ["AAA", "AA", "A", "BBB", "BB", "B", "CCC", "CC", "C", "D"]
+    try:
+        return order.index(candidate_rating) <= order.index(threshold)
+    except ValueError:
+        return False
+
+
+def filter_bond_candidates(
+    candidates: list[BondScannerCandidate],
+    min_maturity: date | None = None,
+    max_maturity: date | None = None,
+    min_yield: Decimal | None = None,
+    min_rating: str | None = None,
+    currency: str | None = None,
+) -> list[BondScannerCandidate]:
+    """Apply scanner filters to a list of candidates."""
+
+    results: list[BondScannerCandidate] = []
+    for candidate in candidates:
+        if min_maturity and candidate.maturity_date < min_maturity:
+            continue
+        if max_maturity and candidate.maturity_date > max_maturity:
+            continue
+        if min_yield is not None and candidate.yield_to_maturity < min_yield:
+            continue
+        if currency and candidate.currency != currency:
+            continue
+        if min_rating and not rating_at_least(candidate.rating, min_rating):
+            continue
+        results.append(candidate)
+    return results

--- a/apps/backend/app/worker/bonds_scanner.py
+++ b/apps/backend/app/worker/bonds_scanner.py
@@ -1,0 +1,98 @@
+"""Scheduled bond scanner refresh job."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import datetime, timezone
+from decimal import Decimal
+import json
+import logging
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.bond_scanner import BondScannerCandidate, CURATED_BOND_SYMBOLS, fetch_bond_candidate
+
+logger = logging.getLogger(__name__)
+
+BondFetcher = Callable[[str], BondScannerCandidate]
+
+
+def _json_default(value: object) -> object:
+    """Serialize precise financial values for jsonb storage."""
+
+    if isinstance(value, Decimal):
+        return str(value)
+    if hasattr(value, "isoformat"):
+        return value.isoformat()  # type: ignore[no-any-return]
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a privileged database session for worker writes."""
+
+    return Session(engine)
+
+
+class BondScannerRefreshJob:
+    """Refresh and upsert daily bond scanner result rows."""
+
+    def __init__(
+        self,
+        symbols: tuple[str, ...] = CURATED_BOND_SYMBOLS,
+        fetcher: BondFetcher = fetch_bond_candidate,
+        session_factory: Callable[[], AbstractContextManager[Session]] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        """Initialize the refresh job with injectable dependencies for tests."""
+
+        self.symbols = symbols
+        self.fetcher = fetcher
+        self.session_factory = session_factory or _default_session_factory
+        self.clock = clock or (lambda: datetime.now(timezone.utc))
+
+    def run(self) -> int:
+        """Fetch the scanner universe and upsert successful symbol results."""
+
+        refreshed_at = self.clock()
+        upserted = 0
+        with self.session_factory() as session:
+            for symbol in self.symbols:
+                try:
+                    candidate = self.fetcher(symbol)
+                except Exception as exc:  # noqa: BLE001 - scheduled batch must continue
+                    logger.warning("Skipping bond scanner symbol %s after fetch failure: %s", symbol, exc)
+                    continue
+                self._upsert_candidate(session, candidate, refreshed_at)
+                upserted += 1
+            session.commit()
+        logger.info("Bond scanner refresh upserted %d/%d symbol(s)", upserted, len(self.symbols))
+        return upserted
+
+    def _upsert_candidate(self, session: Session, candidate: BondScannerCandidate, refreshed_at: datetime) -> None:
+        """Persist one scanner candidate using an idempotent symbol upsert."""
+
+        session.execute(
+            text(
+                """
+                insert into public.bond_scanner_results (symbol, data, refreshed_at)
+                values (:symbol, cast(:data as jsonb), :refreshed_at)
+                on conflict (symbol) do update
+                   set data = excluded.data,
+                       refreshed_at = excluded.refreshed_at
+                """
+            ),
+            {
+                "symbol": candidate.symbol,
+                "data": json.dumps(candidate.to_result_data(), default=_json_default),
+                "refreshed_at": refreshed_at,
+            },
+        )
+
+
+def refresh_bond_scanner_results() -> int:
+    """Run one global bond scanner refresh pass."""
+
+    return BondScannerRefreshJob().run()

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
+from app.worker.bonds_scanner import refresh_bond_scanner_results
+
 JobPayload = dict[str, object]
 JobResult = dict[str, object]
 JobHandler = Callable[[JobPayload], JobResult]
@@ -22,4 +24,11 @@ class JobSchedule:
 
 
 JOB_HANDLERS: dict[str, JobHandler] = {}
-JOB_SCHEDULES: list[JobSchedule] = []
+JOB_SCHEDULES: list[JobSchedule] = [
+    JobSchedule(
+        job_id="bonds_scanner_refresh",
+        kind="cron",
+        handler=refresh_bond_scanner_results,
+        cron_expr="0 4 * * *",
+    ),
+]

--- a/apps/backend/tests/test_bond_scanner_worker.py
+++ b/apps/backend/tests/test_bond_scanner_worker.py
@@ -1,0 +1,85 @@
+"""Tests for the scheduled bond scanner refresh worker."""
+
+from __future__ import annotations
+
+from contextlib import AbstractContextManager
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from types import TracebackType
+from typing import Any
+
+from app.services.bond_scanner import BondScannerCandidate
+from app.worker.bonds_scanner import BondScannerRefreshJob
+from app.worker.registry import JOB_SCHEDULES
+
+
+class FakeSession(AbstractContextManager["FakeSession"]):
+    """Minimal session fake that captures worker upsert statements."""
+
+    def __init__(self) -> None:
+        self.executions: list[dict[str, Any]] = []
+        self.committed = False
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> bool:
+        return False
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> None:
+        self.executions.append({"sql": str(statement), "params": params or {}})
+
+    def commit(self) -> None:
+        self.committed = True
+
+
+def _candidate(symbol: str) -> BondScannerCandidate:
+    return BondScannerCandidate(
+        symbol=symbol,
+        issuer=f"Issuer {symbol}",
+        coupon_rate=Decimal("0.045"),
+        maturity_date=date(2037, 6, 30),
+        yield_to_maturity=Decimal("0.051"),
+        rating="AA",
+        currency="USD",
+        price=Decimal("99.75"),
+    )
+
+
+def test_bonds_scanner_refresh_schedule_registered() -> None:
+    """The worker registry includes the daily 04:00 Asia/Jerusalem batch."""
+
+    schedule = next(item for item in JOB_SCHEDULES if item.job_id == "bonds_scanner_refresh")
+    assert schedule.kind == "cron"
+    assert schedule.cron_expr == "0 4 * * *"
+
+
+def test_refresh_upserts_successful_symbols_and_skips_failed_fetches() -> None:
+    """The batch writes successful fetches and keeps going after one symbol fails."""
+
+    session = FakeSession()
+
+    def fetcher(symbol: str) -> BondScannerCandidate:
+        if symbol == "FAIL":
+            raise RuntimeError("provider timeout")
+        return _candidate(symbol)
+
+    refreshed_at = datetime(2026, 5, 3, 1, 0, tzinfo=timezone.utc)
+    job = BondScannerRefreshJob(
+        symbols=("AAA", "FAIL", "BBB"),
+        fetcher=fetcher,
+        session_factory=lambda: session,
+        clock=lambda: refreshed_at,
+    )
+
+    assert job.run() == 2
+    assert session.committed is True
+    assert [call["params"]["symbol"] for call in session.executions] == ["AAA", "BBB"]
+    assert all("on conflict (symbol) do update" in call["sql"] for call in session.executions)
+    assert '"yield_to_maturity": "0.051"' in session.executions[0]["params"]["data"]
+    assert session.executions[0]["params"]["refreshed_at"] == refreshed_at

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -18,7 +18,6 @@ const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/tax-condor',
   '/api/backtest',
   '/api/analyze',
-  '/api/bonds/scanner',
   '/api/ndx/sync',
   '/api/trading/sync',
   '/api/pension',

--- a/apps/frontend/src/app/ladder/scanner/actions.test.ts
+++ b/apps/frontend/src/app/ladder/scanner/actions.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
+
+import { createClient } from '@/lib/supabase/server';
+import { listBondScanner } from './actions';
+
+function chain(result: unknown) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    then: (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve),
+  };
+}
+
+beforeEach(() => vi.resetAllMocks());
+
+describe('listBondScanner', () => {
+  it('returns empty results when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    await expect(listBondScanner()).resolves.toEqual([]);
+  });
+
+  it('reads bond_scanner_results and filters server-side', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+    const resultChain = chain({
+      data: [
+        {
+          symbol: 'AAA1',
+          data: {
+            issuer: 'AAA Bond',
+            coupon_rate: '0.04',
+            maturity_date: '2037-06-30',
+            yield_to_maturity: '0.051',
+            rating: 'AA',
+            currency: 'USD',
+            price: '99.75',
+          },
+          refreshed_at: '2026-05-03T01:00:00Z',
+        },
+        {
+          symbol: 'BBB1',
+          data: {
+            issuer: 'BBB Bond',
+            coupon_rate: '0.03',
+            maturity_date: '2036-06-30',
+            yield_to_maturity: '0.02',
+            rating: 'BBB',
+            currency: 'EUR',
+            price: '101',
+          },
+          refreshed_at: '2026-05-02T01:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(() => resultChain),
+    });
+
+    const rows = await listBondScanner({ currency: 'USD', min_rating: 'AA', min_yield: 0.05 });
+
+    expect(rows).toEqual([
+      {
+        id: 'AAA1',
+        issuer: 'AAA Bond',
+        coupon_rate: 0.04,
+        maturity_date: '2037-06-30',
+        yield_to_maturity: 0.051,
+        rating: 'AA',
+        currency: 'USD',
+        price: 99.75,
+        refreshed_at: '2026-05-03T01:00:00Z',
+      },
+    ]);
+    expect(resultChain.order).toHaveBeenCalledWith('refreshed_at', { ascending: false });
+  });
+});

--- a/apps/frontend/src/app/ladder/scanner/actions.ts
+++ b/apps/frontend/src/app/ladder/scanner/actions.ts
@@ -1,0 +1,119 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+
+export interface BondScannerFilters {
+  min_maturity?: string;
+  max_maturity?: string;
+  min_yield?: number;
+  min_rating?: string;
+  currency?: string;
+}
+
+export interface BondScannerResult {
+  id: string;
+  issuer: string;
+  coupon_rate: number;
+  maturity_date: string;
+  yield_to_maturity: number;
+  rating: string;
+  currency: string;
+  price: number;
+  refreshed_at: string;
+}
+
+const RATING_ORDER = [
+  'AAA',
+  'AA',
+  'A',
+  'BBB',
+  'BB',
+  'B',
+  'CCC',
+  'CC',
+  'C',
+  'D',
+] as const;
+
+function isIsoDate(value: string | undefined): value is string {
+  return (
+    typeof value === 'string' &&
+    /^\d{4}-\d{2}-\d{2}$/.test(value) &&
+    !Number.isNaN(Date.parse(`${value}T00:00:00Z`))
+  );
+}
+
+function ratingAtLeast(candidateRating: string, threshold: string): boolean {
+  const candidateIndex = RATING_ORDER.indexOf(
+    candidateRating as (typeof RATING_ORDER)[number],
+  );
+  const thresholdIndex = RATING_ORDER.indexOf(
+    threshold as (typeof RATING_ORDER)[number],
+  );
+  return candidateIndex >= 0 && thresholdIndex >= 0 && candidateIndex <= thresholdIndex;
+}
+
+function normalizeRow(row: Record<string, unknown>): BondScannerResult | null {
+  const data = (row.data ?? {}) as Record<string, unknown>;
+  const id = String(row.symbol ?? data.id ?? '');
+  const maturityDate = String(data.maturity_date ?? '');
+  if (!id || !isIsoDate(maturityDate)) return null;
+
+  return {
+    id,
+    issuer: String(data.issuer ?? id),
+    coupon_rate: Number(data.coupon_rate ?? 0),
+    maturity_date: maturityDate,
+    yield_to_maturity: Number(data.yield_to_maturity ?? 0),
+    rating: String(data.rating ?? 'NR'),
+    currency: String(data.currency ?? 'USD'),
+    price: Number(data.price ?? 0),
+    refreshed_at: String(row.refreshed_at ?? ''),
+  };
+}
+
+function matchesFilters(result: BondScannerResult, filters: BondScannerFilters): boolean {
+  if (isIsoDate(filters.min_maturity) && result.maturity_date < filters.min_maturity) {
+    return false;
+  }
+  if (isIsoDate(filters.max_maturity) && result.maturity_date > filters.max_maturity) {
+    return false;
+  }
+  if (
+    typeof filters.min_yield === 'number' &&
+    Number.isFinite(filters.min_yield) &&
+    result.yield_to_maturity < filters.min_yield
+  ) {
+    return false;
+  }
+  if (filters.currency && result.currency !== filters.currency) return false;
+  if (filters.min_rating && !ratingAtLeast(result.rating, filters.min_rating)) return false;
+  return true;
+}
+
+/** Reads cached bond scanner rows from Supabase and applies UI filters server-side. */
+export async function listBondScanner(
+  filters: BondScannerFilters = {},
+): Promise<BondScannerResult[]> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+  if (authError || !user) return [];
+
+  const { data, error } = await supabase
+    .from('bond_scanner_results')
+    .select('symbol, data, refreshed_at')
+    .order('refreshed_at', { ascending: false });
+
+  if (error) {
+    console.error('[listBondScanner] query error:', error.message);
+    return [];
+  }
+
+  return ((data ?? []) as Record<string, unknown>[])
+    .map(normalizeRow)
+    .filter((row): row is BondScannerResult => row !== null)
+    .filter((row) => matchesFilters(row, filters));
+}

--- a/apps/frontend/src/app/ladder/scanner/page.tsx
+++ b/apps/frontend/src/app/ladder/scanner/page.tsx
@@ -1,19 +1,11 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
 import React, { Suspense, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 
-type BondCandidate = {
-  id: string;
-  issuer: string;
-  coupon_rate: number;
-  maturity_date: string;
-  yield_to_maturity: number;
-  rating: string;
-  currency: string;
-  price: number;
-};
+import { listBondScanner, type BondScannerResult } from "./actions";
+
+type BondCandidate = BondScannerResult;
 
 const ScannerPage: React.FC = () => {
   const searchParams = useSearchParams();
@@ -30,7 +22,7 @@ const ScannerPage: React.FC = () => {
   // Initialize maturity filters based on optional fromYear query param.
   useEffect(() => {
     const fromYear = searchParams.get("fromYear");
-    if (fromYear) 
+    if (fromYear)
     {
       const yearNum = Number(fromYear) || new Date().getFullYear();
       setMinMaturity(`${yearNum}-01-01`);
@@ -43,21 +35,16 @@ const ScannerPage: React.FC = () => {
       setLoading(true);
       setError(null);
 
-      const params = new URLSearchParams();
-      if (minMaturity) params.set("min_maturity", minMaturity);
-      if (maxMaturity) params.set("max_maturity", maxMaturity);
-      if (minYield) params.set("min_yield", minYield);
-      if (minRating) params.set("min_rating", minRating);
-      if (currency) params.set("currency", currency);
-
-      const res = await apiFetch(`/api/bonds/scanner?${params.toString()}`);
-      if (!res.ok) {
-        throw new Error(`Request failed with status ${res.status}`);
-      }
-      const data: BondCandidate[] = await res.json();
+      const data = await listBondScanner({
+        min_maturity: minMaturity || undefined,
+        max_maturity: maxMaturity || undefined,
+        min_yield: minYield ? Number(minYield) / 100 : undefined,
+        min_rating: minRating || undefined,
+        currency: currency || undefined,
+      });
       setResults(data);
-    } catch (e: any) {
-      setError(e.message ?? "Search failed");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Search failed");
     } finally {
       setLoading(false);
     }
@@ -132,6 +119,12 @@ const ScannerPage: React.FC = () => {
         {loading ? "Searching..." : "Search"}
       </button>
 
+      {results.length > 0 && (
+        <div className="mt-3 text-xs text-slate-400">
+          Market data refreshed {new Date(results[0].refreshed_at).toLocaleString()}
+        </div>
+      )}
+
       {error && <div className="mt-3 text-sm text-red-400">{error}</div>}
 
       <div className="mt-6 overflow-x-auto text-sm">
@@ -145,6 +138,7 @@ const ScannerPage: React.FC = () => {
               <th className="border border-slate-700 px-2 py-1 text-left">Currency</th>
               <th className="border border-slate-700 px-2 py-1 text-right">Price</th>
               <th className="border border-slate-700 px-2 py-1 text-left">Maturity</th>
+              <th className="border border-slate-700 px-2 py-1 text-left">Freshness</th>
               <th className="border border-slate-700 px-2 py-1" />
             </tr>
           </thead>
@@ -163,6 +157,9 @@ const ScannerPage: React.FC = () => {
                 <td className="border border-slate-800 px-2 py-1 text-right">{b.price.toFixed(2)}</td>
                 <td className="border border-slate-800 px-2 py-1">
                   {new Date(b.maturity_date).toLocaleDateString()}
+                </td>
+                <td className="border border-slate-800 px-2 py-1">
+                  {new Date(b.refreshed_at).toLocaleString()}
                 </td>
                 <td className="border border-slate-800 px-2 py-1 text-center">
                   <button
@@ -184,7 +181,7 @@ const ScannerPage: React.FC = () => {
             {results.length === 0 && !loading && (
               <tr>
                 <td
-                  colSpan={8}
+                  colSpan={9}
                   className="border border-slate-800 px-2 py-4 text-center text-slate-400"
                 >
                   No results yet. Adjust filters and click Search.

--- a/supabase/migrations/20260503163017_add_bond_scanner_results.sql
+++ b/supabase/migrations/20260503163017_add_bond_scanner_results.sql
@@ -1,0 +1,50 @@
+-- Migration: 20260503163017_add_bond_scanner_results
+-- Purpose: Store daily TJ-020 bond scanner batch results for Supabase-only frontend reads.
+
+create table if not exists public.bond_scanner_results (
+  id uuid primary key default gen_random_uuid(),
+  symbol text not null,
+  data jsonb not null,
+  refreshed_at timestamptz not null default now(),
+  constraint bond_scanner_results_symbol_key unique (symbol)
+);
+
+create index if not exists bond_scanner_results_refreshed_at_idx
+  on public.bond_scanner_results (refreshed_at desc);
+
+alter table public.bond_scanner_results enable row level security;
+
+revoke all on table public.bond_scanner_results from anon;
+revoke all on table public.bond_scanner_results from authenticated;
+grant select on table public.bond_scanner_results to authenticated;
+grant select, insert, update on table public.bond_scanner_results to service_role;
+
+drop policy if exists bond_scanner_results_authenticated_select on public.bond_scanner_results;
+create policy bond_scanner_results_authenticated_select
+  on public.bond_scanner_results
+  for select
+  to authenticated
+  using (true);
+
+drop policy if exists bond_scanner_results_service_insert on public.bond_scanner_results;
+create policy bond_scanner_results_service_insert
+  on public.bond_scanner_results
+  for insert
+  to service_role
+  with check (true);
+
+drop policy if exists bond_scanner_results_service_update on public.bond_scanner_results;
+create policy bond_scanner_results_service_update
+  on public.bond_scanner_results
+  for update
+  to service_role
+  using (true)
+  with check (true);
+
+do $$
+begin
+  alter publication supabase_realtime add table public.bond_scanner_results;
+exception
+  when duplicate_object then null;
+  when undefined_object then null;
+end $$;


### PR DESCRIPTION
## Summary
- Closes #213 under TJ-020 umbrella #207; follows ADR .squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md and relates to #219.
- Adds public.bond_scanner_results with RLS, service-role writes, authenticated reads, realtime publication, and refreshed_at freshness.
- Registers bonds_scanner_refresh as a daily 04:00 Asia/Jerusalem worker batch with idempotent symbol upserts and per-symbol skip logging.
- Replaces the ladder scanner /api/bonds/scanner call with a Supabase-backed Server Action and freshness UI; removes the endpoint from walkthrough allow-list.

## Validation
- Supabase MCP migration applied and verified table, policies, and realtime publication.
- cd apps/backend && uv run pytest tests/test_bond_scanner_worker.py -q
- cd apps/backend && uv run ruff check app/api/bonds.py app/services/bond_scanner.py app/worker/bonds_scanner.py tests/test_bond_scanner_worker.py
- cd apps/frontend && npm test -- src/app/ladder/scanner/actions.test.ts
- cd apps/frontend && NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build