### PR TITLE
feat(TJ-020): migrate trading/sync to scheduled batch (#216)

### DIFF
--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -16,6 +16,7 @@ Copy the root `.env.example` or `apps/backend/.env.example` to a local `.env` an
 | `SUPABASE_SERVICE_ROLE_KEY` | Optional, server-only | Required only when worker code needs Supabase Storage access or privileged writes that cannot be performed with the database connection. This key bypasses RLS; never expose it to the browser and never prefix it with `NEXT_PUBLIC_`. |
 | `WORKER_TIMEZONE` | Optional | APScheduler timezone. Defaults to `Asia/Jerusalem`. |
 | `WORKER_POLL_INTERVAL_SECONDS` | Optional | `compute_jobs` polling interval. Defaults to `5`. |
+| `IB_GATEWAY_HOST` / `IB_GATEWAY_PORT` | Optional | IB Gateway TCP endpoint used by the scheduled trading sync health check and IBKR connection. Defaults to `127.0.0.1:4002`. Legacy `IB_HOST` / `IB_PORT` are also honored. |
 | `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional | Local observability settings. |
 
 ## Adding a scheduled batch job

--- a/apps/backend/app/api/trading.py
+++ b/apps/backend/app/api/trading.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 router = APIRouter(prefix="/api/trading", tags=["trading"])
 
+
 class ConfigUpdate(BaseModel):
     id: Optional[int] = None
     name: str
@@ -24,10 +25,12 @@ class ConfigUpdate(BaseModel):
     tokens_path: Optional[str] = None
     linked_account_id: Optional[str] = None
 
+
 @router.get("/configs", response_model=List[TradingAccountConfig])
 def get_configs(session: Session = Depends(get_session)):
     """List all trading account configurations."""
     return session.exec(select(TradingAccountConfig)).all()
+
 
 @router.get("/config", response_model=Optional[TradingAccountConfig])
 def get_config(id: Optional[int] = None, session: Session = Depends(get_session)):
@@ -36,29 +39,31 @@ def get_config(id: Optional[int] = None, session: Session = Depends(get_session)
         return session.get(TradingAccountConfig, id)
     return session.exec(select(TradingAccountConfig)).first()
 
+
 @router.post("/config", response_model=TradingAccountConfig)
 def update_config(config_data: ConfigUpdate, session: Session = Depends(get_session)):
     """Create or update a trading account configuration."""
     config = None
     if config_data.id:
         config = session.get(TradingAccountConfig, config_data.id)
-    
+
     if not config:
-        config = TradingAccountConfig(**config_data.model_dump(exclude={'id'}))
+        config = TradingAccountConfig(**config_data.model_dump(exclude={"id"}))
     else:
-        for key, value in config_data.model_dump(exclude={'id'}).items():
+        for key, value in config_data.model_dump(exclude={"id"}).items():
             setattr(config, key, value)
-    
+
     session.add(config)
     session.commit()
     session.refresh(config)
     return config
 
-@router.post("/sync")
+
+@router.post("/sync", deprecated=True)
 async def sync_account(
     account_id: Optional[int] = None,
     user_id: UUID = Depends(get_current_user_id),
-    session: Session = Depends(get_session)
+    session: Session = Depends(get_session),
 ):
     """
     Triggers a live sync with a broker and stores results in DB.
@@ -66,63 +71,57 @@ async def sync_account(
     household_id = get_user_household_id(session, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         return await trading_service.sync_account(session, household_id, config_id=account_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.get("/summary", response_model=Optional[TradingAccountSummary])
 def get_latest_summary(
     account_id: Optional[int] = None,
     user_id: UUID = Depends(get_current_user_id),
-    session: Session = Depends(get_session)
+    session: Session = Depends(get_session),
 ):
     """Return the most recent trading account summary for the authenticated user's household."""
     household_id = get_user_household_id(session, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
-    statement = (
-        select(TradingAccountSummary)
-        .where(TradingAccountSummary.household_id == household_id)
-    )
+
+    statement = select(TradingAccountSummary).where(TradingAccountSummary.household_id == household_id)
     if account_id:
         statement = statement.where(TradingAccountSummary.account_config_id == account_id)
     statement = statement.order_by(TradingAccountSummary.timestamp.desc()).limit(1)
     return session.exec(statement).first()
 
+
 @router.get("/positions", response_model=List[TradingPosition])
 def get_latest_positions(
     account_id: Optional[int] = None,
     user_id: UUID = Depends(get_current_user_id),
-    session: Session = Depends(get_session)
+    session: Session = Depends(get_session),
 ):
     """List current trading positions for the authenticated user's household, optionally filtered by account."""
     household_id = get_user_household_id(session, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
-    statement = (
-        select(TradingPosition)
-        .where(TradingPosition.household_id == household_id)
-    )
+
+    statement = select(TradingPosition).where(TradingPosition.household_id == household_id)
     if account_id:
         statement = statement.where(TradingPosition.account_config_id == account_id)
     return session.exec(statement).all()
 
+
 @router.post("/sync-to-dividends")
-async def sync_to_dividends(
-    user_id: UUID = Depends(get_current_user_id),
-    session: Session = Depends(get_session)
-):
+async def sync_to_dividends(user_id: UUID = Depends(get_current_user_id), session: Session = Depends(get_session)):
     """
     Propagates data from all trading accounts to the dividend dashboard.
     """
     household_id = get_user_household_id(session, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         return await trading_service.sync_to_dividends(session, household_id)
     except Exception as e:

--- a/apps/backend/app/schema/models.py
+++ b/apps/backend/app/schema/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime, date as date_type
 from decimal import Decimal
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy import BigInteger, Column, Numeric
 from sqlmodel import Field, SQLModel
@@ -149,6 +150,7 @@ class DailyBar(SQLModel, table=True):
 
 class Execution(SQLModel, table=True):
     execId: str = Field(primary_key=True, index=True)
+    household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)
     permId: int
     orderId: int
     clientId: int
@@ -177,6 +179,7 @@ class MatchedTrade(SQLModel, table=True):
     close_price: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     pnl: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     notes: Optional[str] = None
+
 
 # Import backtest models to register them with SQLModel.metadata
 # Import finance models for alebmic registration

--- a/apps/backend/app/schema/trading_models.py
+++ b/apps/backend/app/schema/trading_models.py
@@ -6,9 +6,11 @@ from uuid import UUID
 from sqlalchemy import Column, Numeric
 from sqlmodel import SQLModel, Field
 
+
 class TradingAccountType(str, Enum):
     IBKR = "IBKR"
     SCHWAB = "SCHWAB"
+
 
 class TradingAccountConfig(SQLModel, table=True):
     __tablename__ = "trading_account_config"
@@ -16,28 +18,31 @@ class TradingAccountConfig(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     name: str = Field(default="My Trading Account")
     account_type: TradingAccountType = Field(default=TradingAccountType.IBKR)
-    
+
     # IBKR specific fields
     host: Optional[str] = Field(default="127.0.0.1")
-    port: Optional[int] = Field(default=4001) 
+    port: Optional[int] = Field(default=4001)
     client_id: Optional[int] = Field(default=1)
-    
+
     # Schwab specific fields
     app_key: Optional[str] = Field(default=None)
     app_secret: Optional[str] = Field(default=None)
     account_hash: Optional[str] = Field(default=None)
     tokens_path: Optional[str] = Field(default="schwab_tokens.json")
-    
+
     # Link to the internal FinanceItem ID (from finance_models.py)
-    linked_account_id: Optional[str] = Field(default=None) 
-    
+    linked_account_id: Optional[str] = Field(default=None)
+
     # Account ID from Broker (e.g. IBKR U1234567), populated after connection
     account_id: Optional[str] = Field(default=None)
     last_synced: Optional[datetime] = Field(default=None)
+    last_synced_at: Optional[datetime] = Field(default=None)
+    household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)
+
 
 class TradingAccountSummary(SQLModel, table=True):
     __tablename__ = "trading_account_summary"
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     account_config_id: Optional[int] = Field(default=None, foreign_key="trading_account_config.id")
     net_liquidation: Decimal = Field(sa_column=Column(Numeric(18, 6)))
@@ -46,15 +51,16 @@ class TradingAccountSummary(SQLModel, table=True):
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)
 
+
 class TradingPosition(SQLModel, table=True):
     __tablename__ = "trading_positions"
-    
+
     id: Optional[int] = Field(default=None, primary_key=True)
     account_config_id: Optional[int] = Field(default=None, foreign_key="trading_account_config.id")
     symbol: str
     amount: Decimal = Field(sa_column=Column(Numeric(18, 6)))
     sec_type: str
     avg_cost: Decimal = Field(sa_column=Column(Numeric(18, 6)))
-    con_id: Optional[int] = Field(default=None) # Optional for non-IBKR
+    con_id: Optional[int] = Field(default=None)  # Optional for non-IBKR
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)

--- a/apps/backend/app/services/trading_batch.py
+++ b/apps/backend/app/services/trading_batch.py
@@ -1,0 +1,73 @@
+"""Scheduled trading account sync batch."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import socket
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from typing import Any
+
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.trading_service import trading_service
+
+logger = logging.getLogger(__name__)
+DEFAULT_IB_GATEWAY_HOST = "127.0.0.1"
+DEFAULT_IB_GATEWAY_PORT = 4002
+DEFAULT_IB_GATEWAY_TIMEOUT_SECONDS = 2.0
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+def ib_gateway_endpoint() -> tuple[str, int]:
+    """Return the configured IB Gateway host and port for health checks."""
+
+    host = os.getenv("IB_GATEWAY_HOST") or os.getenv("IB_HOST") or DEFAULT_IB_GATEWAY_HOST
+    raw_port = os.getenv("IB_GATEWAY_PORT") or os.getenv("IB_PORT") or str(DEFAULT_IB_GATEWAY_PORT)
+    try:
+        port = int(raw_port)
+    except ValueError:
+        logger.warning("Invalid IB gateway port %r; using %s", raw_port, DEFAULT_IB_GATEWAY_PORT)
+        port = DEFAULT_IB_GATEWAY_PORT
+    return host, port
+
+
+def is_ib_gateway_available(host: str, port: int, timeout: float = DEFAULT_IB_GATEWAY_TIMEOUT_SECONDS) -> bool:
+    """Return whether a TCP connection to IB Gateway can be established."""
+
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def _session_factory() -> AbstractContextManager[Session]:
+    """Create a SQLModel session bound to the worker database engine."""
+
+    return Session(engine)
+
+
+async def run_trading_sync_batch_async(session_factory: SessionFactory = _session_factory) -> dict[str, Any]:
+    """Run one trading sync batch if IB Gateway is reachable."""
+
+    host, port = ib_gateway_endpoint()
+    if not is_ib_gateway_available(host, port):
+        logger.info("IB Gateway offline, skipping")
+        return {"status": "skipped", "reason": "ib_gateway_offline", "host": host, "port": port}
+
+    try:
+        with session_factory() as session:
+            return await trading_service.sync_all_configured_accounts(session)
+    except Exception as exc:  # noqa: BLE001 - scheduler must keep running after failures
+        logger.exception("Trading sync batch failed")
+        return {"status": "failed", "error": str(exc)}
+
+
+def run_trading_sync_batch(session_factory: SessionFactory = _session_factory) -> dict[str, Any]:
+    """Synchronous APScheduler entry point for the trading sync batch."""
+
+    return asyncio.run(run_trading_sync_batch_async(session_factory=session_factory))

--- a/apps/backend/app/services/trading_service.py
+++ b/apps/backend/app/services/trading_service.py
@@ -1,12 +1,38 @@
 from typing import List, Dict, Any, Optional
 from uuid import UUID
-from datetime import datetime
-from ib_async import IB
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+import logging
+import os
+
+from ib_async import IB, ExecutionFilter
 from app.schema.trading_models import TradingAccountConfig, TradingAccountSummary, TradingPosition
 from sqlmodel import Session, select, delete
-import logging
 
 logger = logging.getLogger(__name__)
+ZERO = Decimal("0")
+
+
+def _decimal_from_broker(value: object) -> Decimal:
+    """Convert broker numeric payloads to Decimal without binary float math."""
+
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return ZERO
+
+
+def _convert_decimal_currency(amount: Decimal, from_curr: str, to_curr: str) -> Decimal:
+    """Convert a Decimal amount using the legacy fixed currency-rate table."""
+
+    from app.utils.currency import RATES
+
+    from_rate = Decimal(str(RATES.get((from_curr or "").upper(), 1)))
+    to_rate = Decimal(str(RATES.get((to_curr or "").upper(), 1)))
+    if to_rate == ZERO:
+        return ZERO
+    return (amount * from_rate) / to_rate
+
 
 class TradingService:
     def __init__(self):
@@ -22,14 +48,28 @@ class TradingService:
         statement = select(TradingAccountConfig).limit(1)
         return db.exec(statement).first()
 
+    def _ib_host(self, config: TradingAccountConfig) -> str:
+        return os.getenv("IB_GATEWAY_HOST") or os.getenv("IB_HOST") or config.host or "127.0.0.1"
+
+    def _ib_port(self, config: TradingAccountConfig) -> int:
+        raw_port = os.getenv("IB_GATEWAY_PORT") or os.getenv("IB_PORT") or config.port or 4002
+        try:
+            return int(raw_port)
+        except (TypeError, ValueError):
+            logger.warning("Invalid IB gateway port %r; using 4002", raw_port)
+            return 4002
+
     async def connect_ibkr(self, config: TradingAccountConfig):
+        host = self._ib_host(config)
+        port = self._ib_port(config)
         if not self.ib.isConnected():
-            logger.info(f"Connecting to IBKR at {config.host}:{config.port} with clientId={config.client_id}...")
-            await self.ib.connectAsync(config.host, config.port, clientId=config.client_id, timeout=20)
-            
+            logger.info("Connecting to IBKR at %s:%s with clientId=%s...", host, port, config.client_id)
+            await self.ib.connectAsync(host, port, clientId=config.client_id, timeout=20)
+
             if not config.account_id:
                 accounts = self.ib.managedAccounts()
-                if accounts: config.account_id = accounts[0]
+                if accounts:
+                    config.account_id = accounts[0]
         return self.ib
 
     async def disconnect_ibkr(self):
@@ -51,139 +91,216 @@ class TradingService:
         else:
             raise Exception(f"Unsupported account type: {config.account_type}")
 
+    async def sync_all_configured_accounts(self, db: Session) -> Dict[str, Any]:
+        """Sync every household-scoped account configuration for the worker batch."""
+
+        configs = db.exec(select(TradingAccountConfig)).all()
+        results: list[dict[str, Any]] = []
+        failures: list[dict[str, str]] = []
+
+        for config in configs:
+            if not config.household_id:
+                logger.warning("Skipping trading account %s without household_id", config.id)
+                continue
+            try:
+                results.append(await self.sync_account(db, config.household_id, config_id=config.id))
+            except Exception as exc:  # noqa: BLE001 - one account must not crash the scheduler
+                logger.exception("Trading sync failed for account config %s", config.id)
+                db.rollback()
+                failures.append({"account": config.name, "error": str(exc)})
+
+        return {"status": "success" if not failures else "partial", "synced": results, "failed": failures}
+
     async def sync_ibkr(self, db: Session, config: TradingAccountConfig, household_id: UUID) -> Dict[str, Any]:
         try:
             await self.connect_ibkr(config)
-            
+
+            synced_at = datetime.now(timezone.utc)
+            previous_sync = config.last_synced_at or config.last_synced
             summary_data = await self.ib.accountSummaryAsync()
-            net_liq = 0.0
-            total_cash = 0.0
+            net_liq = ZERO
+            total_cash = ZERO
             currency = "USD"
-            
+
             for item in summary_data:
                 if item.tag == "NetLiquidation":
-                    net_liq = float(item.value)
+                    net_liq = _decimal_from_broker(item.value)
                     currency = item.currency
                 elif item.tag == "TotalCashValue":
-                    total_cash = float(item.value)
-            
-            new_summary = TradingAccountSummary(
-                account_config_id=config.id,
-                net_liquidation=net_liq,
-                total_cash=total_cash,
-                currency=currency,
-                timestamp=datetime.utcnow(),
-                household_id=household_id
+                    total_cash = _decimal_from_broker(item.value)
+
+            db.add(
+                TradingAccountSummary(
+                    account_config_id=config.id,
+                    net_liquidation=net_liq,
+                    total_cash=total_cash,
+                    currency=currency,
+                    timestamp=synced_at,
+                    household_id=household_id,
+                )
             )
-            db.add(new_summary)
 
             positions_data = self.ib.positions()
-            # Clear old positions for THIS account and household
             db.exec(
                 delete(TradingPosition)
                 .where(TradingPosition.account_config_id == config.id)
                 .where(TradingPosition.household_id == household_id)
             )
-            
+
             for p in positions_data:
                 contract = p.contract
-                new_pos = TradingPosition(
-                    account_config_id=config.id,
-                    symbol=contract.symbol,
-                    amount=p.position,
-                    sec_type=contract.secType,
-                    avg_cost=p.avgCost,
-                    con_id=contract.conId,
-                    timestamp=datetime.utcnow(),
-                    household_id=household_id
+                db.add(
+                    TradingPosition(
+                        account_config_id=config.id,
+                        symbol=contract.symbol,
+                        amount=_decimal_from_broker(p.position),
+                        sec_type=contract.secType,
+                        avg_cost=_decimal_from_broker(p.avgCost),
+                        con_id=contract.conId,
+                        timestamp=synced_at,
+                        household_id=household_id,
+                    )
                 )
-                db.add(new_pos)
-            
-            config.last_synced = datetime.utcnow()
+
+            executions_count = await self._sync_ibkr_executions(db, previous_sync, household_id)
+            config.last_synced = synced_at
+            config.last_synced_at = synced_at
             db.add(config)
             db.commit()
-            
-            # 4. Update Dividend Dashboard and Propagate to Snapshot
-            annual_dividend_income = 0.0
+
+            annual_dividend_income = ZERO
             try:
                 from app.schema.dividend_models import DividendTickerData, DividendAccount, DividendPosition
-                from app.utils.currency import convert_currency
-                from sqlalchemy import delete
-                
-                # A. Get all STK positions for this account
+
                 stk_positions = [p for p in positions_data if p.contract.secType == "STK"]
                 tickers = [p.contract.symbol for p in stk_positions]
-                
-                # B. Sync to Dividend Positions table if linked
+
                 if config.linked_account_id:
-                    # Find dividend account(s) linked to the same FinanceItem in this household
                     stmt = (
                         select(DividendAccount)
                         .where(DividendAccount.linked_id == config.linked_account_id)
                         .where(DividendAccount.household_id == household_id)
                     )
                     div_accounts = db.exec(stmt).all()
-                    
+
                     for da in div_accounts:
-                        # Clear old positions for THIS dashboard account
                         db.exec(delete(DividendPosition).where(DividendPosition.account == da.name))
-                        # Insert new ones
                         for p in stk_positions:
-                            db.add(DividendPosition(
-                                account=da.name,
-                                ticker=p.contract.symbol,
-                                shares=abs(p.position)
-                            ))
-                        logger.info(f"Synced {len(stk_positions)} positions to Dividend Dashboard account: {da.name}")
+                            db.add(
+                                DividendPosition(
+                                    account=da.name,
+                                    ticker=p.contract.symbol,
+                                    shares=_decimal_from_broker(abs(p.position)),
+                                )
+                            )
+                        logger.info(
+                            "Synced %s positions to Dividend Dashboard account: %s", len(stk_positions), da.name
+                        )
                     db.commit()
 
-                # C. Calculate total annual income for the Snapshot updates
                 if tickers:
                     stmt = select(DividendTickerData).where(DividendTickerData.ticker.in_(tickers))
-                    ticker_data_list = db.exec(stmt).all()
-                    ticker_map = {td.ticker: td for td in ticker_data_list}
-                    
+                    ticker_map = {td.ticker: td for td in db.exec(stmt).all()}
+
                     for p in stk_positions:
                         symbol = p.contract.symbol
                         if symbol in ticker_map:
                             td = ticker_map[symbol]
-                            # Calc income: shares * rate. Convert to account currency.
-                            income = abs(p.position) * td.dividend_rate
-                            income_converted = convert_currency(income, td.currency, currency)
-                            annual_dividend_income += income_converted
-                            
-                logger.info(f"Calculated annual dividend income for {config.name}: {annual_dividend_income} {currency}")
-            except Exception as e:
-                logger.error(f"Failed to sync dividend data: {e}", exc_info=True)
+                            income = _decimal_from_broker(abs(p.position)) * _decimal_from_broker(td.dividend_rate)
+                            annual_dividend_income += _convert_decimal_currency(income, td.currency, currency)
 
-            # 5. Propagate totals to Finance Snapshot if linked
+                logger.info(
+                    "Calculated annual dividend income for %s: %s %s", config.name, annual_dividend_income, currency
+                )
+            except Exception as e:
+                logger.error("Failed to sync dividend data: %s", e, exc_info=True)
+
             if config.linked_account_id:
                 try:
                     extra_updates = {
-                        "dividend_fixed_amount": annual_dividend_income,
-                        "dividend_mode": "Fixed"
+                        "dividend_fixed_amount": str(annual_dividend_income),
+                        "dividend_mode": "Fixed",
                     }
-                    await self._update_finance_snapshot(db, config.linked_account_id, household_id, net_liq, extra_updates)
+                    await self._update_finance_snapshot(
+                        db, config.linked_account_id, household_id, str(net_liq), extra_updates
+                    )
                 except Exception as e:
-                    logger.error(f"Failed to update finance snapshot for IBKR sync: {e}")
+                    logger.error("Failed to update finance snapshot for IBKR sync: %s", e)
 
             return {
                 "status": "success",
                 "account": config.name,
-                "summary": {"net_liquidation": net_liq, "total_cash": total_cash, "currency": currency},
+                "summary": {"net_liquidation": str(net_liq), "total_cash": str(total_cash), "currency": currency},
                 "positions_count": len(positions_data),
-                "last_synced": config.last_synced.isoformat(),
-                "dividend_income": annual_dividend_income
+                "executions_count": executions_count,
+                "last_synced_at": config.last_synced_at.isoformat(),
+                "dividend_income": str(annual_dividend_income),
             }
         finally:
             await self.disconnect_ibkr()
 
-    async def _update_finance_snapshot(self, db: Session, linked_id: str, household_id: UUID, new_value: float, extra_updates: Optional[Dict] = None):
+    async def _sync_ibkr_executions(
+        self,
+        db: Session,
+        since: datetime | None,
+        household_id: UUID,
+    ) -> int:
+        """Best-effort sync of IB executions since the last account refresh."""
+
+        from app.schema.models import Execution
+
+        exec_filter = ExecutionFilter()
+        if since:
+            exec_filter.time = since.strftime("%Y%m%d %H:%M:%S")
+
+        try:
+            executions = await self.ib.reqExecutionsAsync(exec_filter)
+        except Exception as exc:  # noqa: BLE001 - executions are not critical to account freshness
+            logger.warning("IB execution sync skipped: %s", exc)
+            return 0
+
+        count = 0
+        for exec_detail in executions:
+            execution = getattr(exec_detail, "execution", None)
+            contract = getattr(exec_detail, "contract", None)
+            commission_report = getattr(exec_detail, "commissionReport", None)
+            exec_id = getattr(execution, "execId", None)
+            if not execution or not contract or not exec_id:
+                continue
+
+            record = db.get(Execution, exec_id)
+            if record is None:
+                record = Execution(
+                    execId=exec_id,
+                    permId=getattr(execution, "permId", 0),
+                    orderId=getattr(execution, "orderId", 0),
+                    clientId=getattr(execution, "clientId", 0),
+                    time=getattr(execution, "time", datetime.now(timezone.utc)),
+                    acctNumber=getattr(execution, "acctNumber", ""),
+                    exchange=getattr(execution, "exchange", ""),
+                    side=getattr(execution, "side", ""),
+                    shares=_decimal_from_broker(getattr(execution, "shares", 0)),
+                    price=_decimal_from_broker(getattr(execution, "price", 0)),
+                    avgPrice=_decimal_from_broker(getattr(execution, "avgPrice", 0)),
+                    cumQty=_decimal_from_broker(getattr(execution, "cumQty", 0)),
+                    symbol=getattr(contract, "symbol", ""),
+                    commission=_decimal_from_broker(getattr(commission_report, "commission", 0)),
+                    currency=getattr(commission_report, "currency", "USD"),
+                    realizedPNL=_decimal_from_broker(getattr(commission_report, "realizedPNL", 0)),
+                )
+            record.household_id = household_id
+            db.add(record)
+            count += 1
+        return count
+
+    async def _update_finance_snapshot(
+        self, db: Session, linked_id: str, household_id: UUID, new_value: object, extra_updates: Optional[Dict] = None
+    ):
         """
         Updates a specific item in the latest finance snapshot and recalculates totals.
         """
         from app.schema.finance_models import FinanceSnapshot
-        
+
         statement = (
             select(FinanceSnapshot)
             .where(FinanceSnapshot.household_id == household_id)
@@ -191,147 +308,152 @@ class TradingService:
             .limit(1)
         )
         snapshot = db.exec(statement).first()
-        
-        if not snapshot or not snapshot.data or 'items' not in snapshot.data:
+
+        if not snapshot or not snapshot.data or "items" not in snapshot.data:
             logger.warning(f"No finance snapshot found to update linked account {linked_id}")
             return
 
-        items = snapshot.data['items']
+        items = snapshot.data["items"]
         updated = False
-        
+
         for item in items:
-            if item.get('id') == linked_id:
-                item['value'] = new_value
+            if item.get("id") == linked_id:
+                item["value"] = new_value
                 if extra_updates:
-                    if 'details' not in item:
-                        item['details'] = {}
-                    item['details'].update(extra_updates)
+                    if "details" not in item:
+                        item["details"] = {}
+                    item["details"].update(extra_updates)
                 updated = True
                 break
-        
+
         if updated:
             # Recalculate totals
             from app.utils.currency import convert_currency
-            
+
             total_savings = 0.0
             total_investments = 0.0
             total_assets = 0.0
             total_liabilities = 0.0
-            
+
             # Use fixed base currency for snapshot totals (ILS)
-            base_curr = snapshot.data.get('mainCurrency', 'ILS')
-            
+            base_curr = snapshot.data.get("mainCurrency", "ILS")
+
             for item in items:
-                val = float(item.get('value', 0))
-                item_curr = item.get('currency', 'USD') # Default to USD if missing, but usually present
-                
+                val = float(item.get("value", 0))
+                item_curr = item.get("currency", "USD")  # Default to USD if missing, but usually present
+
                 # Convert value to base currency for totals
                 val_base = convert_currency(val, item_curr, base_curr)
-                
-                cat = item.get('category')
-                
-                if cat == 'Savings': total_savings += val_base
-                elif cat == 'Investments': total_investments += val_base
-                
-                if cat == 'Liabilities' or cat == 'Debt':
+
+                cat = item.get("category")
+
+                if cat == "Savings":
+                    total_savings += val_base
+                elif cat == "Investments":
+                    total_investments += val_base
+
+                if cat == "Liabilities" or cat == "Debt":
                     total_liabilities += val_base
                 else:
                     total_assets += val_base
-            
+
             snapshot.total_assets = total_assets
             snapshot.total_liabilities = total_liabilities
             snapshot.net_worth = total_assets - total_liabilities
-            
+
             # Update the JSON data too
-            snapshot.data['total_savings'] = total_savings
-            snapshot.data['total_investments'] = total_investments
-            snapshot.data['total_assets'] = total_assets
-            snapshot.data['total_liabilities'] = total_liabilities
-            snapshot.data['net_worth'] = snapshot.net_worth
-            
+            snapshot.data["total_savings"] = total_savings
+            snapshot.data["total_investments"] = total_investments
+            snapshot.data["total_assets"] = total_assets
+            snapshot.data["total_liabilities"] = total_liabilities
+            snapshot.data["net_worth"] = snapshot.net_worth
+
             # Re-assign to trigger mutation detection and use flag_modified
             from sqlalchemy.orm.attributes import flag_modified
+
             snapshot.data = dict(snapshot.data)
             flag_modified(snapshot, "data")
-            
+
             db.add(snapshot)
             db.commit()
-            logger.info(f"Updated finance snapshot item {linked_id} to {new_value} {item_curr}. Totals updated in {base_curr}.")
+            logger.info(
+                f"Updated finance snapshot item {linked_id} to {new_value} {item_curr}. Totals updated in {base_curr}."
+            )
 
     async def sync_schwab(self, db: Session, config: TradingAccountConfig, household_id: UUID) -> Dict[str, Any]:
         """
         Implements Schwab sync using schwab-py.
         """
         from schwab.auth import client_from_token_file
-        
+
         try:
             # Note: schwab-py is synchronous in many parts or uses its own pattern.
             # We assume tokens_path is managed/populated by user.
             client = client_from_token_file(config.tokens_path, config.app_key, config.app_secret)
-            
+
             # Fetch Account Details
             # get_account_details returns a Response object
             resp = client.get_account_details(config.account_hash, fields=client.Account.Fields.POSITIONS)
             if not resp.ok:
                 raise Exception(f"Schwab API error: {resp.status_code} - {resp.text}")
-            
+
             data = resp.json()
-            securities_account = data.get('securitiesAccount', {})
-            
+            securities_account = data.get("securitiesAccount", {})
+
             # 1. Summary
-            net_liq = float(securities_account.get('currentBalances', {}).get('liquidationValue', 0.0))
-            total_cash = float(securities_account.get('currentBalances', {}).get('cashBalance', 0.0))
-            currency = "USD" # Schwab is typically USD
-            
+            net_liq = float(securities_account.get("currentBalances", {}).get("liquidationValue", 0.0))
+            total_cash = float(securities_account.get("currentBalances", {}).get("cashBalance", 0.0))
+            currency = "USD"  # Schwab is typically USD
+
             new_summary = TradingAccountSummary(
                 account_config_id=config.id,
                 net_liquidation=net_liq,
                 total_cash=total_cash,
                 currency=currency,
                 timestamp=datetime.utcnow(),
-                household_id=household_id
+                household_id=household_id,
             )
             db.add(new_summary)
-            
+
             # 2. Positions
-            schwab_positions = securities_account.get('positions', [])
+            schwab_positions = securities_account.get("positions", [])
             db.exec(
                 delete(TradingPosition)
                 .where(TradingPosition.account_config_id == config.id)
                 .where(TradingPosition.household_id == household_id)
             )
-            
+
             count = 0
             for p in schwab_positions:
-                instrument = p.get('instrument', {})
-                symbol = instrument.get('symbol')
-                asset_type = instrument.get('assetType') # e.g. EQUITY
-                
+                instrument = p.get("instrument", {})
+                symbol = instrument.get("symbol")
+                asset_type = instrument.get("assetType")  # e.g. EQUITY
+
                 # Normalize asset type to match IBKR's 'STK', 'OPT', etc if possible
                 sec_type = "STK" if asset_type == "EQUITY" else asset_type
-                
+
                 new_pos = TradingPosition(
                     account_config_id=config.id,
                     symbol=symbol,
-                    amount=float(p.get('longQuantity', 0.0)) or float(p.get('shortQuantity', 0.0)),
+                    amount=float(p.get("longQuantity", 0.0)) or float(p.get("shortQuantity", 0.0)),
                     sec_type=sec_type,
-                    avg_cost=float(p.get('averagePrice', 0.0)),
+                    avg_cost=float(p.get("averagePrice", 0.0)),
                     timestamp=datetime.utcnow(),
-                    household_id=household_id
+                    household_id=household_id,
                 )
                 db.add(new_pos)
                 count += 1
-                
+
             config.last_synced = datetime.utcnow()
             db.add(config)
             db.commit()
-            
+
             return {
                 "status": "success",
                 "account": config.name,
                 "summary": {"net_liquidation": net_liq, "total_cash": total_cash, "currency": currency},
                 "positions_count": count,
-                "last_synced": config.last_synced.isoformat()
+                "last_synced": config.last_synced.isoformat(),
             }
         except Exception as e:
             logger.error(f"Schwab sync failed: {str(e)}")
@@ -342,15 +464,15 @@ class TradingService:
         Propagates STK positions from ALL trading accounts to their linked DividendAccounts.
         """
         from app.schema.dividend_models import DividendAccount, DividendPosition
-        
+
         configs = await self.get_configs(db)
         synced_accounts = []
         total_positions = 0
-        
+
         for config in configs:
             if not config.linked_account_id:
                 continue
-                
+
             # Find DividendAccount for this household
             statement = (
                 select(DividendAccount)
@@ -358,31 +480,32 @@ class TradingService:
                 .where(DividendAccount.household_id == household_id)
             )
             div_account = db.exec(statement).first()
-            if not div_account: continue
-            
+            if not div_account:
+                continue
+
             # Get positions for THIS account and household
             statement = select(TradingPosition).where(
                 TradingPosition.account_config_id == config.id,
                 TradingPosition.household_id == household_id,
-                TradingPosition.sec_type == "STK"
+                TradingPosition.sec_type == "STK",
             )
             trading_positions = db.exec(statement).all()
-            
+
             if trading_positions:
                 # Clear existing in THAT div account
                 db.exec(delete(DividendPosition).where(DividendPosition.account == div_account.name))
                 for tp in trading_positions:
                     new_dp = DividendPosition(account=div_account.name, ticker=tp.symbol, shares=tp.amount)
                     db.add(new_dp)
-                
+
                 synced_accounts.append(div_account.name)
                 total_positions += len(trading_positions)
-        
+
         db.commit()
         return {
             "status": "success",
             "message": f"Synced {total_positions} positions across {len(synced_accounts)} accounts: {', '.join(synced_accounts)}",
-            "count": total_positions
+            "count": total_positions,
         }
 
     async def get_latest_summary(self, db: Session) -> Dict[str, Any]:
@@ -390,12 +513,12 @@ class TradingService:
         summary = db.exec(statement).first()
         if not summary:
             return {"net_liquidation": 0.0, "total_cash": 0.0, "currency": "USD"}
-        
+
         return {
             "net_liquidation": summary.net_liquidation,
             "total_cash": summary.total_cash,
             "currency": summary.currency,
-            "timestamp": summary.timestamp.isoformat()
+            "timestamp": summary.timestamp.isoformat(),
         }
 
     async def get_latest_positions(self, db: Session) -> List[Dict[str, Any]]:
@@ -408,10 +531,11 @@ class TradingService:
                 "type": p.sec_type,
                 "avgCost": p.avg_cost,
                 "conId": p.con_id,
-                "timestamp": p.timestamp.isoformat()
+                "timestamp": p.timestamp.isoformat(),
             }
             for p in positions
         ]
+
 
 # Singleton instance
 trading_service = TradingService()

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
+from app.services.trading_batch import run_trading_sync_batch
 from app.worker.bonds_scanner import refresh_bond_scanner_results
 
 JobPayload = dict[str, object]
@@ -25,6 +26,12 @@ class JobSchedule:
 
 JOB_HANDLERS: dict[str, JobHandler] = {}
 JOB_SCHEDULES: list[JobSchedule] = [
+    JobSchedule(
+        job_id="trading_sync",
+        kind="interval",
+        seconds=15 * 60,
+        handler=run_trading_sync_batch,
+    ),
     JobSchedule(
         job_id="bonds_scanner_refresh",
         kind="cron",

--- a/apps/backend/tests/test_trading_sync_batch.py
+++ b/apps/backend/tests/test_trading_sync_batch.py
@@ -1,0 +1,163 @@
+"""Tests for the scheduled trading sync worker."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterator
+
+import pytest
+from sqlmodel import Session, select
+
+from app.schema.trading_models import TradingAccountConfig, TradingAccountSummary, TradingPosition
+from app.services import trading_batch
+from app.services.trading_service import trading_service
+from app.worker.registry import JOB_SCHEDULES
+from conftest import TEST_HOUSEHOLD_ID
+
+
+@dataclass
+class SummaryItem:
+    """Minimal IB account summary row fixture."""
+
+    tag: str
+    value: str
+    currency: str = "USD"
+
+
+@dataclass
+class Contract:
+    """Minimal IB contract fixture."""
+
+    symbol: str
+    secType: str
+    conId: int
+
+
+@dataclass
+class Position:
+    """Minimal IB position fixture."""
+
+    contract: Contract
+    position: str
+    avgCost: str
+
+
+class FakeIB:
+    """Small async-compatible IB client fake."""
+
+    def __init__(self) -> None:
+        self.connected = False
+        self.positions_payload = [Position(Contract("AAPL", "STK", 265598), "3", "150.25")]
+
+    def isConnected(self) -> bool:
+        """Return connection state."""
+
+        return self.connected
+
+    async def connectAsync(self, *_args: object, **_kwargs: object) -> None:
+        """Mark the fake as connected."""
+
+        self.connected = True
+
+    def disconnect(self) -> None:
+        """Mark the fake as disconnected."""
+
+        self.connected = False
+
+    def managedAccounts(self) -> list[str]:
+        """Return one fake IB managed account."""
+
+        return ["U1234567"]
+
+    async def accountSummaryAsync(self) -> list[SummaryItem]:
+        """Return deterministic account summary data."""
+
+        return [
+            SummaryItem("NetLiquidation", "1000.12"),
+            SummaryItem("TotalCashValue", "200.34"),
+        ]
+
+    def positions(self) -> list[Position]:
+        """Return deterministic positions."""
+
+        return self.positions_payload
+
+    async def reqExecutionsAsync(self, _exec_filter: object) -> list[object]:
+        """Return no executions for these tests."""
+
+        return []
+
+
+@contextmanager
+def session_context(session: Session) -> Iterator[Session]:
+    """Yield the existing SQLModel session without closing it."""
+
+    yield session
+
+
+def test_trading_sync_schedule_registered() -> None:
+    """The worker registers a 15-minute trading_sync interval job."""
+
+    schedule = next((job for job in JOB_SCHEDULES if job.job_id == "trading_sync"), None)
+
+    assert schedule is not None
+    assert schedule.kind == "interval"
+    assert schedule.seconds == 15 * 60
+    assert schedule.handler is trading_batch.run_trading_sync_batch
+
+
+@pytest.mark.asyncio
+async def test_trading_sync_skips_when_ib_gateway_offline(monkeypatch: pytest.MonkeyPatch, session: Session) -> None:
+    """The batch logs and exits without touching IB when the TCP probe fails."""
+
+    monkeypatch.setattr(trading_batch, "is_ib_gateway_available", lambda *_args, **_kwargs: False)
+
+    result = await trading_batch.run_trading_sync_batch_async(session_factory=lambda: session_context(session))
+
+    assert result["status"] == "skipped"
+    assert session.exec(select(TradingAccountSummary)).all() == []
+
+
+@pytest.mark.asyncio
+async def test_trading_sync_upserts_positions_on_success(monkeypatch: pytest.MonkeyPatch, session: Session) -> None:
+    """A reachable IB Gateway sync refreshes summary/config freshness and replaces positions."""
+
+    fake_ib = FakeIB()
+    original_ib = trading_service.ib
+    trading_service.ib = fake_ib  # type: ignore[assignment]
+    monkeypatch.setattr(trading_batch, "is_ib_gateway_available", lambda *_args, **_kwargs: True)
+    session.add(
+        TradingAccountConfig(
+            name="IBKR Paper",
+            account_type="IBKR",
+            host="127.0.0.1",
+            port=4002,
+            client_id=7,
+            household_id=TEST_HOUSEHOLD_ID,
+        )
+    )
+    session.commit()
+
+    try:
+        first = await trading_batch.run_trading_sync_batch_async(session_factory=lambda: session_context(session))
+        fake_ib.positions_payload = [Position(Contract("AAPL", "STK", 265598), "5", "151.00")]
+        second = await trading_batch.run_trading_sync_batch_async(session_factory=lambda: session_context(session))
+    finally:
+        trading_service.ib = original_ib
+
+    config = session.exec(select(TradingAccountConfig)).one()
+    positions = session.exec(select(TradingPosition)).all()
+    summaries = session.exec(select(TradingAccountSummary)).all()
+
+    assert first["status"] == "success"
+    assert second["status"] == "success"
+    assert config.account_id == "U1234567"
+    assert config.last_synced_at is not None
+    assert len(summaries) == 2
+    assert summaries[-1].net_liquidation == Decimal("1000.12")
+    assert len(positions) == 1
+    assert positions[0].symbol == "AAPL"
+    assert positions[0].amount == Decimal("5")
+    assert positions[0].avg_cost == Decimal("151.00")

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -18,7 +18,6 @@ const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
   '/api/backtest',
   '/api/analyze',
   '/api/ndx/sync',
-  '/api/trading/sync',
   '/api/pension',
 ];
 

--- a/apps/frontend/src/app/trading/actions.ts
+++ b/apps/frontend/src/app/trading/actions.ts
@@ -16,6 +16,7 @@ export interface TradingAccountConfig {
   linked_account_id: string | null;
   account_id: string | null;
   last_synced: string | null;
+  last_synced_at: string | null;
 }
 
 export interface TradingAccountConfigInput {
@@ -69,6 +70,7 @@ const CONFIG_SELECT = [
   'linked_account_id',
   'account_id',
   'last_synced',
+  'last_synced_at',
 ].join(', ');
 
 // ── Internal helpers ──────────────────────────────────────────────────────────

--- a/apps/frontend/src/components/trading/TradingAccountDashboard.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountDashboard.tsx
@@ -18,9 +18,7 @@ export default function TradingAccountDashboard() {
     const [stats, setStats] = useState<TradingAccountSummary | { net_liquidation: number; total_cash: number; currency: string; timestamp: string }>({ net_liquidation: 0, total_cash: 0, currency: "USD", timestamp: "" });
     const [positions, setPositions] = useState<TradingPosition[]>([]);
     const [loading, setLoading] = useState(true);
-    const [syncing, setSyncing] = useState(false);
     const [error, setError] = useState("");
-    const [message, setMessage] = useState("");
 
     useEffect(() => {
         init();
@@ -55,56 +53,16 @@ export default function TradingAccountDashboard() {
             setPositions(positionsData);
         } catch (err) {
             console.error("Error fetching trading data:", err);
-            setError("Connection error. Is the backend running?");
+            setError("Unable to load trading data from Supabase.");
         } finally {
             setLoading(false);
         }
     };
 
-    const handleSync = async () => {
-        if (!activeAccountId) return;
-        setSyncing(true);
-        setError("");
-        setMessage("");
-
-        const config = configs.find(c => c.id === activeAccountId);
-        const brokerName = config?.account_type || "Broker";
-
-        try {
-            const res = await fetch(`/api/trading/sync?account_id=${activeAccountId}`, { method: "POST" });
-            if (res.ok) {
-                const data = await res.json();
-                setMessage(`Sync successful! Updated ${data.positions_count} positions.`);
-                await fetchData(activeAccountId);
-            } else {
-                const errData = await res.json().catch(() => ({ detail: "Sync failed" }));
-                setError(errData.detail || `Sync failed. Check ${brokerName} connection.`);
-            }
-        } catch (err) {
-            setError("Sync error. Is the backend running?");
-        } finally {
-            setSyncing(false);
-        }
-    };
-
-    const handlePushToDividends = async () => {
-        setSyncing(true);
-        setError("");
-        setMessage("");
-        try {
-            const res = await fetch("/api/trading/sync-to-dividends", { method: "POST" });
-            if (res.ok) {
-                const data = await res.json();
-                setMessage(data.message || "Successfully pushed stock positions to Dividends dashboard.");
-            } else {
-                const errData = await res.json().catch(() => ({ detail: "Sync failed" }));
-                setError(errData.detail || "Failed to push positions to Dividends dashboard.");
-            }
-        } catch (err) {
-            setError("Connection error. Is the backend running?");
-        } finally {
-            setSyncing(false);
-        }
+    const reloadAccountData = async () => {
+        await fetchData(activeAccountId);
+        const latestConfigs = await getTradingConfigs();
+        setConfigs(latestConfigs);
     };
 
     const handleAccountChange = (id: number) => {
@@ -113,7 +71,7 @@ export default function TradingAccountDashboard() {
         fetchData(id);
     };
 
-    if (loading && !syncing) {
+    if (loading) {
         return <div className="text-center py-12 text-slate-500 animate-pulse">Loading trading data...</div>;
     }
 
@@ -126,8 +84,9 @@ export default function TradingAccountDashboard() {
         );
     }
 
-    const lastSynced = stats?.timestamp ? new Date(stats.timestamp).toLocaleString() : "Never";
     const activeConfig = configs.find(c => c.id === activeAccountId);
+    const freshnessTimestamp = activeConfig?.last_synced_at || activeConfig?.last_synced || stats?.timestamp;
+    const lastSynced = freshnessTimestamp ? new Date(freshnessTimestamp).toLocaleString() : "Never";
 
     return (
         <div className="space-y-6">
@@ -155,41 +114,17 @@ export default function TradingAccountDashboard() {
                 </div>
                 <div className="flex flex-wrap gap-4">
                     <button
-                        onClick={() => fetchData(activeAccountId)}
+                        onClick={reloadAccountData}
                         className="p-2 text-slate-400 hover:text-white transition-colors flex items-center gap-2 text-sm"
-                        title="Refresh from Database"
+                        title="Reload latest synced data from Supabase"
                     >
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M23 4v6h-6"></path><path d="M1 20v-6h6"></path><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"></path></svg>
                         Reload
                     </button>
 
-                    <button
-                        onClick={handlePushToDividends}
-                        disabled={syncing || positions.length === 0}
-                        className="bg-emerald-600 hover:bg-emerald-500 disabled:bg-emerald-800 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-2 shadow-lg shadow-emerald-900/20"
-                        title="Update Dividend Dashboard with all synced STK positions"
-                    >
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M16 4h4v4"></path><path d="M20 4L12 12"></path><path d="M8 20l8-8"></path><path d="M4 16v4h4"></path></svg>
-                        Push Stocks to Dividends
-                    </button>
-
-                    <button
-                        onClick={handleSync}
-                        disabled={syncing}
-                        className="bg-blue-600 hover:bg-blue-500 disabled:bg-blue-800 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors flex items-center gap-2 shadow-lg shadow-blue-900/20"
-                    >
-                        {syncing ? (
-                            <>
-                                <svg className="animate-spin h-4 w-4 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle><path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path></svg>
-                                Syncing with {activeConfig?.account_type}...
-                            </>
-                        ) : (
-                            <>
-                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 2v6h-6"></path><path d="M3 12a9 9 0 0 1 15-6.7L21 8"></path><path d="M3 22v-6h6"></path><path d="M21 12a9 9 0 0 1-15 6.7L3 16"></path></svg>
-                                Sync with {activeConfig?.account_type}
-                            </>
-                        )}
-                    </button>
+                    <div className="rounded-lg border border-slate-800 bg-slate-900 px-4 py-2 text-sm text-slate-400">
+                        Sync runs in the background every 15 minutes when IB Gateway is online.
+                    </div>
                 </div>
             </div>
 
@@ -203,12 +138,6 @@ export default function TradingAccountDashboard() {
                 </div>
             )}
 
-            {message && (
-                <div className="bg-emerald-900/20 border border-emerald-900/50 text-emerald-400 p-4 rounded-lg mb-6 flex items-start gap-3">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
-                    <p className="text-sm">{message}</p>
-                </div>
-            )}
 
             <TradingStatsRow stats={stats} />
             <TradingPositionsTable positions={positions} />

--- a/supabase/migrations/20260503163035_add_trading_last_synced_at.sql
+++ b/supabase/migrations/20260503163035_add_trading_last_synced_at.sql
@@ -1,0 +1,9 @@
+-- TJ-020 / #216: track worker refresh freshness per trading account.
+
+alter table public.trading_account_config
+  add column if not exists last_synced_at timestamptz;
+
+update public.trading_account_config
+set last_synced_at = last_synced
+where last_synced_at is null
+  and last_synced is not null;


### PR DESCRIPTION
## Summary
- Closes #216 under TJ-020 umbrella #207; follows ADR `.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md` and related #219 direction.
- Registers a `trading_sync` worker batch every 15 minutes with an IB Gateway TCP health check (`IB_GATEWAY_HOST`/`IB_GATEWAY_PORT`, default `127.0.0.1:4002`) that logs and skips when offline.
- Reuses existing trading tables for account summaries/positions, tracks per-account `last_synced_at`, and best-effort syncs IB executions since the prior refresh.
- Deprecates but keeps `POST /api/trading/sync`.
- Removes frontend `/api/trading/sync*` callers and walkthrough allow-list entry; UI now shows background sync freshness from Supabase.

## Validation
- `cd apps/backend && uv run pytest tests/test_trading_sync_batch.py -q`
- `cd apps/backend && uv run ruff check app/services/trading_batch.py app/services/trading_service.py app/schema/trading_models.py app/schema/models.py app/api/trading.py app/worker/registry.py tests/test_trading_sync_batch.py`
- `cd apps/frontend && npm run lint -- --file src/components/trading/TradingAccountDashboard.tsx --file src/app/trading/actions.ts` (passes with existing exhaustive-deps warning)
- `rg "/api/trading/sync" apps/frontend` returns no matches

## Notes
- `supabase migration list --local` could not run because the local Supabase Postgres port `54322` was not running.
