### PR TITLE
feat(TJ-020): migrate backtest to compute_jobs queue (#211)

### DIFF
--- a/apps/backend/app/api/backtest.py
+++ b/apps/backend/app/api/backtest.py
@@ -6,13 +6,15 @@ from app.services.backtest_service import BacktestService
 router = APIRouter()
 service = BacktestService()
 
+
 class BacktestRequest(BaseModel):
     year: int
     initial_capital: float = 100000.0
     step_days: int = 1
-    underlying: str = "NDX" # Strategy Underlying (e.g. NDX)
-    leap_underlying: str = "NDX" # LEAP Underlying (e.g. QQQ)
+    underlying: str = "NDX"  # Strategy Underlying (e.g. NDX)
+    leap_underlying: str = "NDX"  # LEAP Underlying (e.g. QQQ)
     strategy: str = "IRON_CONDOR"
+
 
 class BacktestResponse(BaseModel):
     year: int
@@ -23,29 +25,33 @@ class BacktestResponse(BaseModel):
     trades: List[Any]
     metrics: Optional[Dict[str, Any]] = None
 
-@router.post("/run", response_model=BacktestResponse)
+
+@router.post("/run", response_model=BacktestResponse, deprecated=True)
 async def run_backtest(request: BacktestRequest):
-    """Execute a strategy backtest for the given year and parameters."""
+    """Deprecated: use the TJ-020 compute_jobs backtest worker instead."""
     try:
         results = await service.run_backtest(
-            request.year, 
-            request.initial_capital, 
+            request.year,
+            request.initial_capital,
             request.step_days,
             request.underlying,
             request.leap_underlying,
-            request.strategy
+            request.strategy,
         )
         return results
     except Exception as e:
         import traceback
+
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get("/years")
+
+@router.get("/years", deprecated=True)
 def get_available_years():
-    """Return the list of years available for backtesting."""
+    """Deprecated: the frontend derives available years without FastAPI."""
     # 2018 to current year
     # 2018 to current year
     import datetime
+
     current_year = datetime.date.today().year
     return list(range(2018, current_year + 1))

--- a/apps/backend/app/worker/backtest_handler.py
+++ b/apps/backend/app/worker/backtest_handler.py
@@ -1,0 +1,233 @@
+"""Compute-job handler for on-demand backtest runs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+import json
+import logging
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.backtest_service import BacktestService
+
+logger = logging.getLogger(__name__)
+
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+SessionFactory = Callable[[], Session]
+MONETARY_KEYS = frozenset(
+    {
+        "avg_price",
+        "cash",
+        "commission",
+        "equity",
+        "final_equity",
+        "initial_capital",
+        "price",
+        "realized_pnl",
+        "strike",
+        "total_realized_pnl",
+        "total_unrealized_pnl",
+        "unrealized_pnl",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BacktestJobRequest:
+    """Validated payload for a queued backtest job."""
+
+    household_id: UUID
+    compute_job_id: UUID
+    config: dict[str, Any]
+    year: int
+    initial_capital: Decimal
+    step_days: int
+    underlying: str
+    leap_underlying: str
+    strategy: str
+
+
+def run_backtest_job(payload: JobPayload) -> JobResult:
+    """Run a queued backtest, persist its result row, and return the run id."""
+
+    try:
+        request = _parse_payload(payload)
+        started_at = datetime.now(timezone.utc)
+        result = _normalize_backtest_result(_run_service(request))
+        finished_at = datetime.now(timezone.utc)
+        run_id = _insert_backtest_run(request, result, started_at, finished_at)
+        return {"backtest_run_id": run_id}
+    except Exception:
+        logger.exception("Backtest compute job failed")
+        raise
+
+
+def _default_session_factory() -> Session:
+    """Return a database session for handler writes."""
+
+    return Session(engine)
+
+
+def _run_service(request: BacktestJobRequest) -> dict[str, Any]:
+    """Execute the existing async backtest service from the sync worker."""
+
+    service = BacktestService()
+    return asyncio.run(
+        service.run_backtest(
+            request.year,
+            float(request.initial_capital),
+            request.step_days,
+            request.underlying,
+            request.leap_underlying,
+            request.strategy,
+        )
+    )
+
+
+def _insert_backtest_run(
+    request: BacktestJobRequest,
+    result: dict[str, Any],
+    started_at: datetime,
+    finished_at: datetime,
+    session_factory: SessionFactory | None = None,
+) -> str:
+    """Insert the queue result row and return its UUID."""
+
+    factory = session_factory or _default_session_factory
+    with factory() as session:
+        row = session.execute(
+            text("""
+                insert into public.backtest_runs (household_id, compute_job_id, config, result, started_at, finished_at)
+                values (:household_id, :compute_job_id, cast(:config as jsonb), cast(:result as jsonb), :started_at, :finished_at)
+                returning id
+                """),
+            {
+                "household_id": str(request.household_id),
+                "compute_job_id": str(request.compute_job_id),
+                "config": json.dumps(_normalize_for_json(request.config), default=str),
+                "result": json.dumps(result, default=str),
+                "started_at": started_at,
+                "finished_at": finished_at,
+            },
+        ).scalar_one()
+        session.commit()
+        return str(row)
+
+
+def _parse_payload(payload: JobPayload) -> BacktestJobRequest:
+    """Validate and coerce queue payload into backtest service arguments."""
+
+    household_id = _parse_uuid(payload.get("household_id"), "household_id")
+    compute_job_id = _parse_uuid(payload.get("compute_job_id"), "compute_job_id")
+    config_value = payload.get("config")
+    if not isinstance(config_value, dict):
+        raise ValueError("Backtest job payload must include a config object.")
+    config = cast(dict[str, Any], config_value)
+    year = _parse_int(config.get("year", date.today().year), "year")
+    if year < 2018 or year > date.today().year:
+        raise ValueError("Backtest year must be between 2018 and the current year.")
+    step_days = _parse_int(config.get("step_days", 1), "step_days")
+    if step_days < 1 or step_days > 31:
+        raise ValueError("Backtest step_days must be between 1 and 31.")
+    initial_capital = _parse_decimal(config.get("initial_capital", "100000"), "initial_capital")
+    if initial_capital <= 0:
+        raise ValueError("Backtest initial_capital must be positive.")
+    underlying = _parse_symbol(config.get("underlying", "NDX"), "underlying")
+    leap_underlying = _parse_symbol(config.get("leap_underlying", underlying), "leap_underlying")
+    strategy = _parse_symbol(config.get("strategy", "IRON_CONDOR"), "strategy")
+    normalized_config = {
+        **config,
+        "year": year,
+        "initial_capital": str(initial_capital),
+        "step_days": step_days,
+        "underlying": underlying,
+        "leap_underlying": leap_underlying,
+        "strategy": strategy,
+    }
+    return BacktestJobRequest(
+        household_id,
+        compute_job_id,
+        normalized_config,
+        year,
+        initial_capital,
+        step_days,
+        underlying,
+        leap_underlying,
+        strategy,
+    )
+
+
+def _normalize_backtest_result(result: dict[str, Any]) -> dict[str, Any]:
+    """Make the service result JSON-safe with monetary values as strings."""
+
+    normalized = cast(dict[str, Any], _normalize_for_json(result))
+    trades = normalized.get("trades")
+    if isinstance(trades, list):
+        normalized["equity_curve"] = [
+            {"date": trade["date"], "equity": trade["equity"]}
+            for trade in trades
+            if isinstance(trade, dict) and "date" in trade and "equity" in trade
+        ]
+    else:
+        normalized["trades"] = []
+        normalized["equity_curve"] = []
+    return normalized
+
+
+def _normalize_for_json(value: Any, key: str | None = None) -> Any:
+    """Recursively convert dates and Decimals into stable JSON values."""
+
+    if isinstance(value, dict):
+        return {str(item_key): _normalize_for_json(item_value, str(item_key)) for item_key, item_value in value.items()}
+    if isinstance(value, list | tuple):
+        return [_normalize_for_json(item, key) for item in value]
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return str(value)
+    if key in MONETARY_KEYS and isinstance(value, int | float | str):
+        try:
+            return str(Decimal(str(value)))
+        except InvalidOperation:
+            return value
+    return value
+
+
+def _parse_uuid(value: object, field_name: str) -> UUID:
+    if not isinstance(value, str):
+        raise ValueError(f"Backtest job payload must include {field_name}.")
+    try:
+        return UUID(value)
+    except ValueError as exc:
+        raise ValueError(f"Backtest job payload has invalid {field_name}.") from exc
+
+
+def _parse_int(value: object, field_name: str) -> int:
+    try:
+        return int(str(value))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Backtest config has invalid {field_name}.") from exc
+
+
+def _parse_decimal(value: object, field_name: str) -> Decimal:
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"Backtest config has invalid {field_name}.") from exc
+
+
+def _parse_symbol(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"Backtest config has invalid {field_name}.")
+    return value.strip().upper()

--- a/apps/backend/app/worker/job_queue.py
+++ b/apps/backend/app/worker/job_queue.py
@@ -32,6 +32,7 @@ class ComputeJob:
     """Pending compute job row claimed by the worker."""
 
     id: UUID
+    household_id: UUID
     job_type: str
     payload: JobPayload
     attempts: int
@@ -92,7 +93,7 @@ class JobQueuePoller:
                     limit :batch_size
                     for update skip locked
                  )
-                returning id, job_type, payload, attempts
+                returning id, household_id, job_type, payload, attempts
                 """
             ),
             {"max_attempts": MAX_ATTEMPTS, "batch_size": self.batch_size},
@@ -101,6 +102,7 @@ class JobQueuePoller:
         return [
             ComputeJob(
                 id=cast(UUID, row["id"]),
+                household_id=cast(UUID, row["household_id"]),
                 job_type=cast(str, row["job_type"]),
                 payload=cast(JobPayload, row["payload"] or {}),
                 attempts=cast(int, row["attempts"]),
@@ -122,7 +124,7 @@ class JobQueuePoller:
             return
 
         try:
-            result = handler(job.payload)
+            result = handler(_with_job_metadata(job))
         except Exception as exc:  # noqa: BLE001 - queue must capture handler failures
             logger.exception("Compute job %s failed", job.id)
             self._record_failure(session, job, exc)
@@ -176,6 +178,16 @@ class JobQueuePoller:
                 "attempts": next_attempts,
             },
         )
+
+
+def _with_job_metadata(job: ComputeJob) -> JobPayload:
+    """Add queue metadata required by handlers without mutating stored payload."""
+
+    return {
+        **job.payload,
+        "household_id": str(job.household_id),
+        "compute_job_id": str(job.id),
+    }
 
 
 def _json_safe(value: dict[str, Any]) -> str:

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Literal
 
 from app.services.trading_batch import run_trading_sync_batch
+from app.worker.backtest_handler import run_backtest_job
 from app.worker.bonds_scanner import refresh_bond_scanner_results
 from app.worker.pension_pdf_parse import handle_pension_pdf_parse
 
@@ -25,7 +26,10 @@ class JobSchedule:
     seconds: int | None = None
 
 
-JOB_HANDLERS: dict[str, JobHandler] = {"pension_pdf_parse": handle_pension_pdf_parse}
+JOB_HANDLERS: dict[str, JobHandler] = {
+    "pension_pdf_parse": handle_pension_pdf_parse,
+    "backtest": run_backtest_job,
+}
 JOB_SCHEDULES: list[JobSchedule] = [
     JobSchedule(
         job_id="trading_sync",

--- a/apps/backend/tests/test_backtest_job_handler.py
+++ b/apps/backend/tests/test_backtest_job_handler.py
@@ -1,0 +1,117 @@
+"""Unit tests for the queued backtest worker handler."""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Any
+
+import pytest
+
+from app.worker import backtest_handler
+
+
+class FakeScalarResult:
+    """Minimal scalar result returned by the fake DB session."""
+
+    def scalar_one(self) -> str:
+        """Return the inserted run id."""
+
+        return "20000000-0000-0000-0000-000000000001"
+
+
+class FakeSession:
+    """Capture SQL parameters for backtest_runs insert assertions."""
+
+    def __init__(self) -> None:
+        self.executions: list[dict[str, Any]] = []
+        self.committed = False
+
+    def __enter__(self) -> "FakeSession":
+        return self
+
+    def __exit__(
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
+    ) -> bool:
+        return False
+
+    def execute(self, statement: object, params: dict[str, Any]) -> FakeScalarResult:
+        """Record the insert call and mimic SQLAlchemy's scalar result."""
+
+        self.executions.append({"sql": str(statement), "params": params})
+        return FakeScalarResult()
+
+    def commit(self) -> None:
+        """Record that the handler committed the result row."""
+
+        self.committed = True
+
+
+def test_run_backtest_job_writes_result_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The handler stores config/result JSON and returns the backtest run id."""
+
+    fake_session = FakeSession()
+
+    def fake_run_service(request: backtest_handler.BacktestJobRequest) -> dict[str, Any]:
+        return {
+            "year": request.year,
+            "initial_capital": 100000.0,
+            "final_equity": 101250.5,
+            "realized_pnl": 1200.25,
+            "unrealized_pnl": 50.25,
+            "trades": [
+                {
+                    "date": "2026-01-02T00:00:00",
+                    "action": "BUY",
+                    "symbol": "NDX",
+                    "quantity": 1,
+                    "price": 100.12,
+                    "commission": 1.0,
+                    "equity": 99998.88,
+                    "conid": 123,
+                    "realized_pnl": 0.0,
+                }
+            ],
+            "metrics": {"sharpe_ratio": 1.5},
+        }
+
+    monkeypatch.setattr(backtest_handler, "_run_service", fake_run_service)
+    monkeypatch.setattr(backtest_handler, "_default_session_factory", lambda: fake_session)
+    result = backtest_handler.run_backtest_job(
+        {
+            "household_id": "10000000-0000-0000-0000-000000000001",
+            "compute_job_id": "00000000-0000-0000-0000-000000000001",
+            "config": {
+                "year": 2026,
+                "initial_capital": "100000",
+                "step_days": 7,
+                "underlying": "ndx",
+                "leap_underlying": "qqq",
+                "strategy": "iron_condor",
+            },
+        }
+    )
+    assert result == {"backtest_run_id": "20000000-0000-0000-0000-000000000001"}
+    assert fake_session.committed is True
+    params = fake_session.executions[0]["params"]
+    assert params["household_id"] == "10000000-0000-0000-0000-000000000001"
+    assert params["compute_job_id"] == "00000000-0000-0000-0000-000000000001"
+    assert '"initial_capital": "100000"' in params["config"]
+    assert '"final_equity": "101250.5"' in params["result"]
+    assert '"equity_curve": [{"date": "2026-01-02T00:00:00", "equity": "99998.88"}]' in params["result"]
+
+
+def test_run_backtest_job_reraises_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Handler failures propagate so the queue can mark the job failed."""
+
+    def fake_run_service(_request: backtest_handler.BacktestJobRequest) -> dict[str, Any]:
+        raise RuntimeError("service unavailable")
+
+    monkeypatch.setattr(backtest_handler, "_run_service", fake_run_service)
+    with pytest.raises(RuntimeError, match="service unavailable"):
+        backtest_handler.run_backtest_job(
+            {
+                "household_id": "10000000-0000-0000-0000-000000000001",
+                "compute_job_id": "00000000-0000-0000-0000-000000000001",
+                "config": {"year": 2026},
+            }
+        )

--- a/apps/backend/tests/test_worker_job_queue.py
+++ b/apps/backend/tests/test_worker_job_queue.py
@@ -44,7 +44,7 @@ class FakeSession(AbstractContextManager["FakeSession"]):
     def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
         sql = str(statement)
         self.executions.append({"sql": sql, "params": params or {}})
-        if "returning id, job_type, payload, attempts" in sql:
+        if "returning id, household_id, job_type, payload, attempts" in sql:
             return FakeMappings(self.rows)
         return FakeMappings([])
 
@@ -58,7 +58,10 @@ def test_poller_dispatches_handler_and_marks_done() -> None:
     """The poller claims pending jobs, calls the handler, and stores results."""
 
     job_id = UUID("00000000-0000-0000-0000-000000000001")
-    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 0}])
+    household_id = UUID("10000000-0000-0000-0000-000000000001")
+    session = FakeSession(
+        [{"id": job_id, "household_id": household_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 0}]
+    )
     seen_payloads: list[dict[str, object]] = []
 
     def handler(payload: dict[str, object]) -> dict[str, object]:
@@ -68,7 +71,13 @@ def test_poller_dispatches_handler_and_marks_done() -> None:
     poller = JobQueuePoller(handlers={"fake": handler}, session_factory=lambda: session)
 
     assert poller.poll_once() == 1
-    assert seen_payloads == [{"x": 1}]
+    assert seen_payloads == [
+        {
+            "x": 1,
+            "household_id": str(household_id),
+            "compute_job_id": str(job_id),
+        }
+    ]
     assert session.committed is True
     assert any(call["params"].get("result") == '{"ok": true}' for call in session.executions)
     assert any("status = 'done'" in call["sql"] for call in session.executions)
@@ -78,7 +87,10 @@ def test_poller_requeues_failed_job_until_retry_cap() -> None:
     """Handler exceptions increment attempts and keep retryable jobs pending."""
 
     job_id = UUID("00000000-0000-0000-0000-000000000002")
-    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 1}])
+    household_id = UUID("10000000-0000-0000-0000-000000000002")
+    session = FakeSession(
+        [{"id": job_id, "household_id": household_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 1}]
+    )
 
     def handler(_payload: dict[str, object]) -> dict[str, object]:
         raise RuntimeError("boom")
@@ -96,7 +108,10 @@ def test_poller_marks_failed_at_retry_cap() -> None:
     """The third failed attempt permanently marks the job failed."""
 
     job_id = UUID("00000000-0000-0000-0000-000000000003")
-    session = FakeSession([{"id": job_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 2}])
+    household_id = UUID("10000000-0000-0000-0000-000000000003")
+    session = FakeSession(
+        [{"id": job_id, "household_id": household_id, "job_type": "fake", "payload": {"x": 1}, "attempts": 2}]
+    )
 
     def handler(_payload: dict[str, object]) -> dict[str, object]:
         raise RuntimeError("still broken")
@@ -114,7 +129,10 @@ def test_poller_marks_unknown_job_type_failed() -> None:
     """Unknown job types fail permanently so the queue cannot spin forever."""
 
     job_id = UUID("00000000-0000-0000-0000-000000000004")
-    session = FakeSession([{"id": job_id, "job_type": "missing", "payload": {}, "attempts": 0}])
+    household_id = UUID("10000000-0000-0000-0000-000000000004")
+    session = FakeSession(
+        [{"id": job_id, "household_id": household_id, "job_type": "missing", "payload": {}, "attempts": 0}]
+    )
     poller = JobQueuePoller(handlers={}, session_factory=lambda: session)
 
     assert poller.poll_once() == 1

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -13,10 +13,7 @@ const PAGES = [
  * compute route calls FastAPI over `/api/*`; this array goes to `[]` once the
  * TJ-020 Phase B migrations in #208-#217 land.
  */
-const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
-  '/api/backtest',
-  '/api/pension',
-];
+const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [];
 
 /**
  * Returns true if the response URL/error is known-acceptable noise that should

--- a/apps/frontend/src/app/backtest/actions.test.ts
+++ b/apps/frontend/src/app/backtest/actions.test.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ enqueueComputeJob: vi.fn(), getUser: vi.fn() }));
+vi.mock('@/lib/compute-jobs', () => ({ enqueueComputeJob: mocks.enqueueComputeJob }));
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
+
+import { createClient } from '@/lib/supabase/server';
+import { enqueueBacktest, getBacktestRun, listBacktestRuns } from './actions';
+
+const { enqueueComputeJob, getUser } = mocks;
+const currentYear = new Date().getUTCFullYear();
+const config = { year: currentYear, initial_capital: '100000', step_days: 1, underlying: 'NDX', leap_underlying: 'NDX', strategy: 'IRON_CONDOR' };
+function authOk() { getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }); }
+function chain(result: unknown) { return { select: vi.fn().mockReturnThis(), order: vi.fn().mockReturnThis(), limit: vi.fn().mockResolvedValue(result), eq: vi.fn().mockReturnThis(), maybeSingle: vi.fn().mockResolvedValue(result) }; }
+beforeEach(() => { vi.resetAllMocks(); authOk(); });
+
+describe('backtest actions', () => {
+  it('enqueues a backtest compute job with normalized config', async () => { enqueueComputeJob.mockResolvedValue('job-1'); await expect(enqueueBacktest({ ...config, underlying: 'ndx', leap_underlying: 'qqq', strategy: 'iron_condor', step_days: 7 })).resolves.toBe('job-1'); expect(enqueueComputeJob).toHaveBeenCalledWith('backtest', { config: { ...config, step_days: 7, underlying: 'NDX', leap_underlying: 'QQQ', strategy: 'IRON_CONDOR' } }); });
+  it('lists backtest runs through Supabase RLS', async () => { const rows = [{ id: 'run-1', household_id: 'hh-1', compute_job_id: 'job-1', config, result: { final_equity: '101000' }, started_at: '2026-05-03T00:00:00Z', finished_at: '2026-05-03T00:00:01Z', created_at: '2026-05-03T00:00:00Z' }]; const runsChain = chain({ data: rows, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(listBacktestRuns()).resolves.toEqual(rows); expect(runsChain.order).toHaveBeenCalledWith('created_at', { ascending: false }); expect(runsChain.limit).toHaveBeenCalledWith(20); });
+  it('fetches one backtest run by id', async () => { const row = { id: 'run-1', household_id: 'hh-1', compute_job_id: null, config, result: { final_equity: '101000' }, started_at: null, finished_at: null, created_at: '2026-05-03T00:00:00Z' }; const runsChain = chain({ data: row, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(getBacktestRun('run-1')).resolves.toEqual(row); expect(runsChain.eq).toHaveBeenCalledWith('id', 'run-1'); });
+  it('returns empty list when unauthenticated', async () => { getUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn() }); await expect(listBacktestRuns()).resolves.toEqual([]); });
+});

--- a/apps/frontend/src/app/backtest/actions.ts
+++ b/apps/frontend/src/app/backtest/actions.ts
@@ -1,0 +1,43 @@
+'use server';
+
+import { enqueueComputeJob } from '@/lib/compute-jobs';
+import { createClient } from '@/lib/supabase/server';
+
+export interface BacktestConfig { year: number; initial_capital: string; step_days: number; underlying: string; leap_underlying: string; strategy: string; }
+export interface BacktestRun { id: string; household_id: string; compute_job_id: string | null; config: BacktestConfig; result: unknown | null; started_at: string | null; finished_at: string | null; created_at: string; }
+interface BacktestRunRow { id: unknown; household_id: unknown; compute_job_id?: unknown; config: unknown; result?: unknown; started_at?: unknown; finished_at?: unknown; created_at: unknown; }
+
+function normalizeConfig(config: Partial<BacktestConfig>): BacktestConfig {
+  const year = Number(config.year);
+  const currentYear = new Date().getUTCFullYear();
+  if (!Number.isInteger(year) || year < 2018 || year > currentYear) throw new Error('Select a valid backtest year.');
+  const stepDays = Number(config.step_days ?? 1);
+  if (!Number.isInteger(stepDays) || stepDays < 1 || stepDays > 31) throw new Error('Backtest step_days must be between 1 and 31.');
+  const initialCapital = String(config.initial_capital ?? '100000').trim();
+  if (!initialCapital || Number(initialCapital) <= 0) throw new Error('Backtest initial_capital must be positive.');
+  return { year, initial_capital: initialCapital, step_days: stepDays, underlying: normalizeSymbol(config.underlying, 'NDX'), leap_underlying: normalizeSymbol(config.leap_underlying, 'NDX'), strategy: normalizeSymbol(config.strategy, 'IRON_CONDOR') };
+}
+function normalizeSymbol(value: string | undefined, fallback: string): string { const symbol = (value ?? fallback).trim().toUpperCase(); if (!symbol) throw new Error('Backtest symbols must not be empty.'); return symbol; }
+function normalizeRun(row: BacktestRunRow): BacktestRun { return { id: String(row.id), household_id: String(row.household_id), compute_job_id: row.compute_job_id == null ? null : String(row.compute_job_id), config: normalizeConfig((row.config ?? {}) as Partial<BacktestConfig>), result: row.result ?? null, started_at: row.started_at == null ? null : String(row.started_at), finished_at: row.finished_at == null ? null : String(row.finished_at), created_at: String(row.created_at) }; }
+
+/** Enqueue an on-demand backtest compute job for the active household. */
+export async function enqueueBacktest(config: BacktestConfig): Promise<string> { return enqueueComputeJob('backtest', { config: normalizeConfig(config) }); }
+/** List recent backtest runs visible through household RLS. */
+export async function listBacktestRuns(limit = 20): Promise<BacktestRun[]> {
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) return [];
+  const { data, error } = await supabase.from('backtest_runs').select('id, household_id, compute_job_id, config, result, started_at, finished_at, created_at').order('created_at', { ascending: false }).limit(limit);
+  if (error) { console.error('[listBacktestRuns] query error:', error.message); return []; }
+  return ((data ?? []) as BacktestRunRow[]).map(normalizeRun);
+}
+/** Fetch one backtest result row visible through household RLS. */
+export async function getBacktestRun(id: string): Promise<BacktestRun | null> {
+  if (!id.trim()) return null;
+  const supabase = await createClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+  if (authError || !user) return null;
+  const { data, error } = await supabase.from('backtest_runs').select('id, household_id, compute_job_id, config, result, started_at, finished_at, created_at').eq('id', id).maybeSingle();
+  if (error) throw new Error(error.message);
+  return data ? normalizeRun(data as BacktestRunRow) : null;
+}

--- a/apps/frontend/src/app/backtest/page.tsx
+++ b/apps/frontend/src/app/backtest/page.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { apiFetch } from '@/lib/api-client';
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { BacktestChart } from "@/components/Backtest/BacktestChart";
+import { subscribeToComputeJob, type ComputeJob } from "@/lib/compute-job-subscriptions";
+import { enqueueBacktest, getBacktestRun, type BacktestConfig } from "./actions";
 
 interface Trade {
   date: string;
@@ -35,321 +36,219 @@ interface BacktestResponse {
   metrics?: Metrics;
 }
 
+interface ChartPoint {
+  time: string;
+  value: number;
+}
+
+type BacktestViewState =
+  | { status: "idle" }
+  | { status: "running"; jobId: string | null; message: string }
+  | { status: "done"; result: BacktestResponse }
+  | { status: "failed"; error: string };
+
+interface BacktestJobResult {
+  backtest_run_id: string;
+}
+
+function yearsSince2018(): number[] {
+  const currentYear = new Date().getUTCFullYear();
+  return Array.from({ length: currentYear - 2018 + 1 }, (_, index) => 2018 + index);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toStringValue(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function normalizeTrade(value: unknown): Trade | null {
+  if (!isRecord(value)) return null;
+  const date = toStringValue(value.date);
+  if (!date) return null;
+  return {
+    date,
+    action: toStringValue(value.action, "UNKNOWN"),
+    symbol: toStringValue(value.symbol, "UNK"),
+    quantity: toNumber(value.quantity),
+    price: toNumber(value.price),
+    commission: toNumber(value.commission),
+    equity: toNumber(value.equity),
+    conid: Math.trunc(toNumber(value.conid)),
+    realized_pnl: value.realized_pnl == null ? undefined : toNumber(value.realized_pnl),
+  };
+}
+
+function normalizeMetrics(value: unknown): Metrics | undefined {
+  if (!isRecord(value)) return undefined;
+  return {
+    total_return: toNumber(value.total_return),
+    cagr: toNumber(value.cagr),
+    volatility: toNumber(value.volatility),
+    sharpe_ratio: toNumber(value.sharpe_ratio),
+    max_drawdown: toNumber(value.max_drawdown),
+    win_rate: toNumber(value.win_rate),
+  };
+}
+
+function normalizeBacktestResult(value: unknown): BacktestResponse {
+  if (!isRecord(value)) throw new Error("Backtest run did not include a result payload.");
+  const trades = Array.isArray(value.trades)
+    ? value.trades.map(normalizeTrade).filter((trade): trade is Trade => trade !== null)
+    : [];
+  return {
+    year: Math.trunc(toNumber(value.year)),
+    initial_capital: toNumber(value.initial_capital),
+    final_equity: toNumber(value.final_equity),
+    realized_pnl: toNumber(value.realized_pnl),
+    unrealized_pnl: toNumber(value.unrealized_pnl),
+    trades,
+    metrics: normalizeMetrics(value.metrics),
+  };
+}
+
+function isBacktestJobResult(value: unknown): value is BacktestJobResult {
+  return isRecord(value) && typeof value.backtest_run_id === "string" && value.backtest_run_id.length > 0;
+}
+
+function buildChartData(results: BacktestResponse | null, showRealizedOnly: boolean): ChartPoint[] {
+  const chartData = (results?.trades ?? [])
+    .map((trade) => ({
+      time: trade.date.split("T")[0],
+      value: showRealizedOnly ? -(trade.realized_pnl ?? 0) : trade.equity,
+    }))
+    .sort((a, b) => (a.time > b.time ? 1 : -1));
+
+  if (results && chartData.length > 0) {
+    const firstDate = new Date(`${chartData[0].time}T00:00:00Z`);
+    firstDate.setUTCDate(firstDate.getUTCDate() - 1);
+    const initialPoint: ChartPoint = {
+      time: firstDate.toISOString().split("T")[0],
+      value: showRealizedOnly ? 0 : results.initial_capital,
+    };
+    if (initialPoint.time < chartData[0].time) chartData.unshift(initialPoint);
+  }
+
+  const uniqueChartData: ChartPoint[] = [];
+  for (const point of chartData) {
+    const previous = uniqueChartData[uniqueChartData.length - 1];
+    if (previous?.time === point.time) uniqueChartData[uniqueChartData.length - 1] = point;
+    else uniqueChartData.push(point);
+  }
+  return uniqueChartData;
+}
+
 export default function BacktestPage() {
-  const [years, setYears] = useState<number[]>([]);
-  const [selectedYear, setSelectedYear] = useState<number>(2024);
+  const years = useMemo(yearsSince2018, []);
+  const [selectedYear, setSelectedYear] = useState<number>(years[years.length - 1] ?? 2024);
   const [stepDays, setStepDays] = useState<number>(1);
   const [underlying, setUnderlying] = useState<string>("NDX");
   const [leapUnderlying, setLeapUnderlying] = useState<string>("NDX");
   const [strategy, setStrategy] = useState<string>("IRON_CONDOR");
-  const [loading, setLoading] = useState(false);
   const [showRealizedOnly, setShowRealizedOnly] = useState(false);
-  const [results, setResults] = useState<BacktestResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [viewState, setViewState] = useState<BacktestViewState>({ status: "idle" });
+  const unsubscribeRef = useRef<(() => void) | null>(null);
 
-  useEffect(() => {
-    apiFetch("/api/backtest/years")
-      .then((res) => res.json())
-      .then((data) => {
-        setYears(data);
-        if (data.length > 0 && !data.includes(selectedYear)) {
-          setSelectedYear(data[data.length - 1]);
-        }
-      })
-      .catch((err) => {
-        console.error("Failed to fetch years", err);
-        // Fallback to default year if API fails
-        setYears([selectedYear]);
-      });
+  useEffect(() => () => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
   }, []);
 
-  const runBacktest = async () => {
-    setLoading(true);
-    setError(null);
-    setResults(null);
+  const loading = viewState.status === "running";
+  const results = viewState.status === "done" ? viewState.result : null;
+  const error = viewState.status === "failed" ? viewState.error : null;
+  const uniqueChartData = useMemo(() => buildChartData(results, showRealizedOnly), [results, showRealizedOnly]);
+
+  const cleanupSubscription = () => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+  };
+
+  const handleCompletedJob = async (job: ComputeJob) => {
+    cleanupSubscription();
+    if (!isBacktestJobResult(job.result)) {
+      setViewState({ status: "failed", error: "Backtest job finished without a result row." });
+      return;
+    }
     try {
-      const res = await apiFetch("/api/backtest/run", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ 
-            year: selectedYear, 
-            initial_capital: 100000,
-            step_days: stepDays,
-            underlying: underlying,
-            leap_underlying: leapUnderlying,
-            strategy: strategy
-        }),
-      });
-      
-      if (!res.ok) {
-        throw new Error("Backtest failed");
-      }
-      
-      const data = await res.json();
-      setResults(data);
+      const run = await getBacktestRun(job.result.backtest_run_id);
+      if (!run?.result) throw new Error("Backtest result row was not found.");
+      setViewState({ status: "done", result: normalizeBacktestResult(run.result) });
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred');
-    } finally {
-      setLoading(false);
+      setViewState({ status: "failed", error: err instanceof Error ? err.message : "Failed to load backtest result." });
     }
   };
 
-  // Prepare Chart Data
-  const chartData = results?.trades
-    .map((t) => ({
-      time: t.date.split("T")[0], // YYYY-MM-DD
-      value: showRealizedOnly ? -(t.realized_pnl || 0) : t.equity,
-    }))
-    .sort((a, b) => (a.time > b.time ? 1 : -1)) || [];
-  
-  // Add initial point
-  if (results && chartData.length > 0) {
-      const firstDate = new Date(chartData[0].time);
-      firstDate.setDate(firstDate.getDate() - 1);
-      const initialPoint = {
-          time: firstDate.toISOString().split("T")[0],
-          value: showRealizedOnly ? 0 : results.initial_capital
+  const runBacktest = async () => {
+    cleanupSubscription();
+    setViewState({ status: "running", jobId: null, message: "Enqueuing backtest…" });
+    try {
+      const config: BacktestConfig = {
+        year: selectedYear,
+        initial_capital: "100000",
+        step_days: stepDays,
+        underlying,
+        leap_underlying: leapUnderlying,
+        strategy,
       };
-      // Only add if not already present (or earlier)
-      if (initialPoint.time < chartData[0].time) {
-          chartData.unshift(initialPoint);
-      }
-  }
-
-  // Deduplicate by time (keep last value for the day)
-  const uniqueChartData = [];
-  if (chartData.length > 0) {
-      let current = chartData[0];
-      for (let i = 1; i < chartData.length; i++) {
-          if (chartData[i].time === current.time) {
-              current = chartData[i]; // Update to latest value for this day
-          } else {
-              uniqueChartData.push(current);
-              current = chartData[i];
-          }
-      }
-      uniqueChartData.push(current);
-  }
+      const jobId = await enqueueBacktest(config);
+      setViewState({ status: "running", jobId, message: "Running…" });
+      unsubscribeRef.current = subscribeToComputeJob(jobId, (job) => {
+        if (job.status === "done") void handleCompletedJob(job);
+        if (job.status === "failed") {
+          cleanupSubscription();
+          setViewState({ status: "failed", error: job.error ?? "Backtest failed." });
+        }
+      });
+    } catch (err) {
+      cleanupSubscription();
+      setViewState({ status: "failed", error: err instanceof Error ? err.message : "An error occurred" });
+    }
+  };
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
       <h1 className="text-2xl font-bold mb-6">Strategy Backtest</h1>
 
-      {/* Controls */}
       <div className="flex items-center gap-4 mb-8 bg-slate-900 p-4 rounded-lg border border-slate-800">
         <div className="flex flex-col gap-1">
           <label className="text-xs text-slate-400">Select Year</label>
-          <select
-            value={selectedYear}
-            onChange={(e) => setSelectedYear(Number(e.target.value))}
-            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            disabled={years.length === 0}
-          >
-            {years.length === 0 && (
-              <option value={selectedYear}>Loading years...</option>
-            )}
-            {years.map((y) => (
-              <option key={y} value={y}>
-                {y}
-              </option>
-            ))}
+          <select value={selectedYear} onChange={(e) => setSelectedYear(Number(e.target.value))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            {years.map((year) => <option key={year} value={year}>{year}</option>)}
           </select>
         </div>
-
         <div className="flex flex-col gap-1">
           <label className="text-xs text-slate-400">Step (Days)</label>
-          <select
-            value={stepDays}
-            onChange={(e) => setStepDays(Number(e.target.value))}
-            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value={1}>1 Day (Daily PnL)</option>
-            <option value={7}>7 Days (Weekly)</option>
-            <option value={14}>14 Days (Bi-Weekly)</option>
+          <select value={stepDays} onChange={(e) => setStepDays(Number(e.target.value))} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value={1}>1 Day (Daily PnL)</option><option value={7}>7 Days (Weekly)</option><option value={14}>14 Days (Bi-Weekly)</option>
           </select>
         </div>
-
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-slate-400">Strategy Underlying</label>
-          <select
-            value={underlying}
-            onChange={(e) => setUnderlying(e.target.value)}
-            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="NDX">NDX</option>
-            <option value="SPX">SPX</option>
-            <option value="QQQ">QQQ</option>
-            <option value="SPY">SPY</option>
-          </select>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-slate-400">LEAP Underlying</label>
-          <select
-            value={leapUnderlying}
-            onChange={(e) => setLeapUnderlying(e.target.value)}
-            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="NDX">NDX</option>
-            <option value="SPX">SPX</option>
-            <option value="QQQ">QQQ</option>
-            <option value="SPY">SPY</option>
-          </select>
-        </div>
-
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-slate-400">Strategy</label>
-          <select
-            value={strategy}
-            onChange={(e) => setStrategy(e.target.value)}
-            className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-          >
-            <option value="IRON_CONDOR">Iron Condor</option>
-          </select>
-        </div>
-
-        <button
-          onClick={runBacktest}
-          disabled={loading}
-          className={`mt-auto px-6 py-2 rounded font-medium transition-colors ${
-            loading
-              ? "bg-slate-700 text-slate-400 cursor-not-allowed"
-              : "bg-blue-600 hover:bg-blue-500 text-white"
-          }`}
-        >
-          {loading ? "Running Simulation..." : "Run Backtest"}
-        </button>
-        
-        {loading && (
-            <div className="text-sm text-slate-400 animate-pulse">
-                Verifying data & simulating...
-            </div>
-        )}
+        <div className="flex flex-col gap-1"><label className="text-xs text-slate-400">Strategy Underlying</label><select value={underlying} onChange={(e) => setUnderlying(e.target.value)} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"><option value="NDX">NDX</option><option value="SPX">SPX</option><option value="QQQ">QQQ</option><option value="SPY">SPY</option></select></div>
+        <div className="flex flex-col gap-1"><label className="text-xs text-slate-400">LEAP Underlying</label><select value={leapUnderlying} onChange={(e) => setLeapUnderlying(e.target.value)} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"><option value="NDX">NDX</option><option value="SPX">SPX</option><option value="QQQ">QQQ</option><option value="SPY">SPY</option></select></div>
+        <div className="flex flex-col gap-1"><label className="text-xs text-slate-400">Strategy</label><select value={strategy} onChange={(e) => setStrategy(e.target.value)} className="bg-slate-800 border border-slate-700 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"><option value="IRON_CONDOR">Iron Condor</option></select></div>
+        <button onClick={runBacktest} disabled={loading} className={`mt-auto px-6 py-2 rounded font-medium transition-colors ${loading ? "bg-slate-700 text-slate-400 cursor-not-allowed" : "bg-blue-600 hover:bg-blue-500 text-white"}`}>{loading ? "Running…" : "Run Backtest"}</button>
+        {loading && <div className="text-sm text-slate-400 animate-pulse">{viewState.message}{viewState.jobId ? ` job ${viewState.jobId.slice(0, 8)}` : ""}</div>}
       </div>
 
-      {error && (
-        <div className="bg-red-900/50 border border-red-800 text-red-200 p-4 rounded mb-6">
-          Error: {error}
-        </div>
-      )}
+      {error && <div className="bg-red-900/50 border border-red-800 text-red-200 p-4 rounded mb-6">Error: {error}</div>}
 
       {results && (
         <div className="space-y-8">
-          {/* Stats Cards */}
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            <div className="bg-slate-900 p-4 rounded border border-slate-800">
-              <div className="text-slate-400 text-sm mb-1">Final Equity</div>
-              <div className={`text-2xl font-bold ${results.final_equity >= results.initial_capital ? 'text-green-400' : 'text-red-400'}`}>
-                ${results.final_equity.toLocaleString(undefined, { minimumFractionDigits: 2 })}
-              </div>
-              <div className="text-xs text-slate-500 mt-1">
-                Return: {((results.final_equity - results.initial_capital) / results.initial_capital * 100).toFixed(2)}%
-              </div>
-            </div>
-            
-            <div className="bg-slate-900 p-4 rounded border border-slate-800">
-              <div className="text-slate-400 text-sm mb-1">Realized PnL</div>
-              <div className={`text-2xl font-bold ${results.realized_pnl >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-                ${results.realized_pnl.toLocaleString(undefined, { minimumFractionDigits: 2 })}
-              </div>
-            </div>
-            
-            <div className="bg-slate-900 p-4 rounded border border-slate-800">
-              <div className="text-slate-400 text-sm mb-1">Unrealized PnL</div>
-              <div className={`text-2xl font-bold ${results.unrealized_pnl >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-                ${results.unrealized_pnl.toLocaleString(undefined, { minimumFractionDigits: 2 })}
-              </div>
-            </div>
+            <div className="bg-slate-900 p-4 rounded border border-slate-800"><div className="text-slate-400 text-sm mb-1">Final Equity</div><div className={`text-2xl font-bold ${results.final_equity >= results.initial_capital ? "text-green-400" : "text-red-400"}`}>${results.final_equity.toLocaleString(undefined, { minimumFractionDigits: 2 })}</div><div className="text-xs text-slate-500 mt-1">Return: {(((results.final_equity - results.initial_capital) / results.initial_capital) * 100).toFixed(2)}%</div></div>
+            <div className="bg-slate-900 p-4 rounded border border-slate-800"><div className="text-slate-400 text-sm mb-1">Realized PnL</div><div className={`text-2xl font-bold ${results.realized_pnl >= 0 ? "text-green-400" : "text-red-400"}`}>${results.realized_pnl.toLocaleString(undefined, { minimumFractionDigits: 2 })}</div></div>
+            <div className="bg-slate-900 p-4 rounded border border-slate-800"><div className="text-slate-400 text-sm mb-1">Unrealized PnL</div><div className={`text-2xl font-bold ${results.unrealized_pnl >= 0 ? "text-green-400" : "text-red-400"}`}>${results.unrealized_pnl.toLocaleString(undefined, { minimumFractionDigits: 2 })}</div></div>
           </div>
-
-          {/* Metrics Grid */}
-          {results.metrics && (
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="bg-slate-900 p-3 rounded border border-slate-800">
-                    <div className="text-slate-500 text-xs uppercase">Sharpe Ratio</div>
-                    <div className="text-lg font-mono">{results.metrics.sharpe_ratio.toFixed(2)}</div>
-                </div>
-                <div className="bg-slate-900 p-3 rounded border border-slate-800">
-                    <div className="text-slate-500 text-xs uppercase">Max Drawdown</div>
-                    <div className="text-lg font-mono text-red-400">{(results.metrics.max_drawdown * 100).toFixed(2)}%</div>
-                </div>
-                <div className="bg-slate-900 p-3 rounded border border-slate-800">
-                    <div className="text-slate-500 text-xs uppercase">Volatility</div>
-                    <div className="text-lg font-mono">{(results.metrics.volatility * 100).toFixed(2)}%</div>
-                </div>
-                <div className="bg-slate-900 p-3 rounded border border-slate-800">
-                    <div className="text-slate-500 text-xs uppercase">Win Rate</div>
-                    <div className="text-lg font-mono">{(results.metrics.win_rate * 100).toFixed(1)}%</div>
-                </div>
-            </div>
-          )}
-
-          {/* Chart */}
-          <div className="bg-slate-900 p-4 rounded border border-slate-800">
-            <div className="flex justify-between items-center mb-4">
-                <h3 className="text-lg font-medium">
-                    {showRealizedOnly ? "Accumulated Harvested Loss" : "Equity Curve"}
-                </h3>
-                <div className="flex items-center bg-slate-800 rounded-lg p-1 border border-slate-700">
-                    <button
-                        onClick={() => setShowRealizedOnly(false)}
-                        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-                            !showRealizedOnly 
-                            ? 'bg-blue-600 text-white shadow-sm' 
-                            : 'text-slate-400 hover:text-slate-200'
-                        }`}
-                    >
-                        Total Equity
-                    </button>
-                    <button
-                        onClick={() => setShowRealizedOnly(true)}
-                        className={`px-3 py-1 text-xs font-medium rounded transition-colors ${
-                            showRealizedOnly 
-                            ? 'bg-blue-600 text-white shadow-sm' 
-                            : 'text-slate-400 hover:text-slate-200'
-                        }`}
-                    >
-                        Harvested Loss
-                    </button>
-                </div>
-            </div>
-            <BacktestChart data={uniqueChartData} />
-          </div>
-
-          {/* Trade Log */}
-          <div className="bg-slate-900 rounded border border-slate-800 overflow-hidden">
-            <h3 className="text-lg font-medium p-4 border-b border-slate-800">Trade Log</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm text-left">
-                <thead className="bg-slate-950 text-slate-400 uppercase text-xs">
-                  <tr>
-                    <th className="px-4 py-3">Date</th>
-                    <th className="px-4 py-3">Action</th>
-                    <th className="px-4 py-3">Symbol</th>
-                    <th className="px-4 py-3 text-right">Qty</th>
-                    <th className="px-4 py-3 text-right">Price</th>
-                    <th className="px-4 py-3 text-right">Comm</th>
-                    <th className="px-4 py-3 text-right">Equity</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-slate-800">
-                  {results.trades.map((t, i) => (
-                    <tr key={i} className="hover:bg-slate-800/50">
-                      <td className="px-4 py-3">{new Date(t.date).toLocaleDateString()}</td>
-                      <td className={`px-4 py-3 font-medium ${t.action === 'BUY' ? 'text-green-400' : 'text-red-400'}`}>
-                        {t.action}
-                      </td>
-                      <td className="px-4 py-3">{t.symbol}</td>
-                      <td className="px-4 py-3 text-right">{t.quantity}</td>
-                      <td className="px-4 py-3 text-right">${t.price.toFixed(2)}</td>
-                      <td className="px-4 py-3 text-right">${t.commission.toFixed(2)}</td>
-                      <td className="px-4 py-3 text-right font-mono">${t.equity.toLocaleString()}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
+          {results.metrics && <div className="grid grid-cols-2 md:grid-cols-4 gap-4"><div className="bg-slate-900 p-3 rounded border border-slate-800"><div className="text-slate-500 text-xs uppercase">Sharpe Ratio</div><div className="text-lg font-mono">{results.metrics.sharpe_ratio.toFixed(2)}</div></div><div className="bg-slate-900 p-3 rounded border border-slate-800"><div className="text-slate-500 text-xs uppercase">Max Drawdown</div><div className="text-lg font-mono text-red-400">{(results.metrics.max_drawdown * 100).toFixed(2)}%</div></div><div className="bg-slate-900 p-3 rounded border border-slate-800"><div className="text-slate-500 text-xs uppercase">Volatility</div><div className="text-lg font-mono">{(results.metrics.volatility * 100).toFixed(2)}%</div></div><div className="bg-slate-900 p-3 rounded border border-slate-800"><div className="text-slate-500 text-xs uppercase">Win Rate</div><div className="text-lg font-mono">{(results.metrics.win_rate * 100).toFixed(1)}%</div></div></div>}
+          <div className="bg-slate-900 p-4 rounded border border-slate-800"><div className="flex justify-between items-center mb-4"><h3 className="text-lg font-medium">{showRealizedOnly ? "Accumulated Harvested Loss" : "Equity Curve"}</h3><div className="flex items-center bg-slate-800 rounded-lg p-1 border border-slate-700"><button onClick={() => setShowRealizedOnly(false)} className={`px-3 py-1 text-xs font-medium rounded transition-colors ${!showRealizedOnly ? "bg-blue-600 text-white shadow-sm" : "text-slate-400 hover:text-slate-200"}`}>Total Equity</button><button onClick={() => setShowRealizedOnly(true)} className={`px-3 py-1 text-xs font-medium rounded transition-colors ${showRealizedOnly ? "bg-blue-600 text-white shadow-sm" : "text-slate-400 hover:text-slate-200"}`}>Harvested Loss</button></div></div><BacktestChart data={uniqueChartData} /></div>
+          <div className="bg-slate-900 rounded border border-slate-800 overflow-hidden"><h3 className="text-lg font-medium p-4 border-b border-slate-800">Trade Log</h3><div className="overflow-x-auto"><table className="w-full text-sm text-left"><thead className="bg-slate-950 text-slate-400 uppercase text-xs"><tr><th className="px-4 py-3">Date</th><th className="px-4 py-3">Action</th><th className="px-4 py-3">Symbol</th><th className="px-4 py-3 text-right">Qty</th><th className="px-4 py-3 text-right">Price</th><th className="px-4 py-3 text-right">Comm</th><th className="px-4 py-3 text-right">Equity</th></tr></thead><tbody className="divide-y divide-slate-800">{results.trades.map((trade, index) => <tr key={`${trade.date}-${trade.conid}-${index}`} className="hover:bg-slate-800/50"><td className="px-4 py-3">{new Date(trade.date).toLocaleDateString()}</td><td className={`px-4 py-3 font-medium ${trade.action === "BUY" ? "text-green-400" : "text-red-400"}`}>{trade.action}</td><td className="px-4 py-3">{trade.symbol}</td><td className="px-4 py-3 text-right">{trade.quantity}</td><td className="px-4 py-3 text-right">${trade.price.toFixed(2)}</td><td className="px-4 py-3 text-right">${trade.commission.toFixed(2)}</td><td className="px-4 py-3 text-right font-mono">${trade.equity.toLocaleString()}</td></tr>)}</tbody></table></div></div>
         </div>
       )}
     </div>

--- a/apps/frontend/src/lib/compute-job-subscriptions.ts
+++ b/apps/frontend/src/lib/compute-job-subscriptions.ts
@@ -1,0 +1,66 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database';
+
+export type ComputeJobStatus = 'pending' | 'running' | 'done' | 'failed';
+
+export interface ComputeJob {
+  id: string;
+  household_id: string;
+  job_type: string;
+  payload: unknown;
+  status: ComputeJobStatus;
+  result: unknown | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+type SupabaseRealtimeLike = Pick<SupabaseClient<Database>, 'channel' | 'removeChannel'>;
+
+function createBrowserSupabase(): SupabaseRealtimeLike {
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+function normalizeComputeJob(row: Record<string, unknown>): ComputeJob {
+  return {
+    id: String(row.id),
+    household_id: String(row.household_id),
+    job_type: String(row.job_type),
+    payload: row.payload,
+    status: row.status as ComputeJobStatus,
+    result: row.result ?? null,
+    error: row.error == null ? null : String(row.error),
+    attempts: Number(row.attempts ?? 0),
+    created_at: String(row.created_at),
+    started_at: row.started_at == null ? null : String(row.started_at),
+    finished_at: row.finished_at == null ? null : String(row.finished_at),
+  };
+}
+
+/** Subscribe to status changes for one compute job from a Client Component. */
+export function subscribeToComputeJob(
+  jobId: string,
+  onUpdate: (job: ComputeJob) => void,
+): () => void {
+  const supabase = createBrowserSupabase();
+  const channel: RealtimeChannel = supabase
+    .channel(`compute-job:${jobId}`)
+    .on(
+      'postgres_changes',
+      { event: '*', schema: 'public', table: 'compute_jobs', filter: `id=eq.${jobId}` },
+      (event: { new: Record<string, unknown> }) => {
+        if (event.new) onUpdate(normalizeComputeJob(event.new));
+      },
+    )
+    .subscribe();
+
+  return () => {
+    void supabase.removeChannel(channel);
+  };
+}

--- a/supabase/migrations/20260503162842_add_backtest_runs.sql
+++ b/supabase/migrations/20260503162842_add_backtest_runs.sql
@@ -1,0 +1,38 @@
+-- Migration: 20260503162842_add_backtest_runs
+-- Purpose: Add TJ-020 result table for queued backtest jobs.
+
+create table if not exists public.backtest_runs (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  compute_job_id uuid references public.compute_jobs(id) on delete set null,
+  config jsonb not null,
+  result jsonb,
+  started_at timestamptz,
+  finished_at timestamptz,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists backtest_runs_household_created_at_idx
+  on public.backtest_runs (household_id, created_at desc);
+
+alter table public.backtest_runs enable row level security;
+
+revoke all on table public.backtest_runs from anon;
+revoke all on table public.backtest_runs from authenticated;
+grant select on table public.backtest_runs to authenticated;
+grant select, insert, update on table public.backtest_runs to service_role;
+
+drop policy if exists backtest_runs_member_select on public.backtest_runs;
+create policy backtest_runs_member_select
+  on public.backtest_runs
+  for select
+  to authenticated
+  using (public.is_household_member(household_id));
+
+do $$
+begin
+  alter publication supabase_realtime add table public.backtest_runs;
+exception
+  when duplicate_object then null;
+  when undefined_object then null;
+end $$;


### PR DESCRIPTION
Closes #211

Umbrella: #207
Foundation: #219
ADR: .squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md

## Summary
- Adds `public.backtest_runs` result table with household RLS, service-role writes, compute job linkage, and Realtime publication.
- Registers the `backtest` compute job handler, runs the existing Python backtester, stores JSON-safe numeric-string monetary results, and returns `{ backtest_run_id }` on the job result.
- Migrates the `/backtest` frontend from FastAPI calls to `enqueueBacktest`, Supabase reads, and `subscribeToComputeJob` running/done/failed states.
- Removes `/api/backtest` from the walkthrough allowed FastAPI 404 list and marks the legacy FastAPI route deprecated.

## Validation
- Supabase MCP `apply_migration`: `20260503162842_add_backtest_runs`
- `uv run ruff check app/worker/backtest_handler.py app/worker/job_queue.py app/worker/registry.py app/api/backtest.py tests/test_worker_job_queue.py tests/test_backtest_job_handler.py`
- `uv run pytest tests/test_worker_job_queue.py tests/test_backtest_job_handler.py`
- `DATABASE_URL=postgresql://user:password@localhost/trading-journal SUPABASE_URL=https://example.supabase.co SUPABASE_JWT_SECRET=test-secret uv run pytest`
- `npm test -- --run src/lib/__tests__/compute-jobs.test.ts src/app/backtest/actions.test.ts`
- `npm test -- --reporter=dot`
- `npx tsc --noEmit --pretty false | grep -E "src/app/backtest|e2e/walkthrough/all-pages" || true`
- `npx eslint src/app/backtest/page.tsx src/app/backtest/actions.ts src/app/backtest/actions.test.ts e2e/walkthrough/all-pages.spec.ts`