### PR TITLE
feat(TJ-020): migrate pension/upload to Storage + worker (#217)

### DIFF
--- a/apps/backend/app/api/pension.py
+++ b/apps/backend/app/api/pension.py
@@ -261,12 +261,8 @@ def _matches_pension_record(item: dict[str, Any], payload: dict[str, Any]) -> bo
     if payload_account_number or item_account_number:
         return bool(payload_account_number) and item_account_number == payload_account_number
 
-    return (
-        _safe_text(details.get("pension_product")) in {"", payload_product_name}
-        and (
-            payload_fund_name in legacy_names
-            or payload_display_name in legacy_names
-        )
+    return _safe_text(details.get("pension_product")) in {"", payload_product_name} and (
+        payload_fund_name in legacy_names or payload_display_name in legacy_names
     )
 
 
@@ -281,26 +277,10 @@ def _apply_pension_metadata(item: dict[str, Any], payload: dict[str, Any]) -> di
 
 def _recalculate_snapshot(snapshot: FinanceSnapshot) -> None:
     items = snapshot.data.get("items", [])
-    total_savings = sum(
-        _safe_float(item.get("value"))
-        for item in items
-        if item.get("category") == "Savings"
-    )
-    total_investments = sum(
-        _safe_float(item.get("value"))
-        for item in items
-        if item.get("category") == "Investments"
-    )
-    assets_category_total = sum(
-        _safe_float(item.get("value"))
-        for item in items
-        if item.get("category") == "Assets"
-    )
-    total_liabilities = sum(
-        _safe_float(item.get("value"))
-        for item in items
-        if item.get("category") == "Liabilities"
-    )
+    total_savings = sum(_safe_float(item.get("value")) for item in items if item.get("category") == "Savings")
+    total_investments = sum(_safe_float(item.get("value")) for item in items if item.get("category") == "Investments")
+    assets_category_total = sum(_safe_float(item.get("value")) for item in items if item.get("category") == "Assets")
+    total_liabilities = sum(_safe_float(item.get("value")) for item in items if item.get("category") == "Liabilities")
 
     calculated_total_assets = total_savings + total_investments + assets_category_total
     snapshot.data["items"] = items
@@ -316,11 +296,7 @@ def _recalculate_snapshot(snapshot: FinanceSnapshot) -> None:
 def upsert_snapshot_pension(snapshot: FinanceSnapshot, payload: dict[str, Any]) -> None:
     items = snapshot.data.get("items", [])
     existing_item = next(
-        (
-            item
-            for item in items
-            if item.get("type") == "Pension" and _matches_pension_record(item, payload)
-        ),
+        (item for item in items if item.get("type") == "Pension" and _matches_pension_record(item, payload)),
         None,
     )
 
@@ -340,8 +316,7 @@ def upsert_plan_pension(plan: Plan, payload: dict[str, Any]) -> None:
         (
             item
             for item in plan_items
-            if (item.get("account_settings") or {}).get("type") == "Pension"
-            and _matches_pension_record(item, payload)
+            if (item.get("account_settings") or {}).get("type") == "Pension" and _matches_pension_record(item, payload)
         ),
         None,
     )
@@ -392,10 +367,7 @@ def _is_spouse_owner(owner: str) -> bool:
 
 
 def _owner_birth_year(settings: dict[str, Any], owner: str) -> int:
-    primary_birth_year = int(
-        settings.get("birthYear")
-        or settings.get("primaryUser", {}).get("birthYear", 1980)
-    )
+    primary_birth_year = int(settings.get("birthYear") or settings.get("primaryUser", {}).get("birthYear", 1980))
     if _is_spouse_owner(owner):
         return int(settings.get("spouse", {}).get("birthYear", primary_birth_year))
     return primary_birth_year
@@ -488,16 +460,12 @@ def build_pension_dashboard_payload(
 
     if plan:
         for milestone in plan.data.get("milestones", []):
-            if milestone.get("type") == "Retirement" or "Retirement" in milestone.get(
-                "name", ""
-            ):
+            if milestone.get("type") == "Retirement" or "Retirement" in milestone.get("name", ""):
                 owner = milestone.get("owner", "You")
                 milestone_date = milestone.get("date")
                 if milestone_date:
                     try:
-                        milestone_year = datetime.strptime(
-                            milestone_date[:10], "%Y-%m-%d"
-                        ).year
+                        milestone_year = datetime.strptime(milestone_date[:10], "%Y-%m-%d").year
                     except ValueError:
                         continue
                     retirement_years[owner] = milestone_year
@@ -548,8 +516,7 @@ def build_pension_dashboard_payload(
                         or account.get("details", {}).get("monthly_contribution")
                     )
                     current_projection_values[series_id] = (
-                        current_projection_values[series_id] * (1 + monthly_rate)
-                        + deposits
+                        current_projection_values[series_id] * (1 + monthly_rate) + deposits
                     )
                 point[series_id] = current_projection_values[series_id]
             projections.append(point)
@@ -571,126 +538,143 @@ def remove_pension_identity(
     return [item for item in items if not _matches_pension_identity(item, pension_id)]
 
 
-@router.post("/upload")
+def apply_pension_analysis_result(
+    db: Session,
+    household_id: UUID,
+    owner: str,
+    result: dict[str, Any],
+    filename: Optional[str],
+) -> dict[str, Any]:
+    """Persist one parsed pension PDF result into household snapshots and plan data."""
+
+    target_date = parse_report_date(result.get("Report Date"))
+    payload = extract_pension_payload(owner, result, filename, target_date)
+    upload_warnings = _validate_pension_payload(payload)
+
+    snapshot = db.exec(
+        select(FinanceSnapshot).where(
+            FinanceSnapshot.household_id == household_id,
+            FinanceSnapshot.date == target_date,
+        )
+    ).first()
+    snapshot_updated = False
+
+    if not snapshot:
+        closest_past = db.exec(
+            select(FinanceSnapshot)
+            .where(
+                FinanceSnapshot.household_id == household_id,
+                FinanceSnapshot.date < target_date,
+            )
+            .order_by(FinanceSnapshot.date.desc())
+            .limit(1)
+        ).first()
+        if closest_past:
+            new_data = copy.deepcopy(closest_past.data) if closest_past.data else copy.deepcopy(EMPTY_SNAPSHOT_DATA)
+            snapshot = FinanceSnapshot(
+                household_id=household_id,
+                date=target_date,
+                data=new_data,
+                net_worth=closest_past.net_worth,
+                total_assets=closest_past.total_assets,
+                total_liabilities=closest_past.total_liabilities,
+            )
+        else:
+            snapshot = FinanceSnapshot(
+                household_id=household_id,
+                date=target_date,
+                data=copy.deepcopy(EMPTY_SNAPSHOT_DATA),
+                net_worth=0.0,
+                total_assets=0.0,
+                total_liabilities=0.0,
+            )
+
+    if snapshot:
+        upsert_snapshot_pension(snapshot, payload)
+        flag_modified(snapshot, "data")
+        db.add(snapshot)
+        snapshot_updated = True
+
+    latest_snapshot = db.exec(
+        select(FinanceSnapshot)
+        .where(FinanceSnapshot.household_id == household_id)
+        .order_by(FinanceSnapshot.date.desc())
+        .limit(1)
+    ).first()
+    latest_snapshot_updated = False
+    if latest_snapshot and latest_snapshot.date != target_date:
+        upsert_snapshot_pension(latest_snapshot, payload)
+        flag_modified(latest_snapshot, "data")
+        db.add(latest_snapshot)
+        latest_snapshot_updated = True
+
+    plan = db.exec(
+        select(Plan).where(Plan.household_id == household_id).order_by(Plan.updated_at.desc()).limit(1)
+    ).first()
+    plan_updated = False
+    if plan:
+        upsert_plan_pension(plan, payload)
+        flag_modified(plan, "data")
+        db.add(plan)
+        plan_updated = True
+
+    if snapshot_updated or plan_updated or latest_snapshot_updated:
+        db.commit()
+        if snapshot_updated:
+            db.refresh(snapshot)
+        if latest_snapshot_updated:
+            db.refresh(latest_snapshot)
+        if plan_updated:
+            db.refresh(plan)
+
+    result["Pension Product"] = payload["details"]["pension_product"]
+    result["Pension Fund Name"] = payload["details"]["pension_fund_name"]
+    result["Pension Display Name"] = payload["details"]["pension_display_name"]
+    result["Account Number"] = payload["details"].get("account_number")
+
+    snapshot_dates = [target_date.isoformat()]
+    if latest_snapshot_updated and latest_snapshot:
+        snapshot_dates.append(latest_snapshot.date.isoformat())
+
+    response: dict[str, Any] = {
+        "status": "success",
+        "result": result,
+        "analysis_result": result,
+        "snapshot_updated": snapshot_updated,
+        "latest_snapshot_updated": latest_snapshot_updated,
+        "plan_updated": plan_updated,
+        "inserted_rows": int(snapshot_updated) + int(latest_snapshot_updated) + int(plan_updated),
+        "snapshot_dates": snapshot_dates,
+    }
+    if upload_warnings:
+        response["warnings"] = upload_warnings
+    return response
+
+
+@router.post("/upload", deprecated=True)
 async def upload_pension_report(
     owner: str = Form(...),
     file: UploadFile = File(...),
     db: Session = Depends(get_session),
     user_id: UUID = Depends(get_current_user_id),
 ):
-    """Upload and analyze a pension report PDF, updating snapshots and plans (household-scoped)."""
+    """Deprecated HTTP upload path retained for local/admin fallback only."""
+
     household_id = get_user_household_id(db, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         root_dir = Path(__file__).parent.parent.parent.parent.parent
         reports_dir = root_dir / "reports" / owner
         reports_dir.mkdir(parents=True, exist_ok=True)
 
-        file_path = reports_dir / file.filename
+        file_path = reports_dir / (file.filename or "pension-report.pdf")
         with open(file_path, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
 
         result = await analyze_report(str(file_path))
-        target_date = parse_report_date(result.get("Report Date"))
-        payload = extract_pension_payload(owner, result, file.filename, target_date)
-
-        upload_warnings = _validate_pension_payload(payload)
-
-        # Query household-scoped snapshot
-        snapshot = db.exec(
-            select(FinanceSnapshot).where(
-                FinanceSnapshot.household_id == household_id,
-                FinanceSnapshot.date == target_date
-            )
-        ).first()
-        snapshot_updated = False
-
-        if not snapshot:
-            closest_past = db.exec(
-                select(FinanceSnapshot)
-                .where(
-                    FinanceSnapshot.household_id == household_id,
-                    FinanceSnapshot.date < target_date
-                )
-                .order_by(FinanceSnapshot.date.desc())
-                .limit(1)
-            ).first()
-
-            if closest_past:
-                new_data = copy.deepcopy(closest_past.data) if closest_past.data else copy.deepcopy(EMPTY_SNAPSHOT_DATA)
-                snapshot = FinanceSnapshot(
-                    household_id=household_id,
-                    date=target_date,
-                    data=new_data,
-                    net_worth=closest_past.net_worth,
-                    total_assets=closest_past.total_assets,
-                    total_liabilities=closest_past.total_liabilities,
-                )
-            else:
-                snapshot = FinanceSnapshot(
-                    household_id=household_id,
-                    date=target_date,
-                    data=copy.deepcopy(EMPTY_SNAPSHOT_DATA),
-                    net_worth=0.0,
-                    total_assets=0.0,
-                    total_liabilities=0.0,
-                )
-
-        if snapshot:
-            upsert_snapshot_pension(snapshot, payload)
-            flag_modified(snapshot, "data")
-            db.add(snapshot)
-            snapshot_updated = True
-
-        # Bug fix: also propagate to the latest snapshot so the pension
-        # appears on the dashboard immediately, even when later snapshots exist.
-        latest_snapshot = db.exec(
-            select(FinanceSnapshot)
-            .where(FinanceSnapshot.household_id == household_id)
-            .order_by(FinanceSnapshot.date.desc())
-            .limit(1)
-        ).first()
-        latest_snapshot_updated = False
-        if latest_snapshot and latest_snapshot.date != target_date:
-            upsert_snapshot_pension(latest_snapshot, payload)
-            flag_modified(latest_snapshot, "data")
-            db.add(latest_snapshot)
-            latest_snapshot_updated = True
-
-        plan = db.exec(select(Plan).limit(1)).first()
-        plan_updated = False
-        if plan:
-            upsert_plan_pension(plan, payload)
-            flag_modified(plan, "data")
-            db.add(plan)
-            plan_updated = True
-
-        if snapshot_updated or plan_updated or latest_snapshot_updated:
-            db.commit()
-            if snapshot_updated:
-                db.refresh(snapshot)
-            if latest_snapshot_updated:
-                db.refresh(latest_snapshot)
-            if plan_updated:
-                db.refresh(plan)
-
-        result["Pension Product"] = payload["details"]["pension_product"]
-        result["Pension Fund Name"] = payload["details"]["pension_fund_name"]
-        result["Pension Display Name"] = payload["details"]["pension_display_name"]
-        result["Account Number"] = payload["details"].get("account_number")
-
-        response = {
-            "status": "success",
-            "result": result,
-            "snapshot_updated": snapshot_updated,
-            "latest_snapshot_updated": latest_snapshot_updated,
-            "plan_updated": plan_updated,
-        }
-        if upload_warnings:
-            response["warnings"] = upload_warnings
-        return response
+        return apply_pension_analysis_result(db, household_id, owner, result, file.filename)
     except Exception as exc:
         import traceback
 
@@ -707,7 +691,7 @@ def list_pension_reports(
     household_id = get_user_household_id(db, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         root_dir = Path(__file__).parent.parent.parent.parent.parent
         reports_root = root_dir / "reports"
@@ -719,12 +703,14 @@ def list_pension_reports(
             owner = owner_dir.name
             for pdf in sorted(owner_dir.glob("*.pdf"), key=lambda p: p.stat().st_mtime, reverse=True):
                 stat = pdf.stat()
-                report_files.append({
-                    "filename": pdf.name,
-                    "owner": owner,
-                    "uploaded_at": datetime.fromtimestamp(stat.st_mtime).isoformat(),
-                    "size_bytes": stat.st_size,
-                })
+                report_files.append(
+                    {
+                        "filename": pdf.name,
+                        "owner": owner,
+                        "uploaded_at": datetime.fromtimestamp(stat.st_mtime).isoformat(),
+                        "size_bytes": stat.st_size,
+                    }
+                )
 
         # Compute per-snapshot pension totals for delta comparison (household-scoped)
         snapshots = db.exec(
@@ -735,34 +721,35 @@ def list_pension_reports(
 
         snapshot_totals: list[dict[str, Any]] = []
         for snapshot in snapshots:
-            pension_items = [
-                item for item in snapshot.data.get("items", [])
-                if item.get("type") == "Pension"
-            ]
+            pension_items = [item for item in snapshot.data.get("items", []) if item.get("type") == "Pension"]
             if not pension_items:
                 continue
             total_value = sum(_safe_float(item.get("value")) for item in pension_items)
             accounts = []
             for item in pension_items:
                 details = item.get("details") or {}
-                accounts.append({
-                    "id": get_pension_identity(item) or item.get("id", ""),
-                    "owner": _safe_text(item.get("owner")) or "Unknown",
-                    "name": _safe_text(details.get("pension_display_name"))
-                    or _safe_text(item.get("name"))
-                    or "Unknown",
-                    "value": _safe_float(item.get("value")),
-                    "deposits": _safe_float(details.get("deposits")),
-                    "earnings": _safe_float(details.get("earnings")),
-                    "fees": _safe_float(details.get("fees")),
-                    "insurance_fees": _safe_float(details.get("insurance_fees")),
-                })
-            snapshot_totals.append({
-                "date": snapshot.date.isoformat(),
-                "total_value": total_value,
-                "account_count": len(pension_items),
-                "accounts": accounts,
-            })
+                accounts.append(
+                    {
+                        "id": get_pension_identity(item) or item.get("id", ""),
+                        "owner": _safe_text(item.get("owner")) or "Unknown",
+                        "name": _safe_text(details.get("pension_display_name"))
+                        or _safe_text(item.get("name"))
+                        or "Unknown",
+                        "value": _safe_float(item.get("value")),
+                        "deposits": _safe_float(details.get("deposits")),
+                        "earnings": _safe_float(details.get("earnings")),
+                        "fees": _safe_float(details.get("fees")),
+                        "insurance_fees": _safe_float(details.get("insurance_fees")),
+                    }
+                )
+            snapshot_totals.append(
+                {
+                    "date": snapshot.date.isoformat(),
+                    "total_value": total_value,
+                    "account_count": len(pension_items),
+                    "accounts": accounts,
+                }
+            )
 
         return {
             "status": "success",
@@ -785,7 +772,7 @@ def get_pension_dashboard(
     household_id = get_user_household_id(db, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         snapshots = db.exec(
             select(FinanceSnapshot)
@@ -811,7 +798,7 @@ def delete_pension(
     household_id = get_user_household_id(db, user_id)
     if not household_id:
         raise HTTPException(status_code=403, detail="User not associated with any household")
-    
+
     try:
         snapshots = db.exec(
             select(FinanceSnapshot)

--- a/apps/backend/app/worker/pension_pdf_parse.py
+++ b/apps/backend/app/worker/pension_pdf_parse.py
@@ -1,0 +1,135 @@
+"""Worker handler for Supabase Storage pension PDF parse jobs."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+from uuid import UUID
+
+from sqlmodel import Session
+
+from app.api.pension import apply_pension_analysis_result
+from app.dal.database import engine
+from app.utils.copilot_analyzer import analyze_report
+
+PENSION_UPLOAD_BUCKET = "pension-uploads"
+MAX_PENSION_PDF_BYTES = 10 * 1024 * 1024
+
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+Downloader = Callable[[str, UUID], Path]
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a worker database session."""
+
+    return Session(engine)
+
+
+def _sanitize_filename(filename: str) -> str:
+    """Return a storage-safe local filename."""
+
+    safe = "".join(ch if ch.isalnum() or ch in {".", "-", "_"} else "-" for ch in filename)
+    return safe.strip(".-") or "pension-report.pdf"
+
+
+def _require_payload_string(payload: JobPayload, key: str) -> str:
+    """Read a required string field from the job payload."""
+
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"pension_pdf_parse payload requires '{key}'")
+    return value.strip()
+
+
+def _storage_object_url(storage_path: str) -> str:
+    """Build the Supabase Storage object URL for a private object."""
+
+    supabase_url = os.getenv("SUPABASE_URL") or os.getenv("NEXT_PUBLIC_SUPABASE_URL")
+    if not supabase_url:
+        raise RuntimeError("SUPABASE_URL is required to download pension PDFs")
+    encoded_path = quote(storage_path, safe="/")
+    return f"{supabase_url.rstrip('/')}/storage/v1/object/{PENSION_UPLOAD_BUCKET}/{encoded_path}"
+
+
+def download_pension_pdf(storage_path: str, household_id: UUID) -> Path:
+    """Download a private pension PDF from Supabase Storage with the service role key."""
+
+    if not storage_path.startswith(f"{household_id}/"):
+        raise ValueError("storage_path must be scoped under the payload household_id")
+
+    service_role_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+    if not service_role_key:
+        raise RuntimeError("SUPABASE_SERVICE_ROLE_KEY is required to download pension PDFs")
+
+    request = Request(
+        _storage_object_url(storage_path),
+        headers={"Authorization": f"Bearer {service_role_key}", "apikey": service_role_key},
+    )
+    try:
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - URL is server configured Supabase.
+            content_length = response.headers.get("Content-Length")
+            if content_length and int(content_length) > MAX_PENSION_PDF_BYTES:
+                raise ValueError("Pension PDF exceeds the 10MB worker limit")
+            data = response.read(MAX_PENSION_PDF_BYTES + 1)
+    except HTTPError as exc:
+        raise RuntimeError(f"Failed to download pension PDF from Storage: HTTP {exc.code}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"Failed to download pension PDF from Storage: {exc.reason}") from exc
+
+    if len(data) > MAX_PENSION_PDF_BYTES:
+        raise ValueError("Pension PDF exceeds the 10MB worker limit")
+    if not data.startswith(b"%PDF"):
+        raise ValueError("Storage object is not a PDF file")
+
+    root_dir = Path(__file__).resolve().parents[4]
+    download_dir = root_dir / "reports" / "_worker" / str(household_id)
+    download_dir.mkdir(parents=True, exist_ok=True)
+    local_path = download_dir / _sanitize_filename(Path(storage_path).name)
+    local_path.write_bytes(data)
+    return local_path
+
+
+def _run_analyzer(analyzer: Callable[[str], Any], file_path: Path) -> dict[str, Any]:
+    """Run either a sync or async PDF analyzer."""
+
+    analyzed = analyzer(str(file_path))
+    if inspect.isawaitable(analyzed):
+        analyzed = asyncio.run(analyzed)
+    if not isinstance(analyzed, dict):
+        raise ValueError("Pension PDF analyzer returned a non-object result")
+    return analyzed
+
+
+def handle_pension_pdf_parse(
+    payload: JobPayload,
+    *,
+    session_factory: SessionFactory | None = None,
+    downloader: Downloader | None = None,
+    analyzer: Callable[[str], Any] | None = None,
+) -> JobResult:
+    """Parse a pension PDF from Storage and persist extracted pension rows."""
+
+    household_id = UUID(_require_payload_string(payload, "household_id"))
+    storage_path = _require_payload_string(payload, "storage_path")
+    owner = str(payload.get("owner") or "You").strip() or "You"
+    filename = str(payload.get("filename") or Path(storage_path).name)
+
+    active_downloader = downloader or download_pension_pdf
+    local_path = active_downloader(storage_path, household_id)
+    try:
+        result = _run_analyzer(analyzer or analyze_report, local_path)
+        with (session_factory or _default_session_factory)() as db:
+            return apply_pension_analysis_result(db, household_id, owner, result, filename)
+    finally:
+        if downloader is None and local_path.exists():
+            local_path.unlink()

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -4,6 +4,8 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
+from app.worker.pension_pdf_parse import handle_pension_pdf_parse
+
 JobPayload = dict[str, object]
 JobResult = dict[str, object]
 JobHandler = Callable[[JobPayload], JobResult]
@@ -21,5 +23,5 @@ class JobSchedule:
     seconds: int | None = None
 
 
-JOB_HANDLERS: dict[str, JobHandler] = {}
+JOB_HANDLERS: dict[str, JobHandler] = {"pension_pdf_parse": handle_pension_pdf_parse}
 JOB_SCHEDULES: list[JobSchedule] = []

--- a/apps/backend/tests/test_pension_pdf_worker.py
+++ b/apps/backend/tests/test_pension_pdf_worker.py
@@ -1,0 +1,123 @@
+"""Unit tests for the pension PDF worker handler."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import text
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, create_engine, select
+
+from app.schema.finance_models import FinanceSnapshot
+from app.schema.plan_models import Plan
+from app.worker.pension_pdf_parse import handle_pension_pdf_parse
+
+HOUSEHOLD_ID = UUID("00000000-0000-0000-0000-000000000123")
+
+
+def test_pension_pdf_parse_handler_updates_snapshots_and_plan() -> None:
+    """The worker parses a Storage PDF and persists the existing pension rows."""
+
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    with engine.begin() as connection:
+        connection.execute(
+            text("""
+                create table finance_snapshots (
+                  household_id char(32) not null,
+                  date date not null,
+                  data json not null,
+                  net_worth numeric(18, 6),
+                  total_assets numeric(18, 6),
+                  total_liabilities numeric(18, 6),
+                  primary key (household_id, date)
+                )
+                """)
+        )
+        connection.execute(
+            text("""
+                create table plans (
+                  id integer primary key autoincrement,
+                  household_id char(32),
+                  name varchar not null,
+                  description varchar,
+                  data json not null,
+                  created_at datetime,
+                  updated_at datetime
+                )
+                """)
+        )
+
+    with Session(engine) as session:
+        session.add(
+            FinanceSnapshot(
+                household_id=HOUSEHOLD_ID,
+                date=datetime(2026, 1, 31).date(),
+                data={
+                    "items": [],
+                    "total_savings": 0,
+                    "total_investments": 0,
+                    "total_assets": 0,
+                    "total_liabilities": 0,
+                },
+                net_worth=0,
+                total_assets=0,
+                total_liabilities=0,
+            )
+        )
+        session.add(
+            Plan(household_id=HOUSEHOLD_ID, name="Household plan", data={"items": [], "milestones": [], "settings": {}})
+        )
+        session.commit()
+
+    def session_factory() -> Session:
+        return Session(engine)
+
+    def downloader(storage_path: str, household_id: UUID) -> Path:
+        assert storage_path == f"{HOUSEHOLD_ID}/upload.pdf"
+        assert household_id == HOUSEHOLD_ID
+        return Path("reports/test-fixture.pdf")
+
+    def analyzer(_file_path: str) -> dict[str, object]:
+        return {
+            "Report Date": "2026-01-31",
+            "Name": "Rita",
+            "Total Amount": "123,456.78",
+            "Monthly Deposits": "1500",
+            "Earnings": "2500",
+            "Fees": "42",
+            "Insurance Fees": "12",
+            "Pension Fund Name": "Clal Pension",
+            "Pension Product": "פנסיה מקיפה",
+            "Account Number": "987654",
+        }
+
+    result = handle_pension_pdf_parse(
+        {
+            "household_id": str(HOUSEHOLD_ID),
+            "storage_path": f"{HOUSEHOLD_ID}/upload.pdf",
+            "owner": "Rita",
+            "filename": "upload.pdf",
+        },
+        session_factory=session_factory,
+        downloader=downloader,
+        analyzer=analyzer,
+    )
+
+    assert result["status"] == "success"
+    assert result["inserted_rows"] == 2
+    assert result["snapshot_dates"] == ["2026-01-31"]
+
+    with Session(engine) as session:
+        snapshot = session.exec(select(FinanceSnapshot)).one()
+        pension_item = snapshot.data["items"][0]
+        assert pension_item["owner"] == "Rita"
+        assert pension_item["value"] == 123456.78
+        assert snapshot.total_assets == Decimal("123456.780000")
+
+        plan = session.exec(select(Plan)).one()
+        plan_item = plan.data["items"][0]
+        assert plan_item["account_settings"]["type"] == "Pension"
+        assert plan_item["account_settings"]["account_number"] == "987654"

--- a/apps/frontend/src/app/pension/actions.test.ts
+++ b/apps/frontend/src/app/pension/actions.test.ts
@@ -6,10 +6,14 @@ const mockSnapshotOrder = vi.fn();
 const mockPlanMaybeSingle = vi.fn();
 const mockSnapshotUpdateDateEq = vi.fn();
 const mockPlanUpdateIdEq = vi.fn();
+const mockStorageUpload = vi.fn();
+const mockStorageRemove = vi.fn();
+const mockComputeInsert = vi.fn();
+const mockComputeInsertSingle = vi.fn();
 
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
 
-import { deletePensionReport, getPensionDashboard, listPensionReports } from './actions';
+import { deletePensionReport, getPensionDashboard, listPensionReports, uploadPensionPdf } from './actions';
 import { createClient } from '@/lib/supabase/server';
 
 const MOCK_USER_ID = 'user-uuid-1234';
@@ -35,8 +39,20 @@ function makeSupabaseMock() {
           update: vi.fn(() => ({ eq: vi.fn().mockReturnThis().mockImplementationOnce(function firstEq(this: unknown) { return this; }).mockImplementationOnce(mockPlanUpdateIdEq) })),
         };
       }
+      if (table === 'compute_jobs') {
+        const computeChain = {
+          insert: mockComputeInsert,
+          select: vi.fn().mockReturnThis(),
+          single: mockComputeInsertSingle,
+        };
+        mockComputeInsert.mockReturnValue(computeChain);
+        return computeChain;
+      }
       throw new Error(`Unexpected table: ${table}`);
     }),
+    storage: {
+      from: vi.fn(() => ({ upload: mockStorageUpload, remove: mockStorageRemove })),
+    },
   };
 }
 
@@ -85,6 +101,41 @@ beforeEach(() => {
   mockPlanMaybeSingle.mockResolvedValue({ data: null, error: null });
   mockSnapshotUpdateDateEq.mockResolvedValue({ error: null });
   mockPlanUpdateIdEq.mockResolvedValue({ error: null });
+  mockStorageUpload.mockResolvedValue({ error: null });
+  mockStorageRemove.mockResolvedValue({ error: null });
+  mockComputeInsertSingle.mockResolvedValue({ data: { id: 'job-123' }, error: null });
+});
+
+describe('uploadPensionPdf', () => {
+  it('uploads a PDF under the household prefix and enqueues the parser job', async () => {
+    authOk();
+    const file = new File(['%PDF-1.7'], 'quarterly report.pdf', { type: 'application/pdf' });
+
+    await expect(uploadPensionPdf(file, 'Rita')).resolves.toMatchObject({ jobId: 'job-123' });
+
+    expect(mockStorageUpload).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp(`^${MOCK_HOUSEHOLD_ID}/.+-quarterly-report\\.pdf$`)),
+      file,
+      expect.objectContaining({ contentType: 'application/pdf', upsert: false }),
+    );
+    expect(mockComputeInsert).toHaveBeenCalledWith({
+      household_id: MOCK_HOUSEHOLD_ID,
+      job_type: 'pension_pdf_parse',
+      payload: expect.objectContaining({
+        household_id: MOCK_HOUSEHOLD_ID,
+        owner: 'Rita',
+        filename: 'quarterly report.pdf',
+        storage_path: expect.stringMatching(new RegExp(`^${MOCK_HOUSEHOLD_ID}/`)),
+      }),
+    });
+  });
+
+  it('rejects non-PDF uploads before Storage is called', async () => {
+    const file = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+
+    await expect(uploadPensionPdf(file)).rejects.toThrow('Only PDF pension reports can be uploaded.');
+    expect(mockStorageUpload).not.toHaveBeenCalled();
+  });
 });
 
 describe('listPensionReports', () => {
@@ -111,7 +162,7 @@ describe('getPensionDashboard', () => {
     const result = await getPensionDashboard();
     expect(result.history[1][PENSION_ID]).toBe(102_000);
     expect(result.accounts[0]).toMatchObject({ id: PENSION_ID, product_name: 'Makif', fund_name: 'Fund' });
-    expect(result.accounts[0].details.draw_income).toBe(true);
+    expect(result.accounts[0]?.details?.draw_income).toBe(true);
     expect(result.milestones[0]).toMatchObject({ owner: 'You', year: 2040 });
     expect(result.projections.length).toBeGreaterThan(0);
   });

--- a/apps/frontend/src/app/pension/actions.ts
+++ b/apps/frontend/src/app/pension/actions.ts
@@ -1,6 +1,8 @@
 'use server';
 
+import { randomUUID } from 'crypto';
 import { createClient } from '@/lib/supabase/server';
+import { enqueueComputeJob } from '@/lib/compute-jobs';
 import type {
   PensionAccount,
   PensionAccountDetails,
@@ -15,6 +17,8 @@ import type { Plan, PlanItem } from '@/components/Plan/types';
 
 const PENSION_ID_PREFIX = 'pension::';
 const SPOUSE_OWNER_ALIASES = new Set(['spouse', 'rita']);
+const PENSION_UPLOAD_BUCKET = 'pension-uploads';
+const MAX_PENSION_UPLOAD_BYTES = 10 * 1024 * 1024;
 const EMPTY_DASHBOARD: PensionDashboardResponse = {
   status: 'success',
   history: [],
@@ -91,6 +95,62 @@ async function getAuthenticatedHouseholdId(): Promise<string | null> {
 
   if (authError || !user) return null;
   return resolveHouseholdId(user.id);
+}
+
+function sanitizeStorageFilename(filename: string): string {
+  const sanitized = filename
+    .normalize('NFKC')
+    .replace(/[^\p{L}\p{N}._-]+/gu, '-')
+    .replace(/^-+|-+$/gu, '');
+  return sanitized || 'pension-report.pdf';
+}
+
+function validatePensionPdf(file: File): void {
+  if (file.size > MAX_PENSION_UPLOAD_BYTES) {
+    throw new Error('Pension PDF must be 10MB or smaller.');
+  }
+  const hasPdfName = file.name.toLocaleLowerCase().endsWith('.pdf');
+  const hasPdfType = file.type === 'application/pdf' || file.type === '';
+  if (!hasPdfName || !hasPdfType) {
+    throw new Error('Only PDF pension reports can be uploaded.');
+  }
+}
+
+/** Uploads a pension PDF to private Storage and enqueues the parser worker. */
+export async function uploadPensionPdf(
+  file: File,
+  owner = 'You',
+): Promise<{ jobId: string; storagePath: string }> {
+  validatePensionPdf(file);
+  const householdId = await getAuthenticatedHouseholdId();
+  if (!householdId) throw new Error('Not authenticated');
+
+  const storagePath = `${householdId}/${randomUUID()}-${sanitizeStorageFilename(file.name)}`;
+  const supabase = await createClient();
+  const { error: uploadError } = await supabase.storage
+    .from(PENSION_UPLOAD_BUCKET)
+    .upload(storagePath, file, {
+      cacheControl: '3600',
+      contentType: 'application/pdf',
+      upsert: false,
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message || 'Failed to upload pension PDF.');
+  }
+
+  try {
+    const jobId = await enqueueComputeJob('pension_pdf_parse', {
+      household_id: householdId,
+      storage_path: storagePath,
+      owner,
+      filename: file.name,
+    });
+    return { jobId, storagePath };
+  } catch (error) {
+    await supabase.storage.from(PENSION_UPLOAD_BUCKET).remove([storagePath]);
+    throw error;
+  }
 }
 
 function safeFloat(value: unknown): number {

--- a/apps/frontend/src/app/pension/page.tsx
+++ b/apps/frontend/src/app/pension/page.tsx
@@ -6,7 +6,7 @@ import PensionTable from '@/components/Pension/PensionTable';
 import ReportHistory from '@/components/Pension/ReportHistory';
 import SnapshotDetail from '@/components/Pension/SnapshotDetail';
 import { deletePensionReport, getPensionDashboard, listPensionReports, uploadPensionPdf } from './actions';
-import { subscribeToComputeJob, type ComputeJob } from '@/lib/compute-jobs';
+import { subscribeToComputeJob, type ComputeJob } from '@/lib/compute-jobs-client';
 import type { PensionAccount, PensionDashboardResponse, PensionSeriesPoint, PensionSnapshotSummary } from '@/components/Pension/pensionTypes';
 
 interface PensionUploadJobResult {

--- a/apps/frontend/src/app/pension/page.tsx
+++ b/apps/frontend/src/app/pension/page.tsx
@@ -1,20 +1,26 @@
 'use client';
-import { apiFetch } from '@/lib/api-client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import PensionChart from '@/components/Pension/PensionChart';
 import PensionTable from '@/components/Pension/PensionTable';
 import ReportHistory from '@/components/Pension/ReportHistory';
 import SnapshotDetail from '@/components/Pension/SnapshotDetail';
-import { deletePensionReport, getPensionDashboard, listPensionReports } from './actions';
-import type { PensionDashboardResponse, PensionSnapshotSummary } from '@/components/Pension/pensionTypes';
+import { deletePensionReport, getPensionDashboard, listPensionReports, uploadPensionPdf } from './actions';
+import { subscribeToComputeJob, type ComputeJob } from '@/lib/compute-jobs';
+import type { PensionAccount, PensionDashboardResponse, PensionSeriesPoint, PensionSnapshotSummary } from '@/components/Pension/pensionTypes';
 
-interface PensionUploadResponse {
+interface PensionUploadJobResult {
     status: string;
-    result: Record<string, string | number | null | undefined>;
-    snapshot_updated: boolean;
-    plan_updated: boolean;
+    result?: Record<string, string | number | null | undefined>;
+    analysis_result?: Record<string, string | number | null | undefined>;
+    snapshot_updated?: boolean;
+    latest_snapshot_updated?: boolean;
+    plan_updated?: boolean;
+    inserted_rows?: number;
+    snapshot_dates?: string[];
 }
+
+type UploadStatus = 'idle' | 'uploading' | 'parsing' | 'done' | 'failed';
 
 const formatUploadNumber = (value: string | number | null | undefined) => {
     if (typeof value === 'number') return new Intl.NumberFormat().format(value);
@@ -25,11 +31,36 @@ const formatUploadNumber = (value: string | number | null | undefined) => {
 const formatUploadText = (...values: Array<string | number | null | undefined>) =>
     values.find((value) => value !== null && value !== undefined && String(value).trim() !== '') ?? 'N/A';
 
+const toChartPoints = (points: PensionSeriesPoint[]) => points.map((point) => {
+    const chartPoint: { date: string; [key: string]: string | number } = { date: point.date };
+    for (const [key, value] of Object.entries(point)) {
+        if (key !== 'date' && value !== undefined) chartPoint[key] = value;
+    }
+    return chartPoint;
+});
+
+const toChartAccounts = (accounts: PensionAccount[]) => accounts.map((account) => ({
+    id: account.id,
+    series_id: account.series_id,
+    owner: account.owner,
+    name: account.name,
+}));
+
+const toTableAccounts = (accounts: PensionAccount[]) => accounts.map((account) => ({
+    id: account.id,
+    owner: account.owner,
+    name: account.name,
+    value: account.value,
+    details: account.details ?? {},
+}));
+
 export default function PensionPage() {
     const [owner, setOwner] = useState('You');
     const [file, setFile] = useState<File | null>(null);
-    const [loading, setLoading] = useState(false);
-    const [result, setResult] = useState<PensionUploadResponse | null>(null);
+    const [uploadStatus, setUploadStatus] = useState<UploadStatus>('idle');
+    const [jobId, setJobId] = useState<string | null>(null);
+    const [storagePath, setStoragePath] = useState<string | null>(null);
+    const [result, setResult] = useState<PensionUploadJobResult | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [dashboardData, setDashboardData] = useState<PensionDashboardResponse | null>(null);
     const [selectedSnapshot, setSelectedSnapshot] = useState<PensionSnapshotSummary | null>(null);
@@ -38,6 +69,7 @@ export default function PensionPage() {
     const [refreshKey, setRefreshKey] = useState(0);
 
     const fileInputRef = useRef<HTMLInputElement>(null);
+    const loading = uploadStatus === 'uploading' || uploadStatus === 'parsing';
 
     const fetchDashboard = async () => {
         try {
@@ -92,6 +124,31 @@ export default function PensionPage() {
         e.preventDefault();
     };
 
+    const handleJobUpdate = useCallback(async (job: ComputeJob) => {
+        if (job.status === 'running' || job.status === 'pending') {
+            setUploadStatus('parsing');
+            return;
+        }
+        if (job.status === 'failed') {
+            setUploadStatus('failed');
+            setError(job.error ?? 'Pension parser failed.');
+            return;
+        }
+        if (job.status === 'done') {
+            setUploadStatus('done');
+            setResult(job.result as PensionUploadJobResult);
+            await fetchDashboard();
+            setRefreshKey((k) => k + 1);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (!jobId) return undefined;
+        return subscribeToComputeJob(jobId, (job) => {
+            void handleJobUpdate(job);
+        });
+    }, [handleJobUpdate, jobId]);
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
@@ -100,41 +157,21 @@ export default function PensionPage() {
             return;
         }
 
-        setLoading(true);
+        setUploadStatus('uploading');
         setError(null);
         setResult(null);
-
-        const formData = new FormData();
-        formData.append('owner', owner);
-        formData.append('file', file);
+        setJobId(null);
+        setStoragePath(null);
 
         try {
-            const apiUrl = process.env.NEXT_PUBLIC_API_URL || '';
-            const response = await apiFetch(`${apiUrl}/api/pension/upload`, {
-                method: 'POST',
-                body: formData,
-            });
-
-            if (!response.ok) {
-                const errorData = await response.text();
-                throw new Error(`Failed to upload: ${response.status} ${errorData}`);
-            }
-
-            const data = await response.json();
-            setResult(data);
-
-            // Refresh dashboard and report history after successful upload
-            await fetchDashboard();
-            setRefreshKey((k) => k + 1);
+            const data = await uploadPensionPdf(file, owner);
+            setJobId(data.jobId);
+            setStoragePath(data.storagePath);
+            setUploadStatus('parsing');
         } catch (err: unknown) {
             console.error(err);
-            if (err instanceof Error) {
-                setError(err.message || 'An error occurred during upload.');
-            } else {
-                setError('An error occurred during upload.');
-            }
-        } finally {
-            setLoading(false);
+            setUploadStatus('failed');
+            setError(err instanceof Error ? err.message : 'An error occurred during upload.');
         }
     };
 
@@ -156,6 +193,8 @@ export default function PensionPage() {
         }
     };
 
+    const extractedResult = result?.analysis_result ?? result?.result ?? {};
+
     return (
         <div className="min-h-screen bg-slate-950 text-slate-100 p-4 md:p-8 pb-24">
             <div className="max-w-7xl mx-auto space-y-8">
@@ -170,12 +209,12 @@ export default function PensionPage() {
                 {dashboardData && dashboardData.history && dashboardData.history.length > 0 && (
                     <div className="bg-slate-900 border border-slate-800 rounded-xl p-6">
                         <PensionChart
-                            history={dashboardData.history}
-                            projections={dashboardData.projections}
-                            accounts={dashboardData.accounts}
+                            history={toChartPoints(dashboardData.history)}
+                            projections={toChartPoints(dashboardData.projections)}
+                            accounts={toChartAccounts(dashboardData.accounts)}
                             milestones={dashboardData.milestones}
                         />
-                        <PensionTable accounts={dashboardData.accounts} onDelete={handleDelete} />
+                        <PensionTable accounts={toTableAccounts(dashboardData.accounts)} onDelete={handleDelete} />
                     </div>
                 )}
 
@@ -290,9 +329,9 @@ export default function PensionPage() {
                                             <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                                             <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                                         </svg>
-                                        Analyzing Report...
+                                        {uploadStatus === 'uploading' ? 'Uploading PDF...' : 'Parsing PDF...'}
                                     </span>
-                                ) : 'Analyze and Update'}
+                                ) : 'Upload and Parse'}
                             </button>
                         </form>
                     </div>
@@ -308,11 +347,19 @@ export default function PensionPage() {
                         )}
 
                         {loading && (
-                            <div className="text-slate-400 text-sm flex items-center space-x-2 animate-pulse">
-                                <div className="w-2 h-2 rounded-full bg-blue-500"></div>
-                                <div className="w-2 h-2 rounded-full bg-blue-500 animation-delay-200"></div>
-                                <div className="w-2 h-2 rounded-full bg-blue-500 animation-delay-400"></div>
-                                <span>Copilot agent is reading the PDF...</span>
+                            <div className="space-y-2">
+                                <div className="text-slate-400 text-sm flex items-center space-x-2 animate-pulse">
+                                    <div className="w-2 h-2 rounded-full bg-blue-500"></div>
+                                    <div className="w-2 h-2 rounded-full bg-blue-500 animation-delay-200"></div>
+                                    <div className="w-2 h-2 rounded-full bg-blue-500 animation-delay-400"></div>
+                                    <span>{uploadStatus === 'uploading' ? 'Uploading to private Storage...' : 'Worker is parsing the PDF...'}</span>
+                                </div>
+                                {(jobId || storagePath) && (
+                                    <div className="text-xs text-slate-500 break-all">
+                                        {jobId && <div>Job: {jobId}</div>}
+                                        {storagePath && <div>Storage path: {storagePath}</div>}
+                                    </div>
+                                )}
                             </div>
                         )}
 
@@ -329,41 +376,41 @@ export default function PensionPage() {
                                     <div className="grid grid-cols-2 gap-4 text-sm">
                                         <div className="col-span-2">
                                             <span className="block text-slate-500">Pension Fund Name</span>
-                                            <span className="block text-slate-200 font-medium">{formatUploadText(result.result['Pension Fund Name'], result.result['Name'])}</span>
+                                            <span className="block text-slate-200 font-medium">{formatUploadText(extractedResult['Pension Fund Name'], extractedResult['Name'])}</span>
                                         </div>
 
                                         <div>
                                             <span className="block text-slate-500">Total Amount</span>
                                             <span className="block text-slate-200 font-medium">
-                                                {formatUploadNumber(result.result['Total Amount'])}
+                                                {formatUploadNumber(extractedResult['Total Amount'])}
                                             </span>
                                         </div>
 
                                         <div>
                                             <span className="block text-slate-500">Deposits</span>
                                             <span className="block text-slate-200 font-medium">
-                                                {formatUploadNumber(result.result['Deposits'])}
+                                                {formatUploadNumber(extractedResult['Deposits'] ?? extractedResult['Monthly Deposits'])}
                                             </span>
                                         </div>
 
                                         <div>
                                             <span className="block text-slate-500">Earnings</span>
                                             <span className="block text-slate-200 font-medium">
-                                                {formatUploadNumber(result.result['Earnings'])}
+                                                {formatUploadNumber(extractedResult['Earnings'])}
                                             </span>
                                         </div>
 
                                         <div>
                                             <span className="block text-slate-500">Fees</span>
                                             <span className="block text-slate-200 font-medium">
-                                                {formatUploadNumber(result.result['Fees'])}
+                                                {formatUploadNumber(extractedResult['Fees'])}
                                             </span>
                                         </div>
 
                                         <div>
                                             <span className="block text-slate-500">Insurance Fees</span>
                                             <span className="block text-slate-200 font-medium">
-                                                {formatUploadNumber(result.result['Insurance Fees'])}
+                                                {formatUploadNumber(extractedResult['Insurance Fees'])}
                                             </span>
                                         </div>
                                     </div>

--- a/apps/frontend/src/lib/__tests__/compute-jobs.test.ts
+++ b/apps/frontend/src/lib/__tests__/compute-jobs.test.ts
@@ -3,9 +3,12 @@ import {
   __setComputeJobsTestClient,
   enqueueComputeJob,
   getComputeJob,
-  subscribeToComputeJob,
   type ComputeJob,
 } from '../compute-jobs';
+import {
+  __setComputeJobsClientTestClient,
+  subscribeToComputeJob,
+} from '../compute-jobs-client';
 
 const getUser = vi.fn();
 
@@ -24,6 +27,7 @@ function chain(result: unknown) {
 beforeEach(() => {
   vi.resetAllMocks();
   __setComputeJobsTestClient(null);
+  __setComputeJobsClientTestClient(null);
   getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
 });
 
@@ -97,7 +101,7 @@ describe('compute job helpers', () => {
       channel: vi.fn(() => channel),
       removeChannel,
     };
-    __setComputeJobsTestClient(supabase as never);
+    __setComputeJobsClientTestClient(supabase as never);
 
     const unsubscribe = subscribeToComputeJob('job-1', callback);
     expect(supabase.channel).toHaveBeenCalledWith('compute-job:job-1');

--- a/apps/frontend/src/lib/compute-jobs-client.ts
+++ b/apps/frontend/src/lib/compute-jobs-client.ts
@@ -1,0 +1,79 @@
+import { createBrowserClient } from '@supabase/ssr';
+import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/types/database';
+
+export type ComputeJobStatus = 'pending' | 'running' | 'done' | 'failed';
+
+export interface ComputeJob {
+  id: string;
+  household_id: string;
+  job_type: string;
+  payload: unknown;
+  status: ComputeJobStatus;
+  result: unknown | null;
+  error: string | null;
+  attempts: number;
+  created_at: string;
+  started_at: string | null;
+  finished_at: string | null;
+}
+
+type SupabaseLike = Pick<SupabaseClient<Database>, 'channel' | 'removeChannel'>;
+
+let testClient: SupabaseLike | null = null;
+
+/** Override the Supabase client in unit tests. */
+export function __setComputeJobsClientTestClient(client: SupabaseLike | null): void {
+  testClient = client;
+}
+
+function createBrowserSupabase(): SupabaseLike {
+  if (testClient) return testClient;
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}
+
+export function normalizeComputeJob(row: Record<string, unknown>): ComputeJob {
+  return {
+    id: String(row.id),
+    household_id: String(row.household_id),
+    job_type: String(row.job_type),
+    payload: row.payload,
+    status: row.status as ComputeJobStatus,
+    result: row.result ?? null,
+    error: row.error == null ? null : String(row.error),
+    attempts: Number(row.attempts ?? 0),
+    created_at: String(row.created_at),
+    started_at: row.started_at == null ? null : String(row.started_at),
+    finished_at: row.finished_at == null ? null : String(row.finished_at),
+  };
+}
+
+/** Subscribe to status changes for one compute job. Returns an unsubscribe callback. */
+export function subscribeToComputeJob(
+  jobId: string,
+  onUpdate: (job: ComputeJob) => void,
+): () => void {
+  const supabase = createBrowserSupabase();
+  const channel: RealtimeChannel = supabase
+    .channel(`compute-job:${jobId}`)
+    .on(
+      'postgres_changes',
+      {
+        event: '*',
+        schema: 'public',
+        table: 'compute_jobs',
+        filter: `id=eq.${jobId}`,
+      },
+      (event: { new: Record<string, unknown> }) => {
+        if (event.new) onUpdate(normalizeComputeJob(event.new));
+      },
+    )
+    .subscribe();
+
+  return () => {
+    void supabase.removeChannel(channel);
+  };
+}

--- a/apps/frontend/src/lib/compute-jobs.ts
+++ b/apps/frontend/src/lib/compute-jobs.ts
@@ -1,22 +1,8 @@
-import { createBrowserClient } from '@supabase/ssr';
-import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
+import { normalizeComputeJob, type ComputeJob } from './compute-jobs-client';
 
-export type ComputeJobStatus = 'pending' | 'running' | 'done' | 'failed';
-
-export interface ComputeJob {
-  id: string;
-  household_id: string;
-  job_type: string;
-  payload: unknown;
-  status: ComputeJobStatus;
-  result: unknown | null;
-  error: string | null;
-  attempts: number;
-  created_at: string;
-  started_at: string | null;
-  finished_at: string | null;
-}
+export type { ComputeJob, ComputeJobStatus } from './compute-jobs-client';
 
 type SupabaseLike = Pick<SupabaseClient<Database>, 'auth' | 'from' | 'channel' | 'removeChannel'>;
 
@@ -31,14 +17,6 @@ async function createServerSupabase(): Promise<SupabaseLike> {
   if (testClient) return testClient;
   const { createClient } = await import('@/lib/supabase/server');
   return createClient();
-}
-
-function createBrowserSupabase(): SupabaseLike {
-  if (testClient) return testClient;
-  return createBrowserClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-  );
 }
 
 async function requireActiveHouseholdId(supabase: SupabaseLike): Promise<string> {
@@ -64,22 +42,6 @@ async function requireActiveHouseholdId(supabase: SupabaseLike): Promise<string>
   }
 
   return String(data.household_id);
-}
-
-function normalizeComputeJob(row: Record<string, unknown>): ComputeJob {
-  return {
-    id: String(row.id),
-    household_id: String(row.household_id),
-    job_type: String(row.job_type),
-    payload: row.payload,
-    status: row.status as ComputeJobStatus,
-    result: row.result ?? null,
-    error: row.error == null ? null : String(row.error),
-    attempts: Number(row.attempts ?? 0),
-    created_at: String(row.created_at),
-    started_at: row.started_at == null ? null : String(row.started_at),
-    finished_at: row.finished_at == null ? null : String(row.finished_at),
-  };
 }
 
 /** Enqueue an on-demand backend compute job for the current household. */
@@ -122,31 +84,4 @@ export async function getComputeJob(jobId: string): Promise<ComputeJob | null> {
   }
 
   return data ? normalizeComputeJob(data as Record<string, unknown>) : null;
-}
-
-/** Subscribe to status changes for one compute job. Returns an unsubscribe callback. */
-export function subscribeToComputeJob(
-  jobId: string,
-  onUpdate: (job: ComputeJob) => void,
-): () => void {
-  const supabase = createBrowserSupabase();
-  const channel: RealtimeChannel = supabase
-    .channel(`compute-job:${jobId}`)
-    .on(
-      'postgres_changes',
-      {
-        event: '*',
-        schema: 'public',
-        table: 'compute_jobs',
-        filter: `id=eq.${jobId}`,
-      },
-      (event: { new: Record<string, unknown> }) => {
-        if (event.new) onUpdate(normalizeComputeJob(event.new));
-      },
-    )
-    .subscribe();
-
-  return () => {
-    void supabase.removeChannel(channel);
-  };
 }

--- a/supabase/migrations/20260503163659_add_pension_upload_bucket.sql
+++ b/supabase/migrations/20260503163659_add_pension_upload_bucket.sql
@@ -1,51 +1,61 @@
 -- Migration: 20260503163659_add_pension_upload_bucket
 -- Purpose: Create private pension PDF upload bucket and household-scoped Storage policies for TJ-020.
 
-insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
-values ('pension-uploads', 'pension-uploads', false, 10485760, array['application/pdf'])
-on conflict (id) do update
-   set public = false,
-       file_size_limit = 10485760,
-       allowed_mime_types = array['application/pdf'];
+-- The GitHub Actions shadow database used for migration dry-runs does not install
+-- Supabase Storage. Skip this migration there while still applying it on hosted Supabase.
+do $$
+begin
+  if to_regclass('storage.buckets') is null or to_regclass('storage.objects') is null then
+    raise notice 'Skipping pension-uploads bucket setup because Supabase Storage is unavailable';
+    return;
+  end if;
 
-drop policy if exists pension_uploads_member_insert on storage.objects;
-create policy pension_uploads_member_insert
-  on storage.objects
-  for insert
-  to authenticated
-  with check (
-    bucket_id = 'pension-uploads'
-    and case
-      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-      then public.is_household_member(((storage.foldername(name))[1])::uuid)
-      else false
-    end
-  );
+  insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+  values ('pension-uploads', 'pension-uploads', false, 10485760, array['application/pdf'])
+  on conflict (id) do update
+     set public = false,
+         file_size_limit = 10485760,
+         allowed_mime_types = array['application/pdf'];
 
-drop policy if exists pension_uploads_member_select on storage.objects;
-create policy pension_uploads_member_select
-  on storage.objects
-  for select
-  to authenticated
-  using (
-    bucket_id = 'pension-uploads'
-    and case
-      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-      then public.is_household_member(((storage.foldername(name))[1])::uuid)
-      else false
-    end
-  );
+  drop policy if exists pension_uploads_member_insert on storage.objects;
+  create policy pension_uploads_member_insert
+    on storage.objects
+    for insert
+    to authenticated
+    with check (
+      bucket_id = 'pension-uploads'
+      and case
+        when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        then public.is_household_member(((storage.foldername(name))[1])::uuid)
+        else false
+      end
+    );
 
-drop policy if exists pension_uploads_member_delete on storage.objects;
-create policy pension_uploads_member_delete
-  on storage.objects
-  for delete
-  to authenticated
-  using (
-    bucket_id = 'pension-uploads'
-    and case
-      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
-      then public.is_household_member(((storage.foldername(name))[1])::uuid)
-      else false
-    end
-  );
+  drop policy if exists pension_uploads_member_select on storage.objects;
+  create policy pension_uploads_member_select
+    on storage.objects
+    for select
+    to authenticated
+    using (
+      bucket_id = 'pension-uploads'
+      and case
+        when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        then public.is_household_member(((storage.foldername(name))[1])::uuid)
+        else false
+      end
+    );
+
+  drop policy if exists pension_uploads_member_delete on storage.objects;
+  create policy pension_uploads_member_delete
+    on storage.objects
+    for delete
+    to authenticated
+    using (
+      bucket_id = 'pension-uploads'
+      and case
+        when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+        then public.is_household_member(((storage.foldername(name))[1])::uuid)
+        else false
+      end
+    );
+end $$;

--- a/supabase/migrations/20260503163659_add_pension_upload_bucket.sql
+++ b/supabase/migrations/20260503163659_add_pension_upload_bucket.sql
@@ -1,0 +1,51 @@
+-- Migration: 20260503163659_add_pension_upload_bucket
+-- Purpose: Create private pension PDF upload bucket and household-scoped Storage policies for TJ-020.
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values ('pension-uploads', 'pension-uploads', false, 10485760, array['application/pdf'])
+on conflict (id) do update
+   set public = false,
+       file_size_limit = 10485760,
+       allowed_mime_types = array['application/pdf'];
+
+drop policy if exists pension_uploads_member_insert on storage.objects;
+create policy pension_uploads_member_insert
+  on storage.objects
+  for insert
+  to authenticated
+  with check (
+    bucket_id = 'pension-uploads'
+    and case
+      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      then public.is_household_member(((storage.foldername(name))[1])::uuid)
+      else false
+    end
+  );
+
+drop policy if exists pension_uploads_member_select on storage.objects;
+create policy pension_uploads_member_select
+  on storage.objects
+  for select
+  to authenticated
+  using (
+    bucket_id = 'pension-uploads'
+    and case
+      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      then public.is_household_member(((storage.foldername(name))[1])::uuid)
+      else false
+    end
+  );
+
+drop policy if exists pension_uploads_member_delete on storage.objects;
+create policy pension_uploads_member_delete
+  on storage.objects
+  for delete
+  to authenticated
+  using (
+    bucket_id = 'pension-uploads'
+    and case
+      when (storage.foldername(name))[1] ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+      then public.is_household_member(((storage.foldername(name))[1])::uuid)
+      else false
+    end
+  );


### PR DESCRIPTION
## Summary
- Migrates the pension PDF upload UI off FastAPI multipart and onto private Supabase Storage + `compute_jobs`.
- Adds `pension-uploads` Storage bucket DDL/policies: private bucket, PDF-only, 10MB limit, authenticated household path scoping for INSERT/SELECT/DELETE.
- Registers the backend `pension_pdf_parse` worker handler, downloads Storage objects with the server-only service-role key, reuses the existing parser/persistence logic, and marks `/api/pension/upload` deprecated.

## UI flow
1. Pension page calls `uploadPensionPdf(file, owner)` Server Action.
2. The action validates PDF + 10MB limit, uploads to `pension-uploads/{household_id}/{uuid}-{filename}`, and enqueues `pension_pdf_parse`.
3. The client subscribes to `subscribeToComputeJob(jobId, ...)` and shows uploading → parsing → done/failed, including extracted data from `compute_jobs.result`.

## TJ-020 migration note
- Closes #217 under #207 and follows ADR `.squad/decisions/inbox/keaton-tj019-frontend-supabase-only.md`.
- Links #219 for the storage/worker arc.
- Verified there is no `UNMIGRATED_FASTAPI_PATHS` array in this branch and no remaining `/api/pension/upload` frontend call sites; this should complete the TJ-018/TJ-019/TJ-020 migration arc for the final pension upload entry.

## Validation
- `uv run ruff check app/api/pension.py app/worker/pension_pdf_parse.py tests/test_pension_pdf_worker.py`
- `uv run pytest tests/test_pension_api.py tests/test_pension_pdf_worker.py tests/test_worker_job_queue.py`
- `npm test -- --run src/app/pension/actions.test.ts src/lib/__tests__/compute-jobs.test.ts`
- `npx tsc --noEmit --pretty false --incremental false` filtered for pension/compute-job errors: none
- Supabase MCP verified `pension-uploads` is private, 10MB, PDF-only, and Storage policies exist for INSERT/SELECT/DELETE.

Closes #217