### PR TITLE
chore(TJ-020): remove migrated entries from walkthrough allow-list

### DIFF
--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -14,10 +14,7 @@ const PAGES = [
  * TJ-020 Phase B migrations in #208-#217 land.
  */
 const TEMPORARILY_ALLOWED_COMPUTE_API_PATHS: string[] = [
-  '/api/tax-condor',
   '/api/backtest',
-  '/api/bonds/scanner',
-  '/api/ndx/sync',
   '/api/pension',
 ];
 


### PR DESCRIPTION
Working as Hockney (Frontend Dev).\n\n## Summary\n- Remove migrated TJ-020 compute API paths from the walkthrough temporary allow-list\n- Keep /api/backtest and /api/pension until #228 and #229 land\n\n## Validation\n- npm test (apps/frontend)\n- npm run lint (apps/frontend) currently fails on pre-existing unrelated lint errors in Plan/trading files\n\n