### PR TITLE
feat(options): #245 phase 0 — flex probe + field mapping + synthetic harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ share/python-wheels/
 MANIFEST
 
 # Data files
+tmp/
 *.xlsx
 # *.csv # User didn't explicitly ask for csv, but often goes with xlsx. I will leave it commented out for now unless specifically asked, but user mentioned "data files". The user prompt specifically mentioned "xlsx files like we added to track bond data". I'll stick to xlsx for now to be precise.
 

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -19,3 +19,12 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 # OpenTelemetry
 OTEL_SERVICE_NAME=trading-journal-backend-worker
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# IBKR Flex Query Phase 0 probe (see docs/options-flex-query-setup.md)
+# Keep real values in apps/backend/.env locally; use gh secret set for production.
+IBKR_FLEX_TOKEN=your-flex-web-service-token
+IBKR_FLEX_QUERY_ID_TRADES=your-trades-query-id
+IBKR_FLEX_QUERY_ID_OPTION_EAE=your-option-eae-query-id
+IBKR_FLEX_QUERY_ID_CASH=your-cash-transactions-query-id
+IBKR_FLEX_QUERY_ID_POSITIONS=your-open-positions-query-id
+IBKR_FLEX_QUERY_ID_ACCOUNT_INFO=your-account-information-query-id

--- a/apps/backend/scripts/flex_probe.py
+++ b/apps/backend/scripts/flex_probe.py
@@ -1,0 +1,361 @@
+"""Probe IBKR Flex Query XML fields for the options income dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlencode
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, ParseError
+
+import requests
+
+FLEX_BASE_URL = "https://gdcdyn.interactivebrokers.com/Universal/servlet"
+SEND_REQUEST_URL = f"{FLEX_BASE_URL}/FlexStatementService.SendRequest"
+GET_STATEMENT_URL = f"{FLEX_BASE_URL}/FlexStatementService.GetStatement"
+OUTPUT_DIR = Path("tmp/flex")
+MONEY_DISPLAY = Decimal("0.01")
+
+QUERY_ENV_VARS = {
+    "trades": ("IBKR_FLEX_QUERY_ID_TRADES",),
+    "option_eae": ("IBKR_FLEX_QUERY_ID_OPTION_EAE", "IBKR_FLEX_QUERY_ID_OPTIONEAE"),
+    "cash": ("IBKR_FLEX_QUERY_ID_CASH",),
+    "positions": ("IBKR_FLEX_QUERY_ID_POSITIONS",),
+    "account_info": ("IBKR_FLEX_QUERY_ID_ACCOUNT_INFO",),
+}
+
+SECTION_ROW_NAMES = {
+    "TradeConfirms": "TradeConfirm",
+    "CashTransactions": "CashTransaction",
+    "OpenPositions": "OpenPosition",
+    "OptionEAE": "OptionEAE",
+    "AccountInformation": "AccountInformation",
+}
+
+DATE_ATTRIBUTES = ("dateTime", "tradeDate", "reportDate", "date")
+SYMBOL_ATTRIBUTES = ("underlyingSymbol", "symbol")
+
+
+class FlexProbeError(RuntimeError):
+    """Raised when a Flex probe cannot complete safely."""
+
+
+@dataclass(frozen=True)
+class QueryConfig:
+    """Configured Flex query name and ID."""
+
+    name: str
+    query_id: str
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--account", help="Filter rows to one IBKR accountId")
+    parser.add_argument("--from", dest="from_date", type=parse_iso_date, help="Statement start date, YYYY-MM-DD")
+    parser.add_argument("--to", dest="to_date", type=parse_iso_date, help="Statement end date, YYYY-MM-DD")
+    parser.add_argument("--synthetic", action="store_true", help="Read tmp/flex/synthetic_*.xml instead of IBKR")
+    parser.add_argument("--poll-seconds", type=int, default=5, help="Seconds between GetStatement polls")
+    parser.add_argument("--max-polls", type=int, default=24, help="Maximum GetStatement polls before failing")
+    return parser.parse_args(argv)
+
+
+def parse_iso_date(value: str) -> date:
+    """Parse an ISO calendar date for CLI flags."""
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"invalid date {value!r}; expected YYYY-MM-DD") from exc
+
+
+def warn_if_window_exceeds_limit(start: date | None, end: date | None) -> None:
+    """Warn when the requested Flex date range exceeds IBKR's 365-day window."""
+    if start and end and (end - start).days > 365:
+        print(
+            "warning: IBKR Flex date ranges are limited to 365 days; split this request if live probing fails",
+            file=sys.stderr,
+        )
+
+
+def query_configs_from_env() -> list[QueryConfig]:
+    """Read available Flex query IDs from environment variables."""
+    configs: list[QueryConfig] = []
+    for name, env_names in QUERY_ENV_VARS.items():
+        query_id = next((os.environ.get(env_name) for env_name in env_names if os.environ.get(env_name)), None)
+        if query_id:
+            configs.append(QueryConfig(name=name, query_id=query_id))
+    return configs
+
+
+def ensure_synthetic_fixtures() -> list[Path]:
+    """Return synthetic fixtures, generating them when absent."""
+    paths = sorted(OUTPUT_DIR.glob("synthetic_*.xml"))
+    if paths:
+        return paths
+    from flex_synthetic import write_synthetic_files
+
+    print("No synthetic fixtures found; generating tmp/flex/synthetic_*.xml", file=sys.stderr)
+    return sorted(write_synthetic_files(OUTPUT_DIR))
+
+
+def request_xml(url: str, params: dict[str, str], timeout_seconds: int = 30) -> Element:
+    """GET a Flex endpoint and return the XML root, raising clear errors."""
+    safe_params = {key: ("***" if key == "t" else value) for key, value in params.items()}
+    print(f"GET {url}?{urlencode(safe_params)}", file=sys.stderr)
+    response = requests.get(url, params=params, timeout=timeout_seconds)
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        raise FlexProbeError(f"HTTP error from IBKR Flex: {exc}") from exc
+    return parse_xml_bytes(response.content, source=url)
+
+
+def parse_xml_bytes(content: bytes, *, source: str) -> Element:
+    """Parse XML bytes and raise a source-qualified error on failure."""
+    try:
+        return ElementTree.fromstring(content)
+    except ParseError as exc:
+        raise FlexProbeError(f"XML parse error in {source}: {exc}") from exc
+
+
+def child_text(root: Element, name: str) -> str | None:
+    """Return direct or descendant child text for a Flex response node."""
+    child = root.find(f".//{name}")
+    if child is None or child.text is None:
+        return None
+    return child.text.strip()
+
+
+def flex_error(root: Element) -> tuple[str | None, str | None]:
+    """Return Flex error code and message when present."""
+    return child_text(root, "ErrorCode"), child_text(root, "ErrorMessage")
+
+
+def send_flex_request(config: QueryConfig, token: str, start: date | None, end: date | None) -> str:
+    """Call SendRequest and return the Flex reference code."""
+    params = {"t": token, "q": config.query_id, "v": "3"}
+    if start:
+        params["startdate"] = start.strftime("%Y%m%d")
+    if end:
+        params["enddate"] = end.strftime("%Y%m%d")
+    root = request_xml(SEND_REQUEST_URL, params)
+    error_code, error_message = flex_error(root)
+    if error_code and error_code != "0":
+        raise FlexProbeError(f"SendRequest failed for {config.name}: {error_code} {error_message or ''}".strip())
+    reference_code = child_text(root, "ReferenceCode")
+    if not reference_code:
+        raise FlexProbeError(f"SendRequest for {config.name} did not return a ReferenceCode")
+    return reference_code
+
+
+def get_statement(config: QueryConfig, token: str, reference_code: str, poll_seconds: int, max_polls: int) -> bytes:
+    """Poll GetStatement until the Flex XML statement is ready."""
+    params = {"t": token, "q": reference_code, "v": "3"}
+    for attempt in range(1, max_polls + 1):
+        response = requests.get(GET_STATEMENT_URL, params=params, timeout=60)
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            raise FlexProbeError(f"HTTP error from GetStatement for {config.name}: {exc}") from exc
+        root = parse_xml_bytes(response.content, source=f"GetStatement {config.name}")
+        error_code, error_message = flex_error(root)
+        if error_code == "1019":
+            print(
+                f"{config.name}: statement generation in progress (poll {attempt}/{max_polls}); waiting",
+                file=sys.stderr,
+            )
+            time.sleep(poll_seconds)
+            continue
+        if error_code and error_code != "0":
+            raise FlexProbeError(f"GetStatement failed for {config.name}: {error_code} {error_message or ''}".strip())
+        return response.content
+    raise FlexProbeError(f"GetStatement timed out for {config.name} after {max_polls} polls")
+
+
+def fetch_live_xml(configs: list[QueryConfig], token: str, args: argparse.Namespace) -> list[Path]:
+    """Fetch configured live Flex queries and dump raw XML to tmp/flex."""
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    paths: list[Path] = []
+    for config in configs:
+        print(f"Requesting Flex query {config.name}", file=sys.stderr)
+        reference_code = send_flex_request(config, token, args.from_date, args.to_date)
+        content = get_statement(config, token, reference_code, args.poll_seconds, args.max_polls)
+        path = OUTPUT_DIR / f"{config.name}_{timestamp}.xml"
+        path.write_bytes(content)
+        print(f"Wrote raw Flex XML to {path}", file=sys.stderr)
+        paths.append(path)
+    return paths
+
+
+def iter_section_rows(root: Element) -> Iterable[tuple[str, Element]]:
+    """Yield known Flex section row elements from a parsed document."""
+    for section_name, row_name in SECTION_ROW_NAMES.items():
+        for section in root.iter(section_name):
+            for row in section:
+                if row.tag == row_name:
+                    yield section_name, row
+
+
+def row_date(attrs: dict[str, str]) -> date | None:
+    """Extract a best-effort date from common Flex attributes."""
+    for attr in DATE_ATTRIBUTES:
+        raw_value = attrs.get(attr)
+        if not raw_value:
+            continue
+        value = raw_value.split(";", maxsplit=1)[0]
+        for fmt in ("%Y-%m-%d", "%Y%m%d"):
+            try:
+                return datetime.strptime(value, fmt).date()
+            except ValueError:
+                continue
+    return None
+
+
+def decimal_attr(attrs: dict[str, str], name: str) -> Decimal:
+    """Parse a Decimal XML attribute, returning zero for missing values."""
+    value = attrs.get(name)
+    if value in (None, ""):
+        return Decimal("0")
+    try:
+        return Decimal(value.replace(",", ""))
+    except (InvalidOperation, AttributeError) as exc:
+        raise FlexProbeError(f"invalid decimal for {name}: {value!r}") from exc
+
+
+def display_decimal(value: Decimal) -> str:
+    """Format a Decimal for summary display using cents."""
+    return str(value.quantize(MONEY_DISPLAY))
+
+
+def update_scenario_totals(
+    scenario_summaries: dict[str, dict[str, Decimal | int]],
+    scenario: str,
+    cash_flow: Decimal,
+    realized_pnl: Decimal,
+    row_count_increment: int,
+) -> None:
+    """Accumulate per-scenario financial totals."""
+    summary = scenario_summaries[scenario]
+    summary["rows"] = int(summary["rows"]) + row_count_increment
+    summary["cash_flow"] = Decimal(summary["cash_flow"]) + cash_flow
+    summary["fifoPnlRealized"] = Decimal(summary["fifoPnlRealized"]) + realized_pnl
+
+
+def summarize_flex_xml(paths: Iterable[Path], account_id: str | None = None) -> dict[str, Any]:
+    """Parse Flex XML files and return a dict summary for Phase 0 verification."""
+    section_counts: dict[str, int] = defaultdict(int)
+    symbols: set[str] = set()
+    dates: list[date] = []
+    total_notional = Decimal("0")
+    fifo_pnl_realized = Decimal("0")
+    trade_cash_flow = Decimal("0")
+    cash_transaction_amount = Decimal("0")
+    scenario_summaries: dict[str, dict[str, Decimal | int]] = defaultdict(
+        lambda: {"rows": 0, "cash_flow": Decimal("0"), "fifoPnlRealized": Decimal("0")}
+    )
+    files: list[str] = []
+
+    for path in paths:
+        files.append(str(path))
+        try:
+            root = ElementTree.parse(path).getroot()
+        except ParseError as exc:
+            raise FlexProbeError(f"XML parse error in {path}: {exc}") from exc
+        for section_name, row in iter_section_rows(root):
+            attrs = dict(row.attrib)
+            if account_id and attrs.get("accountId") != account_id:
+                continue
+            section_counts[section_name] += 1
+            scenario = attrs.get("scenario", "unclassified")
+            for attr in SYMBOL_ATTRIBUTES:
+                symbol = attrs.get(attr)
+                if symbol:
+                    symbols.add(symbol.strip())
+                    break
+            parsed_date = row_date(attrs)
+            if parsed_date:
+                dates.append(parsed_date)
+
+            realized = decimal_attr(attrs, "fifoPnlRealized")
+            fifo_pnl_realized += realized
+
+            if section_name == "TradeConfirms":
+                quantity = abs(decimal_attr(attrs, "quantity"))
+                price = abs(decimal_attr(attrs, "tradePrice") or decimal_attr(attrs, "price"))
+                multiplier = abs(decimal_attr(attrs, "multiplier") or Decimal("100"))
+                row_notional = quantity * price * multiplier
+                net_cash = decimal_attr(attrs, "netCash")
+                total_notional += row_notional
+                trade_cash_flow += net_cash
+                update_scenario_totals(scenario_summaries, scenario, net_cash, realized, 1)
+            elif section_name == "CashTransactions":
+                cash_transaction_amount += decimal_attr(attrs, "amount")
+                update_scenario_totals(scenario_summaries, scenario, Decimal("0"), Decimal("0"), 1)
+            else:
+                update_scenario_totals(scenario_summaries, scenario, Decimal("0"), realized, 1)
+
+    scenario_output = {
+        scenario: {
+            "rows": totals["rows"],
+            "cash_flow": display_decimal(Decimal(totals["cash_flow"])),
+            "fifoPnlRealized": display_decimal(Decimal(totals["fifoPnlRealized"])),
+        }
+        for scenario, totals in sorted(scenario_summaries.items())
+    }
+
+    return {
+        "files": files,
+        "row_counts": dict(sorted(section_counts.items())),
+        "distinct_symbols": sorted(symbols),
+        "date_range": {
+            "from": min(dates).isoformat() if dates else None,
+            "to": max(dates).isoformat() if dates else None,
+        },
+        "total_notional": display_decimal(total_notional),
+        "sum_fifoPnlRealized": display_decimal(fifo_pnl_realized),
+        "sum_cash_flow": display_decimal(trade_cash_flow),
+        "sum_cash_transactions": display_decimal(cash_transaction_amount),
+        "scenario_summaries": scenario_output,
+    }
+
+
+def select_input_files(args: argparse.Namespace) -> list[Path]:
+    """Return XML files to parse, using synthetic fallback when live credentials are absent."""
+    token = os.environ.get("IBKR_FLEX_TOKEN")
+    configs = query_configs_from_env()
+    if args.synthetic:
+        return ensure_synthetic_fixtures()
+    if not token or not configs:
+        print(
+            "IBKR_FLEX_TOKEN or query IDs are not configured; falling back to synthetic fixtures",
+            file=sys.stderr,
+        )
+        return ensure_synthetic_fixtures()
+    return fetch_live_xml(configs, token, args)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Run the Flex probe and print exactly one final summary dict to stdout."""
+    args = parse_args(argv)
+    warn_if_window_exceeds_limit(args.from_date, args.to_date)
+    try:
+        paths = select_input_files(args)
+        summary = summarize_flex_xml(paths, args.account)
+    except (FlexProbeError, requests.RequestException, OSError) as exc:
+        print(f"flex_probe error: {exc}", file=sys.stderr)
+        return 1
+    print(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apps/backend/scripts/flex_synthetic.py
+++ b/apps/backend/scripts/flex_synthetic.py
@@ -1,0 +1,644 @@
+"""Generate synthetic IBKR Flex XML fixtures for options income Phase 0."""
+
+from __future__ import annotations
+
+import sys
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable
+from xml.etree.ElementTree import Element, ElementTree, SubElement, indent
+
+MONEY = Decimal("0.000001")
+DEFAULT_OUTPUT_DIR = Path("tmp/flex")
+ACCOUNT_ID = "U1234567"
+CURRENCY = "USD"
+
+
+def decimal_text(value: str | Decimal) -> str:
+    """Return a six-decimal string suitable for persisted monetary fixtures."""
+    return str(Decimal(value).quantize(MONEY))
+
+
+def base_attrs(trade_id: str, transaction_id: str) -> dict[str, str]:
+    """Return common Flex attributes required on every synthetic row."""
+    return {
+        "accountId": ACCOUNT_ID,
+        "tradeID": trade_id,
+        "transactionID": transaction_id,
+        "currency": CURRENCY,
+    }
+
+
+def flex_root(statement_name: str) -> Element:
+    """Create the shared Flex response/statement envelope."""
+    root = Element("FlexQueryResponse", {"queryName": statement_name})
+    statements = SubElement(root, "FlexStatements", {"count": "1"})
+    SubElement(
+        statements,
+        "FlexStatement",
+        {
+            "accountId": ACCOUNT_ID,
+            "fromDate": "2025-01-01",
+            "toDate": "2025-12-31",
+            "period": "YearToDate",
+        },
+    )
+    return root
+
+
+def statement(root: Element) -> Element:
+    """Return the single FlexStatement element from a synthetic root."""
+    flex_statements = root.find("FlexStatements")
+    if flex_statements is None:
+        raise ValueError("synthetic root is missing FlexStatements")
+    flex_statement = flex_statements.find("FlexStatement")
+    if flex_statement is None:
+        raise ValueError("synthetic root is missing FlexStatement")
+    return flex_statement
+
+
+def option_trade(
+    *,
+    trade_id: str,
+    transaction_id: str,
+    scenario: str,
+    date_time: str,
+    symbol: str,
+    underlying_symbol: str,
+    put_call: str,
+    strike: str,
+    expiry: str,
+    quantity: str,
+    trade_price: str,
+    proceeds: str,
+    commission: str,
+    net_cash: str,
+    fifo_pnl_realized: str,
+    buy_sell: str,
+    open_close_indicator: str,
+    notes: str = "",
+) -> dict[str, str]:
+    """Return one TradeConfirm-shaped option row."""
+    attrs = base_attrs(trade_id, transaction_id)
+    attrs.update(
+        {
+            "scenario": scenario,
+            "assetCategory": "OPT",
+            "symbol": symbol,
+            "underlyingSymbol": underlying_symbol,
+            "putCall": put_call,
+            "strike": decimal_text(strike),
+            "expiry": expiry,
+            "multiplier": decimal_text("100"),
+            "quantity": decimal_text(quantity),
+            "tradePrice": decimal_text(trade_price),
+            "price": decimal_text(trade_price),
+            "proceeds": decimal_text(proceeds),
+            "commission": decimal_text(commission),
+            "ibCommission": decimal_text(commission),
+            "netCash": decimal_text(net_cash),
+            "fifoPnlRealized": decimal_text(fifo_pnl_realized),
+            "buySell": buy_sell,
+            "openCloseIndicator": open_close_indicator,
+            "dateTime": date_time,
+            "tradeDate": date_time[:10].replace("-", ""),
+            "tradeTime": date_time[11:].replace(":", ""),
+            "description": notes,
+        }
+    )
+    return attrs
+
+
+def cash_event(
+    *,
+    trade_id: str,
+    transaction_id: str,
+    scenario: str,
+    date_time: str,
+    event_type: str,
+    description: str,
+    amount: str,
+) -> dict[str, str]:
+    """Return one CashTransaction-shaped row."""
+    attrs = base_attrs(trade_id, transaction_id)
+    attrs.update(
+        {
+            "scenario": scenario,
+            "dateTime": date_time,
+            "date": date_time[:10].replace("-", ""),
+            "type": event_type,
+            "description": description,
+            "amount": decimal_text(amount),
+            "netCash": decimal_text(amount),
+        }
+    )
+    return attrs
+
+
+def eae_event(
+    *,
+    trade_id: str,
+    transaction_id: str,
+    scenario: str,
+    date_time: str,
+    symbol: str,
+    underlying_symbol: str,
+    put_call: str,
+    strike: str,
+    expiry: str,
+    quantity: str,
+    event_type: str,
+    fifo_pnl_realized: str,
+    proceeds: str,
+    notes: str,
+) -> dict[str, str]:
+    """Return one OptionEAE-shaped exercise, assignment, or expiration row."""
+    attrs = base_attrs(trade_id, transaction_id)
+    attrs.update(
+        {
+            "scenario": scenario,
+            "dateTime": date_time,
+            "reportDate": date_time[:10].replace("-", ""),
+            "symbol": symbol,
+            "underlyingSymbol": underlying_symbol,
+            "putCall": put_call,
+            "strike": decimal_text(strike),
+            "expiry": expiry,
+            "multiplier": decimal_text("100"),
+            "quantity": decimal_text(quantity),
+            "type": event_type,
+            "action": event_type,
+            "fifoPnlRealized": decimal_text(fifo_pnl_realized),
+            "proceeds": decimal_text(proceeds),
+            "description": notes,
+        }
+    )
+    return attrs
+
+
+def write_xml(path: Path, root: Element) -> None:
+    """Write an XML document with deterministic formatting."""
+    indent(root, space="  ")
+    ElementTree(root).write(path, encoding="utf-8", xml_declaration=True)
+
+
+def write_trades(path: Path) -> None:
+    """Write synthetic TradeConfirms covering Phase 0 scenarios."""
+    root = flex_root("synthetic_trades")
+    section = SubElement(statement(root), "TradeConfirms")
+    rows = [
+        option_trade(
+            trade_id="T-JONY-001",
+            transaction_id="X-JONY-001",
+            scenario="jony_worked_example",
+            date_time="2025-01-17;093000",
+            symbol="SPY   250321P00550000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="550",
+            expiry="20250321",
+            quantity="-10",
+            trade_price="4.00",
+            proceeds="4000",
+            commission="0",
+            net_cash="4000",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Open short leg of bullish put spread",
+        ),
+        option_trade(
+            trade_id="T-JONY-002",
+            transaction_id="X-JONY-002",
+            scenario="jony_worked_example",
+            date_time="2025-01-17;093002",
+            symbol="SPY   250321P00545000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="545",
+            expiry="20250321",
+            quantity="10",
+            trade_price="1.00",
+            proceeds="-1000",
+            commission="0",
+            net_cash="-1000",
+            fifo_pnl_realized="0",
+            buy_sell="BUY",
+            open_close_indicator="O",
+            notes="Open long leg of bullish put spread",
+        ),
+        option_trade(
+            trade_id="T-JONY-003",
+            transaction_id="X-JONY-003",
+            scenario="jony_worked_example",
+            date_time="2025-02-14;101500",
+            symbol="SPY   250321P00550000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="550",
+            expiry="20250321",
+            quantity="10",
+            trade_price="5.00",
+            proceeds="-5000",
+            commission="0",
+            net_cash="-5000",
+            fifo_pnl_realized="-1000",
+            buy_sell="BUY",
+            open_close_indicator="C",
+            notes="Roll close losing short leg",
+        ),
+        option_trade(
+            trade_id="T-JONY-004",
+            transaction_id="X-JONY-004",
+            scenario="jony_worked_example",
+            date_time="2025-02-14;101501",
+            symbol="SPY   250418P00535000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="535",
+            expiry="20250418",
+            quantity="-10",
+            trade_price="5.20",
+            proceeds="5200",
+            commission="0",
+            net_cash="5200",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Roll open lower strike short leg for incremental credit",
+        ),
+        option_trade(
+            trade_id="T-JONY-005",
+            transaction_id="X-JONY-005",
+            scenario="jony_worked_example",
+            date_time="2025-03-21;154500",
+            symbol="SPY   250418P00535000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="535",
+            expiry="20250418",
+            quantity="10",
+            trade_price="3.20",
+            proceeds="-3200",
+            commission="0",
+            net_cash="-3200",
+            fifo_pnl_realized="2000",
+            buy_sell="BUY",
+            open_close_indicator="C",
+            notes="Close rolled short leg",
+        ),
+        option_trade(
+            trade_id="T-JONY-006",
+            transaction_id="X-JONY-006",
+            scenario="jony_worked_example",
+            date_time="2025-03-21;154501",
+            symbol="SPY   250321P00545000",
+            underlying_symbol="SPY",
+            put_call="P",
+            strike="545",
+            expiry="20250321",
+            quantity="-10",
+            trade_price="2.70",
+            proceeds="2700",
+            commission="0",
+            net_cash="2700",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="C",
+            notes="Close long leg; pair leaves final close cash flow at -500",
+        ),
+        option_trade(
+            trade_id="T-CSP-WORTHLESS-001",
+            transaction_id="X-CSP-WORTHLESS-001",
+            scenario="cash_secured_put_expired_worthless",
+            date_time="2025-04-01;100000",
+            symbol="MSFT  250516P00390000",
+            underlying_symbol="MSFT",
+            put_call="P",
+            strike="390",
+            expiry="20250516",
+            quantity="-1",
+            trade_price="2.50",
+            proceeds="250",
+            commission="0",
+            net_cash="250",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Open CSP later expiring worthless",
+        ),
+        option_trade(
+            trade_id="T-CSP-WORTHLESS-002",
+            transaction_id="X-CSP-WORTHLESS-002",
+            scenario="cash_secured_put_expired_worthless",
+            date_time="2025-05-16;160000",
+            symbol="MSFT  250516P00390000",
+            underlying_symbol="MSFT",
+            put_call="P",
+            strike="390",
+            expiry="20250516",
+            quantity="1",
+            trade_price="0",
+            proceeds="0",
+            commission="0",
+            net_cash="0",
+            fifo_pnl_realized="250",
+            buy_sell="BUY",
+            open_close_indicator="C",
+            notes="Expiration realizes the original CSP credit",
+        ),
+        option_trade(
+            trade_id="T-CSP-ASSIGNED-001",
+            transaction_id="X-CSP-ASSIGNED-001",
+            scenario="cash_secured_put_assigned",
+            date_time="2025-06-03;110000",
+            symbol="AAPL  250620P00125000",
+            underlying_symbol="AAPL",
+            put_call="P",
+            strike="125",
+            expiry="20250620",
+            quantity="-1",
+            trade_price="1.80",
+            proceeds="180",
+            commission="0",
+            net_cash="180",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Open CSP that is later assigned",
+        ),
+        option_trade(
+            trade_id="T-CSP-ASSIGNED-002",
+            transaction_id="X-CSP-ASSIGNED-002",
+            scenario="cash_secured_put_assigned",
+            date_time="2025-06-20;160000",
+            symbol="AAPL  250620P00125000",
+            underlying_symbol="AAPL",
+            put_call="P",
+            strike="125",
+            expiry="20250620",
+            quantity="1",
+            trade_price="125",
+            proceeds="-12500",
+            commission="0",
+            net_cash="-12500",
+            fifo_pnl_realized="180",
+            buy_sell="BUY",
+            open_close_indicator="C",
+            notes="Assignment cash flow represents share purchase funding",
+        ),
+        option_trade(
+            trade_id="T-VERTICAL-001",
+            transaction_id="X-VERTICAL-001",
+            scenario="vertical_spread_max_profit",
+            date_time="2025-07-08;103000",
+            symbol="NVDA  250815P00100000",
+            underlying_symbol="NVDA",
+            put_call="P",
+            strike="100",
+            expiry="20250815",
+            quantity="-1",
+            trade_price="4.00",
+            proceeds="400",
+            commission="0",
+            net_cash="400",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Open credit spread short leg",
+        ),
+        option_trade(
+            trade_id="T-VERTICAL-002",
+            transaction_id="X-VERTICAL-002",
+            scenario="vertical_spread_max_profit",
+            date_time="2025-07-08;103001",
+            symbol="NVDA  250815P00095000",
+            underlying_symbol="NVDA",
+            put_call="P",
+            strike="95",
+            expiry="20250815",
+            quantity="1",
+            trade_price="1.00",
+            proceeds="-100",
+            commission="0",
+            net_cash="-100",
+            fifo_pnl_realized="0",
+            buy_sell="BUY",
+            open_close_indicator="O",
+            notes="Open credit spread long leg",
+        ),
+        option_trade(
+            trade_id="T-VERTICAL-003",
+            transaction_id="X-VERTICAL-003",
+            scenario="vertical_spread_max_profit",
+            date_time="2025-08-15;160000",
+            symbol="NVDA  250815P00100000",
+            underlying_symbol="NVDA",
+            put_call="P",
+            strike="100",
+            expiry="20250815",
+            quantity="1",
+            trade_price="0",
+            proceeds="0",
+            commission="0",
+            net_cash="0",
+            fifo_pnl_realized="300",
+            buy_sell="BUY",
+            open_close_indicator="C",
+            notes="Spread expires at max profit",
+        ),
+        option_trade(
+            trade_id="T-LONE-001",
+            transaction_id="X-LONE-001",
+            scenario="ungrouped_lone_trade",
+            date_time="2025-09-10;143000",
+            symbol="TSLA  251017C00300000",
+            underlying_symbol="TSLA",
+            put_call="C",
+            strike="300",
+            expiry="20251017",
+            quantity="-1",
+            trade_price="0.75",
+            proceeds="75",
+            commission="0",
+            net_cash="75",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Ungrouped lone covered-call candidate",
+        ),
+    ]
+    for row in rows:
+        SubElement(section, "TradeConfirm", row)
+    write_xml(path, root)
+
+
+def write_cash(path: Path) -> None:
+    """Write synthetic CashTransactions rows."""
+    root = flex_root("synthetic_cash")
+    section = SubElement(statement(root), "CashTransactions")
+    rows = [
+        cash_event(
+            trade_id="C-JONY-001",
+            transaction_id="CX-JONY-001",
+            scenario="jony_worked_example",
+            date_time="2025-03-21;170000",
+            event_type="Broker Interest Received",
+            description="Non-trade cash event kept separate from option trade cash flow",
+            amount="0",
+        ),
+        cash_event(
+            trade_id="C-ASSIGN-001",
+            transaction_id="CX-ASSIGN-001",
+            scenario="cash_secured_put_assigned",
+            date_time="2025-06-23;090000",
+            event_type="Option Assignment",
+            description="Assignment funding: 100 AAPL shares purchased at 125.00",
+            amount="-12500",
+        ),
+    ]
+    for row in rows:
+        SubElement(section, "CashTransaction", row)
+    write_xml(path, root)
+
+
+def write_positions(path: Path) -> None:
+    """Write synthetic OpenPositions rows."""
+    root = flex_root("synthetic_positions")
+    section = SubElement(statement(root), "OpenPositions")
+    row = base_attrs("P-LONE-001", "PX-LONE-001")
+    row.update(
+        {
+            "scenario": "ungrouped_lone_trade",
+            "symbol": "TSLA  251017C00300000",
+            "underlyingSymbol": "TSLA",
+            "putCall": "C",
+            "strike": decimal_text("300"),
+            "expiry": "20251017",
+            "multiplier": decimal_text("100"),
+            "position": decimal_text("-1"),
+            "quantity": decimal_text("-1"),
+            "costBasis": decimal_text("-75"),
+            "costPrice": decimal_text("0.75"),
+            "markPrice": decimal_text("0.80"),
+            "fifoPnlUnrealized": decimal_text("-5"),
+        }
+    )
+    SubElement(section, "OpenPosition", row)
+    write_xml(path, root)
+
+
+def write_option_eae(path: Path) -> None:
+    """Write synthetic OptionEAE lifecycle events."""
+    root = flex_root("synthetic_option_eae")
+    section = SubElement(statement(root), "OptionEAE")
+    rows = [
+        eae_event(
+            trade_id="E-CSP-WORTHLESS-001",
+            transaction_id="EX-CSP-WORTHLESS-001",
+            scenario="cash_secured_put_expired_worthless",
+            date_time="2025-05-16;160000",
+            symbol="MSFT  250516P00390000",
+            underlying_symbol="MSFT",
+            put_call="P",
+            strike="390",
+            expiry="20250516",
+            quantity="1",
+            event_type="Expiration",
+            fifo_pnl_realized="250",
+            proceeds="0",
+            notes="Short put expired worthless; realized P&L equals opening credit",
+        ),
+        eae_event(
+            trade_id="E-CSP-ASSIGNED-001",
+            transaction_id="EX-CSP-ASSIGNED-001",
+            scenario="cash_secured_put_assigned",
+            date_time="2025-06-20;160000",
+            symbol="AAPL  250620P00125000",
+            underlying_symbol="AAPL",
+            put_call="P",
+            strike="125",
+            expiry="20250620",
+            quantity="1",
+            event_type="Assignment",
+            fifo_pnl_realized="180",
+            proceeds="-12500",
+            notes="Assignment creates stock-purchase cash flow; Phase 1 must tag specially",
+        ),
+        eae_event(
+            trade_id="E-VERTICAL-001",
+            transaction_id="EX-VERTICAL-001",
+            scenario="vertical_spread_max_profit",
+            date_time="2025-08-15;160000",
+            symbol="NVDA  250815P00100000",
+            underlying_symbol="NVDA",
+            put_call="P",
+            strike="100",
+            expiry="20250815",
+            quantity="1",
+            event_type="Expiration",
+            fifo_pnl_realized="300",
+            proceeds="0",
+            notes="Vertical credit spread expires at max profit",
+        ),
+    ]
+    for row in rows:
+        SubElement(section, "OptionEAE", row)
+    write_xml(path, root)
+
+
+def write_account_info(path: Path) -> None:
+    """Write synthetic AccountInformation rows."""
+    root = flex_root("synthetic_account_info")
+    section = SubElement(statement(root), "AccountInformation")
+    row = base_attrs("A-INFO-001", "AX-INFO-001")
+    row.update(
+        {
+            "scenario": "account_snapshot",
+            "accountType": "INDIVIDUAL",
+            "baseCurrency": CURRENCY,
+            "currency": CURRENCY,
+            "dateTime": "2025-09-10;170000",
+            "marginRequirement": decimal_text("15000"),
+            "maintenanceMarginRequirement": decimal_text("15000"),
+            "buyingPower": decimal_text("85000"),
+            "availableFunds": decimal_text("85000"),
+            "netLiquidation": decimal_text("100000"),
+        }
+    )
+    SubElement(section, "AccountInformation", row)
+    write_xml(path, root)
+
+
+def write_synthetic_files(output_dir: Path = DEFAULT_OUTPUT_DIR) -> list[Path]:
+    """Write all synthetic Flex fixtures and return their paths."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    writers = {
+        "synthetic_trades.xml": write_trades,
+        "synthetic_cash.xml": write_cash,
+        "synthetic_positions.xml": write_positions,
+        "synthetic_option_eae.xml": write_option_eae,
+        "synthetic_account_info.xml": write_account_info,
+    }
+    paths: list[Path] = []
+    for filename, writer in writers.items():
+        path = output_dir / filename
+        writer(path)
+        paths.append(path)
+    return paths
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Generate synthetic fixtures under tmp/flex by default."""
+    args = list(argv or [])
+    output_dir = Path(args[0]) if args else DEFAULT_OUTPUT_DIR
+    paths = write_synthetic_files(output_dir)
+    print(
+        f"Wrote {len(paths)} synthetic Flex XML files to {output_dir}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apps/backend/tests/test_flex_synthetic.py
+++ b/apps/backend/tests/test_flex_synthetic.py
@@ -1,0 +1,26 @@
+"""Smoke tests for synthetic IBKR Flex fixtures."""
+
+from __future__ import annotations
+
+import shutil
+from decimal import Decimal
+from pathlib import Path
+
+from scripts.flex_probe import summarize_flex_xml
+from scripts.flex_synthetic import write_synthetic_files
+
+
+def test_jony_worked_example_totals() -> None:
+    """The synthetic harness preserves Jony's cash-vs-P&L worked example."""
+    output_dir = Path("tmp/test-flex-synthetic")
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    try:
+        paths = write_synthetic_files(output_dir)
+        summary = summarize_flex_xml(paths)
+        jony = summary["scenario_summaries"]["jony_worked_example"]
+        assert Decimal(jony["cash_flow"]) == Decimal("2700.00")
+        assert Decimal(jony["fifoPnlRealized"]) == Decimal("1000.00")
+    finally:
+        if output_dir.exists():
+            shutil.rmtree(output_dir)

--- a/docs/options-flex-query-setup.md
+++ b/docs/options-flex-query-setup.md
@@ -1,0 +1,175 @@
+# IBKR Flex Query Setup for Options Income Dashboard
+
+This runbook is a one-time manual setup for Jony. The backend can run with synthetic fixtures before these steps are complete:
+
+```bash
+cd apps/backend
+uv run python scripts/flex_synthetic.py
+uv run python scripts/flex_probe.py --synthetic
+```
+
+## 1. Create the Flex Queries
+
+1. Sign in to IBKR Client Portal.
+2. Open **Performance & Reports → Flex Queries**.
+3. Choose **Create Flex Query**.
+4. Set **Format** to **XML** and enable **Flex Web Service** access.
+5. Create either one master query containing all sections below, or separate queries for Trades, Cash Transactions, Option EAE, Open Positions, and Account Information.
+6. Use a date period that fits Phase 0 validation, or rely on the probe's `--from YYYY-MM-DD --to YYYY-MM-DD` flags. IBKR enforces roughly a 365-day request window.
+7. Save each query and record its **Query ID**.
+
+## 2. Fields to Select
+
+The target mapping is documented in [Appendix A of the design doc](./options-income-dashboard-design.md#appendix-a-flex-field--schema-mapping). Select these fields where the IBKR UI exposes them.
+
+### Trades / Trade Confirms
+
+Tick at least:
+
+- `tradeID`
+- `transactionID`
+- `accountId`
+- `dateTime`, `tradeDate`, `tradeTime`
+- `symbol`
+- `underlyingSymbol`
+- `putCall`
+- `strike`
+- `expiry`
+- `multiplier`
+- `quantity`
+- `tradePrice` / `price`
+- `proceeds`
+- `commission` or `ibCommission`
+- `netCash`
+- `fifoPnlRealized`
+- `buySell`
+- `openCloseIndicator`
+- `currency`
+- optional audit fields: `ibExecID`, `orderID`, `description`, `assetCategory`, `conid`
+
+### Cash Transactions
+
+Tick at least:
+
+- `transactionID`
+- `accountId`
+- `dateTime` or `date`
+- `type`
+- `description`
+- `amount` or `netCash`
+- `currency`
+- optional audit fields: `tradeID`, `reportDate`
+
+### Options Exercises, Assignments, and Expirations (Option EAE)
+
+Tick at least:
+
+- `tradeID`
+- `transactionID`
+- `accountId`
+- `dateTime` or `reportDate`
+- `symbol`
+- `underlyingSymbol`
+- `putCall`
+- `strike`
+- `expiry`
+- `multiplier`
+- `quantity`
+- `type` or `action`
+- `proceeds`
+- `fifoPnlRealized`
+- `currency`
+- optional audit fields: `description`, `settlementDate`
+
+### Open Positions
+
+Tick at least:
+
+- `accountId`
+- `symbol`
+- `underlyingSymbol`
+- `putCall`
+- `strike`
+- `expiry`
+- `multiplier`
+- `position` or `quantity`
+- `costBasis`
+- `costPrice`
+- `markPrice`
+- `fifoPnlUnrealized`
+- `currency`
+- optional audit fields: `conid`, `description`, `openDateTime`
+
+### Account Information
+
+Tick at least:
+
+- `accountId`
+- `baseCurrency` or `currency`
+- `netLiquidation`
+- `availableFunds`
+- `buyingPower`
+- `maintenanceMarginRequirement` or `marginRequirement`
+
+## 3. Obtain the Flex Web Service Token
+
+1. Open **Performance & Reports → Flex Web Service Configuration**.
+2. Generate or copy the current token.
+3. If IBKR asks for IP restrictions, add the public IP of the machine that will run the worker. For local Phase 0, add Jony's current public IP if whitelisting is enabled.
+4. Treat the token like a password. Do not paste it into GitHub issues, PRs, logs, or committed files.
+
+## 4. Configure Local Environment
+
+Create or update `apps/backend/.env` (never commit it):
+
+```dotenv
+IBKR_FLEX_TOKEN=...
+IBKR_FLEX_QUERY_ID_TRADES=...
+IBKR_FLEX_QUERY_ID_OPTION_EAE=...
+IBKR_FLEX_QUERY_ID_CASH=...
+IBKR_FLEX_QUERY_ID_POSITIONS=...
+IBKR_FLEX_QUERY_ID_ACCOUNT_INFO=...
+```
+
+If a single master Flex query contains all sections, it is acceptable to reuse the same query ID for multiple variables during Phase 0.
+
+For production/CI-style environments, set secrets instead of committing values:
+
+```bash
+gh secret set IBKR_FLEX_TOKEN
+gh secret set IBKR_FLEX_QUERY_ID_TRADES
+gh secret set IBKR_FLEX_QUERY_ID_OPTION_EAE
+gh secret set IBKR_FLEX_QUERY_ID_CASH
+gh secret set IBKR_FLEX_QUERY_ID_POSITIONS
+gh secret set IBKR_FLEX_QUERY_ID_ACCOUNT_INFO
+```
+
+## 5. Verify the Probe
+
+Synthetic first:
+
+```bash
+cd apps/backend
+uv run python scripts/flex_synthetic.py
+uv run python scripts/flex_probe.py --synthetic
+```
+
+Live probe after the token and query IDs are configured:
+
+```bash
+cd apps/backend
+set -a && source .env && set +a
+uv run python scripts/flex_probe.py --account U1234567 --from 2025-01-01 --to 2025-12-31
+```
+
+The probe writes raw XML to `apps/backend/tmp/flex/` and prints one Python dict summary. Confirm that `row_counts` includes `TradeConfirms`, `CashTransactions`, `OpenPositions`, `OptionEAE`, and `AccountInformation`, then compare one known rolled spread against the broker statement to the cent.
+
+## 6. Troubleshooting
+
+- **No token configured:** `flex_probe.py` intentionally falls back to synthetic fixtures so Phase 1 can continue in parallel.
+- **Token expired or revoked:** generate a new token in Flex Web Service Configuration and update `apps/backend/.env` or GitHub secrets.
+- **IP not whitelisted:** add the worker's current public IP in IBKR's Flex Web Service Configuration, or temporarily disable IP restriction if acceptable.
+- **Query ID typo:** re-copy the Query ID from the Flex Queries page and verify it is in the matching `IBKR_FLEX_QUERY_ID_*` variable.
+- **1019 Statement generation in progress:** the probe polls `GetStatement`; if it times out, retry with a smaller date range or increase `--max-polls`.
+- **365-day range failure:** split the date range into multiple runs.
+- **Missing fields:** edit the Flex Query and tick every field in Appendix A; rerun the probe and inspect `tmp/flex/*.xml`.

--- a/docs/options-income-dashboard-design.md
+++ b/docs/options-income-dashboard-design.md
@@ -945,3 +945,111 @@ Acceptance criteria:
 2. Decide the open questions above, especially roll window, matching preference, and backfill scope.
 3. After Phase 0, implement schema migrations and worker ingestion in small PRs.
 4. Build the `/options` replacement only after cooked monthly metrics exist, so Fenster can focus on UI fidelity instead of financial reconciliation logic.
+
+## Appendix A: Flex Field → Schema Mapping
+
+Phase 0 uses IBKR Flex XML as the source-of-truth probe format. Attribute availability can vary by account type and Flex UI version; if IBKR exposes an equivalent field with a slightly different name, keep the raw XML payload and normalize during Phase 1 ingestion.
+
+### TradeConfirms → `options_trades`
+
+| Flex XML attribute | Target column | Notes |
+|---|---|---|
+| `tradeID` | `options_trades.source_trade_id` | Primary broker trade identifier. |
+| `transactionID` | `options_trades.source_transaction_id` | Used with `tradeID` for idempotency. |
+| `ibExecID` | `options_trades.source_exec_id` | Optional execution-level uniqueness when available. |
+| `accountId` | `options_trades.account_id` | Also links to account configuration. |
+| `dateTime` | `options_trades.trade_time` | Prefer this over separate date/time fields. |
+| `tradeDate` | `options_trades.trade_date` | Fallback when `dateTime` is absent. |
+| `symbol` | `options_legs.option_symbol`; raw payload | IBKR option symbol can be retained for audit. |
+| `underlyingSymbol` | `options_legs.underlying_symbol` | Required for grouping and roll detection. |
+| `putCall` | `options_legs.right` | Normalize `P`/`PUT` to `put`, `C`/`CALL` to `call`. |
+| `strike` | `options_legs.strike` | Persist as `numeric(18,6)`. |
+| `expiry` | `options_legs.expiry` | Normalize `YYYYMMDD` to date. |
+| `multiplier` | `options_legs.multiplier` | Usually `100` for US equity options. |
+| `currency` | `options_trades.currency`; `options_legs.currency` | Default `USD` only when Flex omits it. |
+| `quantity` | `options_trades.quantity` | Preserve sign from IBKR; side is still normalized separately. |
+| `tradePrice` / `price` | `options_trades.price` | Prefer `tradePrice`; `price` is fallback in some exports. |
+| `proceeds` | `options_trades.gross_amount` | Broker-reported gross amount before commissions/fees. |
+| `commission` / `ibCommission` | `options_trades.commission` | Flex often emits `ibCommission`; map either name. |
+| `taxes` / fees fields | `options_trades.fees` | Not always present in Trades; retain raw payload for reconciliation. |
+| `netCash` | `options_trades.net_cash_flow` | Preferred cash-flow source. |
+| `fifoPnlRealized` | `options_trades.realized_pnl` | Canonical realized P&L per resolved decision §12.2. |
+| `buySell` | `options_trades.side` | Normalize `BUY`/`SELL`. |
+| `openCloseIndicator` | `options_trades.event_type` | `O` → `open`, `C` → `close`; EAE can override lifecycle events. |
+| all row attributes | `options_trades.raw_payload` | Preserve for audit and future field drift. |
+
+### CashTransactions → `options_cash_events`
+
+| Flex XML attribute | Target column | Notes |
+|---|---|---|
+| `transactionID` | `options_cash_events.source_transaction_id` | Primary idempotency key for cash rows. |
+| `accountId` | `options_cash_events.account_id` | Required for household account scope. |
+| `dateTime` | `options_cash_events.event_time` | Preferred timestamp when present. |
+| `date` / `reportDate` | `options_cash_events.event_date` | Fallback date. |
+| `type` | `options_cash_events.event_category`; raw payload | Normalize known option-related types; otherwise `other`. |
+| `description` | `options_cash_events.description` | Useful for assignment/exercise explanations. |
+| `amount` / `netCash` | `options_cash_events.amount` | Prefer `amount`; fallback to `netCash`. |
+| `currency` | `options_cash_events.currency` | Default `USD` only when Flex omits it. |
+| `tradeID` | `options_cash_events.raw_payload` | Flex may not emit this for every cash row; use only as a weak link. |
+| all row attributes | `options_cash_events.raw_payload` | Preserve full source row. |
+
+### OptionEAE → `options_trades` augmentation
+
+| Flex XML attribute | Target column | Notes |
+|---|---|---|
+| `tradeID` | `options_trades.source_trade_id` | Use for lifecycle trade rows when supplied. |
+| `transactionID` | `options_trades.source_transaction_id` | Use for idempotency and cash-event linkage. |
+| `accountId` | `options_trades.account_id` | Required account scope. |
+| `dateTime` / `reportDate` | `options_trades.trade_time`; `options_trades.trade_date` | Normalize lifecycle event date. |
+| `symbol` | `options_legs.option_symbol`; raw payload | Same leg-resolution path as TradeConfirms. |
+| `underlyingSymbol` | `options_legs.underlying_symbol` | Required for strategy grouping. |
+| `putCall` | `options_legs.right` | Normalize to enum. |
+| `strike` | `options_legs.strike` | Persist as `numeric(18,6)`. |
+| `expiry` | `options_legs.expiry` | Normalize to date. |
+| `multiplier` | `options_legs.multiplier` | Usually `100`. |
+| `quantity` | `options_trades.quantity` | Lifecycle quantity; sign conventions should be verified against real XML. |
+| `type` / `action` | `options_trades.event_type`; `raw_payload` flags | Map `Expiration` → `expire`, `Assignment` → `assign`, `Exercise` → `exercise`. |
+| `proceeds` | `options_trades.gross_amount`; `net_cash_flow` fallback | Assignments may represent stock settlement, so tag specially. |
+| `fifoPnlRealized` | `options_trades.realized_pnl` | Prefer Flex when present. |
+| `currency` | `options_trades.currency` | Default `USD` only when Flex omits it. |
+| all row attributes | `options_trades.raw_payload` | Preserve assignment/exercise/expiration flags. |
+
+### OpenPositions → `options_positions`
+
+| Flex XML attribute | Target column | Notes |
+|---|---|---|
+| `accountId` | `options_positions.account_id` | Required account scope. |
+| `symbol` | `options_legs.option_symbol`; raw payload | Resolve or create leg. |
+| `underlyingSymbol` | `options_legs.underlying_symbol` | Required leg attribute. |
+| `putCall` | `options_legs.right` | Normalize to enum. |
+| `strike` | `options_legs.strike` | Persist as `numeric(18,6)`. |
+| `expiry` | `options_legs.expiry` | Normalize to date. |
+| `multiplier` | `options_legs.multiplier` | Usually `100`. |
+| `position` / `quantity` | `options_positions.quantity_open` | Prefer `position`; fallback to `quantity`. |
+| `costBasis` | `options_positions.open_cash_flow`; raw payload | Flex cost basis is not always identical to original option cash flow; reconcile in Phase 1. |
+| `costPrice` | `options_positions.average_open_price` | Fallback when cost basis must be reconstructed. |
+| `markPrice` | `options_positions.raw_payload` | §6 table does not include mark price; propose later `mark_price numeric(18,6)` or keep in raw payload. |
+| `fifoPnlUnrealized` | `options_positions.raw_payload` | §6 table intentionally omits unrealized P&L; keep raw for future MTM add-on. |
+| margin fields if emitted | `options_positions.ib_margin_requirement` | Flex may not emit per-position margin; use account-level or IB Gateway fallback. |
+| all row attributes | future raw payload column or sync-run artifact | §6 `options_positions` currently lacks `raw_payload`; Phase 1 should add it if auditability is required. |
+
+### AccountInformation → `options_flex_sync_state` / sync metadata
+
+The current §6 table is named `options_sync_runs`, not `options_flex_sync_state`. Phase 1 should either store account snapshots in `options_sync_runs.metadata` or add an `options_margin_snapshots` / `options_account_snapshots` table if historical margin charts are required.
+
+| Flex XML attribute | Target column | Notes |
+|---|---|---|
+| `accountId` | `options_sync_runs.metadata.accountId` | Also identifies configured account. |
+| `baseCurrency` / `currency` | `options_sync_runs.metadata.currency` | Prefer `baseCurrency` when present. |
+| `marginRequirement` / `maintenanceMarginRequirement` | `options_sync_runs.metadata.marginRequirement` | Flex naming varies; IB Gateway may be fresher. |
+| `buyingPower` | `options_sync_runs.metadata.buyingPower` | Used for margin utilization alternatives. |
+| `availableFunds` | `options_sync_runs.metadata.availableFunds` | Alternative denominator per §7.6. |
+| `netLiquidation` | `options_sync_runs.metadata.netLiquidation` | Needed for account-wide margin utilization. |
+| all row attributes | `options_sync_runs.metadata.accountInformationRaw` | Preserve exact Flex names for Phase 1 schema decisions. |
+
+### Known Flex gaps / alternatives
+
+- The design prompt references `options_flex_sync_state`; §6 currently defines `options_sync_runs`. Use `options_sync_runs.metadata` in Phase 0/1 unless a dedicated account snapshot table is added.
+- `options_positions.markPrice` and `options_positions.fifoPnlUnrealized` are not present in the §6 DDL. Keep them in raw payload or add explicit columns only if Phase 4 MTM/margin gauges need them.
+- Flex may not emit per-position `marginRequirement`; prefer Account Information or IB Gateway account summary for account-wide margin utilization.
+- CashTransactions may not reliably include `tradeID`; use `transactionID`, dates, descriptions, and raw payload for reconciliation rather than hard-linking every cash row to a trade.


### PR DESCRIPTION
Refs #245\n\nWorking as Hockney (Backend).\n\n## Summary\n- Adds `apps/backend/scripts/flex_probe.py` with IBKR Flex SendRequest/GetStatement polling, raw XML dump to `tmp/flex/`, account/date filters, synthetic fallback, and Decimal-safe summaries.\n- Adds `apps/backend/scripts/flex_synthetic.py` fixtures covering Jony's worked example plus CSP expiration, assignment, max-profit vertical spread, and an ungrouped trade.\n- Documents one-time IBKR setup in `docs/options-flex-query-setup.md` and appends Appendix A field mapping to the design doc.\n- Adds backend Flex env placeholders and a tiny smoke test for Jony's expected +2700 cash / +1000 realized P&L.\n\n## Validation\n- `cd apps/backend && uv run python scripts/flex_synthetic.py`\n- `cd apps/backend && uv run python scripts/flex_probe.py --synthetic`\n- `cd apps/backend && uv run ruff check scripts/`\n- `cd apps/backend && uv run pytest -x -q tests/` (291 passed)\n\n## Deferred\n- Real IBKR.com Flex Query creation and token configuration require Jony's manual login.\n- Real-account reconciliation acceptance remains deferred until Jony runs the runbook against his account.\n