### PR TITLE
feat(options): #246 phase 1 — schema + flex ingestion + 2025 backfill

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -20,7 +20,9 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 OTEL_SERVICE_NAME=trading-journal-backend-worker
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 
-# IBKR Flex Query Phase 0 probe (see docs/options-flex-query-setup.md)
+# IBKR Flex Query Phase 0/1 probe + options-income worker (see docs/options-flex-query-setup.md)
+# Default dev/CI mode reads tmp/flex/synthetic_*.xml. Set OPTIONS_FLEX_SOURCE=live in prod once tokens are configured.
+OPTIONS_FLEX_SOURCE=synthetic
 # Keep real values in apps/backend/.env locally; use gh secret set for production.
 IBKR_FLEX_TOKEN=your-flex-web-service-token
 IBKR_FLEX_QUERY_ID_TRADES=your-trades-query-id

--- a/apps/backend/app/dal/database.py
+++ b/apps/backend/app/dal/database.py
@@ -1,6 +1,7 @@
 import os
 from urllib.parse import quote_plus
 
+from dotenv import load_dotenv
 from sqlalchemy import text
 from sqlmodel import Session, create_engine
 
@@ -24,8 +25,11 @@ def _normalize_database_url(raw_url: str) -> str:
     return f"postgresql://{username}:{password}@{host}:{port}/{database}"
 
 
+load_dotenv()
+
 DATABASE_URL = _normalize_database_url(
-    os.getenv("DATABASE_URL", "postgresql://user:password@localhost/trading-journal")
+    os.getenv("DIRECT_DATABASE_URL")
+    or os.getenv("DATABASE_URL", "postgresql://user:password@localhost/trading-journal")
 )
 
 engine = create_engine(

--- a/apps/backend/app/schema/trading_models.py
+++ b/apps/backend/app/schema/trading_models.py
@@ -37,6 +37,7 @@ class TradingAccountConfig(SQLModel, table=True):
     account_id: Optional[str] = Field(default=None)
     last_synced: Optional[datetime] = Field(default=None)
     last_synced_at: Optional[datetime] = Field(default=None)
+    compute_options_income: bool = Field(default=True)
     household_id: Optional[UUID] = Field(default=None, foreign_key="households.id", index=True)
 
 

--- a/apps/backend/app/services/options/__init__.py
+++ b/apps/backend/app/services/options/__init__.py
@@ -1,0 +1,1 @@
+"""Options-income ingestion and metrics services."""

--- a/apps/backend/app/services/options/flex_parser.py
+++ b/apps/backend/app/services/options/flex_parser.py
@@ -1,0 +1,470 @@
+"""Typed IBKR Flex XML parsers for options-income ingestion."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import date, datetime, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element, ParseError
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SECTION_ROW_NAMES = {
+    "TradeConfirms": "TradeConfirm",
+    "CashTransactions": "CashTransaction",
+    "OpenPositions": "OpenPosition",
+    "OptionEAE": "OptionEAE",
+    "AccountInformation": "AccountInformation",
+}
+MONEY_ZERO = Decimal("0")
+
+
+class FlexParserError(RuntimeError):
+    """Raised when Flex XML cannot be normalized into typed option rows."""
+
+
+class OptionLegKey(BaseModel):
+    """Natural key for one option contract in an account."""
+
+    model_config = ConfigDict(frozen=True)
+
+    account_id: str
+    underlying_symbol: str
+    option_symbol: str | None = None
+    expiry: date
+    strike: Decimal
+    right: str
+    multiplier: Decimal = Decimal("100")
+    currency: str = "USD"
+    source_conid: int | None = None
+
+
+class FlexTradeConfirm(BaseModel):
+    """Normalized TradeConfirms/OptionEAE execution or lifecycle row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    account_id: str
+    leg: OptionLegKey
+    source_trade_id: str
+    source_transaction_id: str | None = None
+    source_exec_id: str | None = None
+    event_type: str
+    side: str
+    trade_time: datetime
+    trade_date: date
+    quantity: Decimal
+    price: Decimal
+    gross_amount: Decimal
+    commission: Decimal = MONEY_ZERO
+    fees: Decimal = MONEY_ZERO
+    net_cash_flow: Decimal = MONEY_ZERO
+    realized_pnl: Decimal = MONEY_ZERO
+    currency: str = "USD"
+    raw_payload: dict[str, str] = Field(default_factory=dict)
+
+
+class FlexCashTransaction(BaseModel):
+    """Normalized option-relevant cash transaction row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    account_id: str
+    source_transaction_id: str
+    event_date: date
+    event_time: datetime | None = None
+    event_category: str
+    description: str | None = None
+    amount: Decimal
+    currency: str = "USD"
+    raw_payload: dict[str, str] = Field(default_factory=dict)
+
+
+class FlexOpenPosition(BaseModel):
+    """Normalized open option position snapshot row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    account_id: str
+    leg: OptionLegKey
+    as_of_date: date
+    opened_at: datetime
+    quantity_open: Decimal
+    average_open_price: Decimal
+    open_cash_flow: Decimal
+    ib_margin_requirement: Decimal | None = None
+    last_broker_sync_at: datetime
+    raw_payload: dict[str, str] = Field(default_factory=dict)
+
+
+class FlexAccountInformation(BaseModel):
+    """Normalized Flex account snapshot metadata."""
+
+    model_config = ConfigDict(frozen=True)
+
+    account_id: str
+    as_of: datetime | None = None
+    currency: str = "USD"
+    raw_payload: dict[str, str] = Field(default_factory=dict)
+
+
+class FlexParseResult(BaseModel):
+    """All normalized rows parsed from one or more Flex XML files."""
+
+    model_config = ConfigDict(frozen=True)
+
+    trades: list[FlexTradeConfirm] = Field(default_factory=list)
+    cash_transactions: list[FlexCashTransaction] = Field(default_factory=list)
+    open_positions: list[FlexOpenPosition] = Field(default_factory=list)
+    option_eae: list[FlexTradeConfirm] = Field(default_factory=list)
+    account_information: list[FlexAccountInformation] = Field(default_factory=list)
+    section_counts: dict[str, int] = Field(default_factory=dict)
+
+
+def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> FlexParseResult:
+    """Parse Flex XML files into typed rows, optionally filtering to one account."""
+
+    trades: list[FlexTradeConfirm] = []
+    cash: list[FlexCashTransaction] = []
+    positions: list[FlexOpenPosition] = []
+    eae_rows: list[FlexTradeConfirm] = []
+    account_info: list[FlexAccountInformation] = []
+    counts: dict[str, int] = {}
+    for path in paths:
+        root = _parse_xml_file(path)
+        statement_dates = _statement_dates(root)
+        for section_name, row in _iter_section_rows(root):
+            attrs = dict(row.attrib)
+            if account_id and attrs.get("accountId") != account_id:
+                continue
+            counts[section_name] = counts.get(section_name, 0) + 1
+            if section_name == "TradeConfirms":
+                trades.append(parse_trade_confirm(attrs, statement_dates[1]))
+            elif section_name == "CashTransactions":
+                cash.append(parse_cash_transaction(attrs))
+            elif section_name == "OpenPositions":
+                positions.append(parse_open_position(attrs, statement_dates[1]))
+            elif section_name == "OptionEAE":
+                eae_rows.append(parse_option_eae(attrs, statement_dates[1]))
+            elif section_name == "AccountInformation":
+                account_info.append(parse_account_information(attrs))
+    return FlexParseResult(
+        trades=trades,
+        cash_transactions=cash,
+        open_positions=positions,
+        option_eae=eae_rows,
+        account_information=account_info,
+        section_counts=counts,
+    )
+
+
+def parse_trade_confirm(attrs: dict[str, str], fallback_date: date | None = None) -> FlexTradeConfirm:
+    """Normalize one TradeConfirm row into an options trade model."""
+
+    leg = _leg_from_attrs(attrs)
+    trade_time = _datetime_attr(attrs, ("dateTime",), fallback_date=fallback_date)
+    side = _normalize_side(attrs.get("buySell"), _decimal_attr(attrs, "quantity"))
+    return FlexTradeConfirm(
+        account_id=leg.account_id,
+        leg=leg,
+        source_trade_id=_required_any(attrs, ("tradeID", "transactionID")),
+        source_transaction_id=_optional_text(attrs.get("transactionID")),
+        source_exec_id=_optional_text(attrs.get("ibExecID")),
+        event_type=_event_type_from_open_close(attrs.get("openCloseIndicator")),
+        side=side,
+        trade_time=trade_time,
+        trade_date=_date_attr(attrs, ("tradeDate", "dateTime"), fallback=trade_time.date()),
+        quantity=_decimal_attr(attrs, "quantity"),
+        price=_first_decimal(attrs, ("tradePrice", "price")),
+        gross_amount=_decimal_attr(attrs, "proceeds"),
+        commission=_first_decimal(attrs, ("commission", "ibCommission")),
+        fees=_first_decimal(attrs, ("taxes", "fees")),
+        net_cash_flow=_first_decimal(attrs, ("netCash", "proceeds")),
+        realized_pnl=_decimal_attr(attrs, "fifoPnlRealized"),
+        currency=_currency(attrs),
+        raw_payload=attrs,
+    )
+
+
+def parse_option_eae(attrs: dict[str, str], fallback_date: date | None = None) -> FlexTradeConfirm:
+    """Normalize one OptionEAE lifecycle row into a trade-like event model."""
+
+    leg = _leg_from_attrs(attrs)
+    trade_time = _datetime_attr(attrs, ("dateTime", "reportDate"), fallback_date=fallback_date)
+    event_type = _event_type_from_lifecycle(attrs.get("type") or attrs.get("action"))
+    quantity = _decimal_attr(attrs, "quantity")
+    return FlexTradeConfirm(
+        account_id=leg.account_id,
+        leg=leg,
+        source_trade_id=_required_any(attrs, ("tradeID", "transactionID")),
+        source_transaction_id=_optional_text(attrs.get("transactionID")),
+        event_type=event_type,
+        side=_normalize_side(attrs.get("buySell"), quantity),
+        trade_time=trade_time,
+        trade_date=_date_attr(attrs, ("reportDate", "dateTime"), fallback=trade_time.date()),
+        quantity=quantity,
+        price=_first_decimal(attrs, ("tradePrice", "price")),
+        gross_amount=_decimal_attr(attrs, "proceeds"),
+        net_cash_flow=_first_decimal(attrs, ("netCash", "proceeds")),
+        realized_pnl=_decimal_attr(attrs, "fifoPnlRealized"),
+        currency=_currency(attrs),
+        raw_payload=attrs,
+    )
+
+
+def parse_cash_transaction(attrs: dict[str, str]) -> FlexCashTransaction:
+    """Normalize one CashTransaction row into an options cash event."""
+
+    event_time = _optional_datetime_attr(attrs, ("dateTime",))
+    event_date = _date_attr(attrs, ("date", "reportDate", "dateTime"), fallback=(event_time or _utc_now()).date())
+    return FlexCashTransaction(
+        account_id=_required_any(attrs, ("accountId",)),
+        source_transaction_id=_required_any(attrs, ("transactionID", "tradeID")),
+        event_date=event_date,
+        event_time=event_time,
+        event_category=_cash_category(attrs.get("type"), attrs.get("description")),
+        description=_optional_text(attrs.get("description")),
+        amount=_first_decimal(attrs, ("amount", "netCash")),
+        currency=_currency(attrs),
+        raw_payload=attrs,
+    )
+
+
+def parse_open_position(attrs: dict[str, str], fallback_date: date | None = None) -> FlexOpenPosition:
+    """Normalize one OpenPosition row into a snapshot position model."""
+
+    leg = _leg_from_attrs(attrs)
+    sync_time = _optional_datetime_attr(attrs, ("dateTime",)) or datetime.combine(
+        fallback_date or date.today(), datetime.min.time(), tzinfo=timezone.utc
+    )
+    return FlexOpenPosition(
+        account_id=leg.account_id,
+        leg=leg,
+        as_of_date=sync_time.date(),
+        opened_at=sync_time,
+        quantity_open=_first_decimal(attrs, ("position", "quantity")),
+        average_open_price=_first_decimal(attrs, ("costPrice", "avgCost")),
+        open_cash_flow=_first_decimal(attrs, ("costBasis", "openCashFlow")),
+        ib_margin_requirement=_optional_decimal(attrs, "marginRequirement"),
+        last_broker_sync_at=sync_time,
+        raw_payload=attrs,
+    )
+
+
+def parse_account_information(attrs: dict[str, str]) -> FlexAccountInformation:
+    """Normalize one AccountInformation row into sync metadata."""
+
+    return FlexAccountInformation(
+        account_id=_required_any(attrs, ("accountId",)),
+        as_of=_optional_datetime_attr(attrs, ("dateTime", "reportDate", "date")),
+        currency=attrs.get("baseCurrency") or _currency(attrs),
+        raw_payload=attrs,
+    )
+
+
+def _parse_xml_file(path: Path) -> Element:
+    try:
+        return ElementTree.parse(path).getroot()
+    except (OSError, ParseError) as exc:
+        raise FlexParserError(f"Could not parse Flex XML {path}: {exc}") from exc
+
+
+def _iter_section_rows(root: Element) -> Iterable[tuple[str, Element]]:
+    for section_name, row_name in SECTION_ROW_NAMES.items():
+        for section in root.iter(section_name):
+            for row in section:
+                if row.tag == row_name:
+                    yield section_name, row
+
+
+def _statement_dates(root: Element) -> tuple[date | None, date | None]:
+    statement = root.find(".//FlexStatement")
+    if statement is None:
+        return None, None
+    return _parse_date_value(statement.attrib.get("fromDate")), _parse_date_value(statement.attrib.get("toDate"))
+
+
+def _leg_from_attrs(attrs: dict[str, str]) -> OptionLegKey:
+    return OptionLegKey(
+        account_id=_required_any(attrs, ("accountId",)),
+        underlying_symbol=_required_any(attrs, ("underlyingSymbol", "symbol")),
+        option_symbol=_optional_text(attrs.get("symbol")),
+        expiry=_required_date(attrs, "expiry"),
+        strike=_decimal_attr(attrs, "strike"),
+        right=_normalize_right(attrs.get("putCall")),
+        multiplier=_decimal_attr(attrs, "multiplier") or Decimal("100"),
+        currency=_currency(attrs),
+        source_conid=_optional_int(attrs.get("conid") or attrs.get("conId")),
+    )
+
+
+def _required_any(attrs: dict[str, str], names: tuple[str, ...]) -> str:
+    for name in names:
+        value = _optional_text(attrs.get(name))
+        if value:
+            return value
+    raise FlexParserError(f"Flex row missing required attribute: {'/'.join(names)}")
+
+
+def _optional_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _currency(attrs: dict[str, str]) -> str:
+    return _optional_text(attrs.get("currency")) or "USD"
+
+
+def _decimal_attr(attrs: dict[str, str], name: str) -> Decimal:
+    return _optional_decimal(attrs, name) or MONEY_ZERO
+
+
+def _optional_decimal(attrs: dict[str, str], name: str) -> Decimal | None:
+    value = _optional_text(attrs.get(name))
+    if value is None:
+        return None
+    try:
+        return Decimal(value.replace(",", ""))
+    except InvalidOperation as exc:
+        raise FlexParserError(f"Invalid decimal for {name}: {value!r}") from exc
+
+
+def _first_decimal(attrs: dict[str, str], names: tuple[str, ...]) -> Decimal:
+    for name in names:
+        value = _optional_decimal(attrs, name)
+        if value is not None:
+            return value
+    return MONEY_ZERO
+
+
+def _optional_int(value: str | None) -> int | None:
+    text = _optional_text(value)
+    if text is None:
+        return None
+    return int(text)
+
+
+def _required_date(attrs: dict[str, str], name: str) -> date:
+    parsed = _parse_date_value(attrs.get(name))
+    if parsed is None:
+        raise FlexParserError(f"Flex row missing required date: {name}")
+    return parsed
+
+
+def _date_attr(attrs: dict[str, str], names: tuple[str, ...], fallback: date) -> date:
+    for name in names:
+        parsed = _parse_date_value(attrs.get(name))
+        if parsed:
+            return parsed
+    return fallback
+
+
+def _optional_datetime_attr(attrs: dict[str, str], names: tuple[str, ...]) -> datetime | None:
+    for name in names:
+        parsed = _parse_datetime_value(attrs.get(name))
+        if parsed:
+            return parsed
+    return None
+
+
+def _datetime_attr(attrs: dict[str, str], names: tuple[str, ...], fallback_date: date | None) -> datetime:
+    return _optional_datetime_attr(attrs, names) or datetime.combine(
+        fallback_date or date.today(), datetime.min.time(), tzinfo=timezone.utc
+    )
+
+
+def _parse_date_value(raw_value: str | None) -> date | None:
+    value = _optional_text(raw_value)
+    if not value:
+        return None
+    value = value.split(";", maxsplit=1)[0]
+    for fmt in ("%Y-%m-%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_datetime_value(raw_value: str | None) -> datetime | None:
+    value = _optional_text(raw_value)
+    if not value:
+        return None
+    candidates = [value]
+    if ";" in value:
+        day, time_part = value.split(";", maxsplit=1)
+        if len(time_part) == 6:
+            candidates.append(f"{day} {time_part[:2]}:{time_part[2:4]}:{time_part[4:6]}")
+    for candidate in candidates:
+        for fmt in ("%Y-%m-%d %H:%M:%S", "%Y%m%d %H:%M:%S", "%Y-%m-%d", "%Y%m%d"):
+            try:
+                parsed = datetime.strptime(candidate, fmt)
+                return parsed.replace(tzinfo=timezone.utc)
+            except ValueError:
+                continue
+    return None
+
+
+def _normalize_right(value: str | None) -> str:
+    normalized = (_optional_text(value) or "").lower()
+    if normalized in {"p", "put"}:
+        return "put"
+    if normalized in {"c", "call"}:
+        return "call"
+    raise FlexParserError(f"Unsupported option right: {value!r}")
+
+
+def _normalize_side(value: str | None, quantity: Decimal) -> str:
+    normalized = (_optional_text(value) or "").lower()
+    if normalized.startswith("b"):
+        return "buy"
+    if normalized.startswith("s"):
+        return "sell"
+    return "sell" if quantity < 0 else "buy"
+
+
+def _event_type_from_open_close(value: str | None) -> str:
+    normalized = (_optional_text(value) or "").lower()
+    if normalized in {"o", "open"}:
+        return "open"
+    if normalized in {"c", "close"}:
+        return "close"
+    return "adjustment"
+
+
+def _event_type_from_lifecycle(value: str | None) -> str:
+    normalized = (_optional_text(value) or "").lower()
+    if "expir" in normalized:
+        return "expire"
+    if "assign" in normalized:
+        return "assign"
+    if "exercise" in normalized:
+        return "exercise"
+    if "cash" in normalized:
+        return "cash_settle"
+    return "adjustment"
+
+
+def _cash_category(event_type: str | None, description: str | None) -> str:
+    text = f"{event_type or ''} {description or ''}".lower()
+    if "option" in text or "assign" in text or "exercise" in text:
+        return "option_related"
+    if "commission" in text or "fee" in text:
+        return "commission_fee"
+    if "tax" in text:
+        return "tax_withholding"
+    if "interest" in text:
+        return "interest"
+    if "dividend" in text:
+        return "dividend"
+    if "transfer" in text:
+        return "transfer"
+    return "other"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/apps/backend/app/services/options/metrics.py
+++ b/apps/backend/app/services/options/metrics.py
@@ -1,0 +1,82 @@
+"""Monthly options-income metric aggregation using Decimal arithmetic."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from datetime import date, timedelta
+from decimal import Decimal
+from pydantic import BaseModel, ConfigDict
+
+
+class OptionMetricTrade(BaseModel):
+    """Minimal dated fact required for monthly dashboard metrics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    trade_date: date
+    net_cash_flow: Decimal
+    realized_pnl: Decimal
+    trade_count: int = 1
+
+
+class MonthlyMetric(BaseModel):
+    """Persistable monthly options dashboard row."""
+
+    model_config = ConfigDict(frozen=True)
+
+    period_start: date
+    period_end: date
+    cash_flow_total: Decimal
+    realized_pnl_total: Decimal
+    cash_flow_cumulative: Decimal
+    realized_pnl_cumulative: Decimal
+    variance_gap: Decimal
+    variance_gap_cumulative: Decimal
+    trade_count: int
+
+
+def compute_monthly_metrics(trades: Iterable[OptionMetricTrade]) -> list[MonthlyMetric]:
+    """Aggregate trades by calendar month and persist rolling cash-vs-P&L gap."""
+
+    buckets: dict[date, dict[str, Decimal | int]] = defaultdict(
+        lambda: {"cash": Decimal("0"), "pnl": Decimal("0"), "count": 0}
+    )
+    for trade in trades:
+        month = date(trade.trade_date.year, trade.trade_date.month, 1)
+        buckets[month]["cash"] = Decimal(buckets[month]["cash"]) + trade.net_cash_flow
+        buckets[month]["pnl"] = Decimal(buckets[month]["pnl"]) + trade.realized_pnl
+        buckets[month]["count"] = int(buckets[month]["count"]) + trade.trade_count
+
+    rows: list[MonthlyMetric] = []
+    cumulative_cash = Decimal("0")
+    cumulative_pnl = Decimal("0")
+    for month in sorted(buckets):
+        cash = Decimal(buckets[month]["cash"])
+        pnl = Decimal(buckets[month]["pnl"])
+        cumulative_cash += cash
+        cumulative_pnl += pnl
+        rows.append(
+            MonthlyMetric(
+                period_start=month,
+                period_end=_month_end(month),
+                cash_flow_total=cash,
+                realized_pnl_total=pnl,
+                cash_flow_cumulative=cumulative_cash,
+                realized_pnl_cumulative=cumulative_pnl,
+                variance_gap=cash - pnl,
+                variance_gap_cumulative=cumulative_cash - cumulative_pnl,
+                trade_count=int(buckets[month]["count"]),
+            )
+        )
+    return rows
+
+
+def _month_end(month_start: date) -> date:
+    """Return the inclusive end date for a month start."""
+
+    if month_start.month == 12:
+        next_month = date(month_start.year + 1, 1, 1)
+    else:
+        next_month = date(month_start.year, month_start.month + 1, 1)
+    return next_month - timedelta(days=1)

--- a/apps/backend/app/worker/handlers/__init__.py
+++ b/apps/backend/app/worker/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Worker job handlers."""

--- a/apps/backend/app/worker/handlers/options_metrics.py
+++ b/apps/backend/app/worker/handlers/options_metrics.py
@@ -1,0 +1,190 @@
+"""Worker handler that rebuilds monthly options-income dashboard metrics."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.options.metrics import OptionMetricTrade, compute_monthly_metrics
+
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a worker database session."""
+
+    return Session(engine)
+
+
+def handle_compute_options_monthly_metrics(
+    payload: JobPayload,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> JobResult:
+    """Rebuild options dashboard monthly rows for one or more accounts."""
+
+    with (session_factory or _default_session_factory)() as session:
+        result = compute_options_monthly_metrics(
+            session,
+            household_id=_optional_str(payload.get("household_id")),
+            account_id=_optional_str(payload.get("account_id")),
+            from_date=_optional_date(payload.get("from")),
+            to_date=_optional_date(payload.get("to")),
+        )
+        session.commit()
+        return result
+
+
+def compute_options_monthly_metrics(
+    session: Session,
+    *,
+    household_id: str | None = None,
+    account_id: str | None = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
+) -> JobResult:
+    """Aggregate normalized trade facts and replace affected monthly rows."""
+
+    accounts = _metric_accounts(session, household_id=household_id, account_id=account_id)
+    output: dict[str, Any] = {"accounts": [], "row_count": 0}
+    for account in accounts:
+        rows = _load_trade_facts(session, account["household_id"], account["account_id"], from_date, to_date)
+        metrics = compute_monthly_metrics(rows)
+        if metrics:
+            start = metrics[0].period_start
+            end = metrics[-1].period_start
+            session.execute(
+                text(
+                    """
+                    delete from public.options_dashboard_monthly
+                     where household_id = :household_id
+                       and account_id = :account_id
+                       and period_start between :start and :end
+                    """
+                ),
+                {
+                    "household_id": account["household_id"],
+                    "account_id": account["account_id"],
+                    "start": start,
+                    "end": end,
+                },
+            )
+            for metric in metrics:
+                session.execute(
+                    text(
+                        """
+                        insert into public.options_dashboard_monthly (
+                          household_id, account_id, period_start, period_end,
+                          cash_flow_total, realized_pnl_total,
+                          cash_flow_cumulative, realized_pnl_cumulative,
+                          variance_gap, variance_gap_cumulative, trade_count, last_computed_at
+                        ) values (
+                          :household_id, :account_id, :period_start, :period_end,
+                          :cash_flow_total, :realized_pnl_total,
+                          :cash_flow_cumulative, :realized_pnl_cumulative,
+                          :variance_gap, :variance_gap_cumulative, :trade_count, now()
+                        )
+                        """
+                    ),
+                    {
+                        "household_id": account["household_id"],
+                        "account_id": account["account_id"],
+                        **metric.model_dump(),
+                    },
+                )
+        output["accounts"].append(
+            {
+                "household_id": account["household_id"],
+                "account_id": account["account_id"],
+                "months": len(metrics),
+                "cash_flow_total": str(sum((m.cash_flow_total for m in metrics), Decimal("0"))),
+                "realized_pnl_total": str(sum((m.realized_pnl_total for m in metrics), Decimal("0"))),
+                "variance_gap_cumulative": str(metrics[-1].variance_gap_cumulative if metrics else Decimal("0")),
+            }
+        )
+        output["row_count"] += len(metrics)
+    return output
+
+
+def _metric_accounts(session: Session, *, household_id: str | None, account_id: str | None) -> list[dict[str, str]]:
+    where = ["1=1"]
+    params: dict[str, Any] = {}
+    if household_id:
+        where.append("household_id = :household_id")
+        params["household_id"] = household_id
+    if account_id:
+        where.append("account_id = :account_id")
+        params["account_id"] = account_id
+    rows = session.execute(
+        text(
+            f"""
+            select distinct household_id::text as household_id, account_id
+              from public.options_trades
+             where {" and ".join(where)}
+             order by account_id
+            """
+        ),
+        params,
+    ).mappings()
+    return [{"household_id": str(row["household_id"]), "account_id": str(row["account_id"])} for row in rows]
+
+
+def _load_trade_facts(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[OptionMetricTrade]:
+    where = ["household_id = :household_id", "account_id = :account_id"]
+    params: dict[str, Any] = {"household_id": household_id, "account_id": account_id}
+    if from_date:
+        where.append("trade_date >= :from_date")
+        params["from_date"] = from_date
+    if to_date:
+        where.append("trade_date <= :to_date")
+        params["to_date"] = to_date
+    rows = session.execute(
+        text(
+            f"""
+            select trade_date, net_cash_flow, realized_pnl, 1 as trade_count
+              from public.options_trades
+             where {" and ".join(where)}
+            union all
+            select event_date as trade_date, amount as net_cash_flow, 0::numeric as realized_pnl, 0 as trade_count
+              from public.options_cash_events
+             where {" and ".join(where).replace("trade_date", "event_date")}
+               and event_category = 'option_related'
+             order by trade_date
+            """
+        ),
+        params,
+    ).mappings()
+    return [
+        OptionMetricTrade(
+            trade_date=row["trade_date"],
+            net_cash_flow=Decimal(str(row["net_cash_flow"])),
+            realized_pnl=Decimal(str(row["realized_pnl"])),
+            trade_count=int(row["trade_count"]),
+        )
+        for row in rows
+    ]
+
+
+def _optional_str(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_date(value: object) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return date.fromisoformat(value)

--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -1,0 +1,436 @@
+"""Worker handler for IBKR Flex options-income ingestion."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import date
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.options.flex_parser import (
+    FlexCashTransaction,
+    FlexOpenPosition,
+    FlexParseResult,
+    FlexTradeConfirm,
+    OptionLegKey,
+    parse_flex_files,
+)
+from app.worker.handlers.options_metrics import compute_options_monthly_metrics
+
+logger = logging.getLogger(__name__)
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+PROJECT_ROOT = Path(__file__).resolve().parents[4]
+SYNTHETIC_DIR = PROJECT_ROOT / "tmp" / "flex"
+
+
+@dataclass(frozen=True)
+class OptionsAccount:
+    """Trading account configuration selected for options-income computation."""
+
+    household_id: str
+    account_id: str | None
+    config_id: int | None = None
+    name: str | None = None
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a worker database session."""
+
+    return Session(engine)
+
+
+def handle_flex_options_sync(
+    payload: JobPayload,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> JobResult:
+    """Ingest Flex XML option facts and then rebuild monthly dashboard metrics."""
+
+    with (session_factory or _default_session_factory)() as session:
+        result = run_flex_options_sync(
+            session,
+            from_date=_optional_date(payload.get("from")),
+            to_date=_optional_date(payload.get("to")),
+            account_id=_optional_str(payload.get("account_id")),
+            synthetic=_optional_bool(payload.get("synthetic")),
+        )
+        metric_result = compute_options_monthly_metrics(
+            session,
+            household_id=_optional_str(payload.get("household_id")),
+            account_id=_optional_str(payload.get("account_id")),
+            from_date=_optional_date(payload.get("from")),
+            to_date=_optional_date(payload.get("to")),
+        )
+        session.commit()
+        return {**result, "monthly_metrics": metric_result}
+
+
+def run_scheduled_flex_options_sync() -> None:
+    """Run the daily scheduled Flex sync with configured source selection."""
+
+    with _default_session_factory() as session:
+        result = run_flex_options_sync(session)
+        compute_options_monthly_metrics(session)
+        session.commit()
+    logger.info("Scheduled flex_options_sync completed: %s", result)
+
+
+def run_flex_options_sync(
+    session: Session,
+    *,
+    from_date: date | None = None,
+    to_date: date | None = None,
+    account_id: str | None = None,
+    synthetic: bool | None = None,
+) -> JobResult:
+    """Parse selected Flex source files and upsert normalized option facts."""
+
+    accounts = _load_accounts(session, account_id=account_id)
+    if not accounts:
+        return {"accounts": [], "trade_count": 0, "cash_event_count": 0, "position_count": 0}
+
+    paths = _select_flex_source(from_date=from_date, to_date=to_date, synthetic=synthetic)
+    total_trades = 0
+    total_cash = 0
+    total_positions = 0
+    summaries: list[dict[str, Any]] = []
+    for account in accounts:
+        parsed = parse_flex_files(paths, account.account_id)
+        if account.account_id is None:
+            account_ids = _parsed_account_ids(parsed)
+        else:
+            account_ids = {account.account_id}
+        for parsed_account_id in sorted(account_ids):
+            scoped = _scope_result(parsed, parsed_account_id)
+            counts = _ingest_account(session, account.household_id, parsed_account_id, scoped, from_date, to_date)
+            total_trades += counts["trade_count"]
+            total_cash += counts["cash_event_count"]
+            total_positions += counts["position_count"]
+            summaries.append({"account_id": parsed_account_id, **counts})
+    return {
+        "accounts": summaries,
+        "trade_count": total_trades,
+        "cash_event_count": total_cash,
+        "position_count": total_positions,
+        "source_files": [str(path) for path in paths],
+    }
+
+
+def _load_accounts(session: Session, *, account_id: str | None) -> list[OptionsAccount]:
+    params: dict[str, Any] = {}
+    filters = ["coalesce(compute_options_income, true) = true", "deleted_at is null"]
+    if account_id:
+        filters.append("account_id = :account_id")
+        params["account_id"] = account_id
+    rows = session.execute(
+        text(
+            f"""
+            select id, household_id::text as household_id, account_id, name
+              from public.trading_account_config
+             where {" and ".join(filters)}
+             order by id
+            """
+        ),
+        params,
+    ).mappings()
+    return [
+        OptionsAccount(
+            household_id=str(row["household_id"]),
+            account_id=str(row["account_id"]) if row["account_id"] else None,
+            config_id=int(row["id"]),
+            name=str(row["name"]),
+        )
+        for row in rows
+        if row["household_id"]
+    ]
+
+
+def _select_flex_source(*, from_date: date | None, to_date: date | None, synthetic: bool | None) -> list[Path]:
+    source = os.getenv("OPTIONS_FLEX_SOURCE", "synthetic").lower()
+    if synthetic is True or source == "synthetic" or not os.getenv("IBKR_FLEX_TOKEN"):
+        return _synthetic_files()
+    from scripts.flex_probe import fetch_live_xml, parse_args, query_configs_from_env
+
+    args = parse_args([])
+    args.from_date = from_date
+    args.to_date = to_date
+    configs = query_configs_from_env()
+    token = os.environ["IBKR_FLEX_TOKEN"]
+    return fetch_live_xml(configs, token, args)
+
+
+def _synthetic_files() -> list[Path]:
+    paths = sorted(SYNTHETIC_DIR.glob("synthetic_*.xml"))
+    if paths:
+        return paths
+    from scripts.flex_synthetic import write_synthetic_files
+
+    return sorted(write_synthetic_files(SYNTHETIC_DIR))
+
+
+def _parsed_account_ids(parsed: FlexParseResult) -> set[str]:
+    ids = {row.account_id for row in parsed.trades}
+    ids.update(row.account_id for row in parsed.cash_transactions)
+    ids.update(row.account_id for row in parsed.open_positions)
+    ids.update(row.account_id for row in parsed.option_eae)
+    ids.update(row.account_id for row in parsed.account_information)
+    return ids
+
+
+def _scope_result(parsed: FlexParseResult, account_id: str) -> FlexParseResult:
+    return FlexParseResult(
+        trades=[row for row in parsed.trades if row.account_id == account_id],
+        cash_transactions=[row for row in parsed.cash_transactions if row.account_id == account_id],
+        open_positions=[row for row in parsed.open_positions if row.account_id == account_id],
+        option_eae=[row for row in parsed.option_eae if row.account_id == account_id],
+        account_information=[row for row in parsed.account_information if row.account_id == account_id],
+        section_counts=parsed.section_counts,
+    )
+
+
+def _ingest_account(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    parsed: FlexParseResult,
+    from_date: date | None,
+    to_date: date | None,
+) -> dict[str, int]:
+    leg_ids: dict[OptionLegKey, str] = {}
+    trades_to_insert = parsed.trades
+    for trade in trades_to_insert:
+        leg_ids[trade.leg] = _upsert_leg(session, household_id, trade.leg)
+        _upsert_trade(session, household_id, trade, leg_ids[trade.leg])
+    for cash in parsed.cash_transactions:
+        _upsert_cash_event(session, household_id, cash)
+    snapshot_dates = {position.as_of_date for position in parsed.open_positions}
+    for snapshot_date in snapshot_dates:
+        session.execute(
+            text(
+                """
+                delete from public.options_positions
+                 where household_id = :household_id and account_id = :account_id and as_of_date = :as_of_date
+                """
+            ),
+            {"household_id": household_id, "account_id": account_id, "as_of_date": snapshot_date},
+        )
+    for position in parsed.open_positions:
+        leg_id = leg_ids.get(position.leg) or _upsert_leg(session, household_id, position.leg)
+        leg_ids[position.leg] = leg_id
+        _insert_position(session, household_id, position, leg_id)
+    _upsert_sync_state(session, household_id, account_id, parsed, from_date, to_date)
+    return {
+        "trade_count": len(trades_to_insert),
+        "cash_event_count": len(parsed.cash_transactions),
+        "position_count": len(parsed.open_positions),
+    }
+
+
+def _upsert_leg(session: Session, household_id: str, leg: OptionLegKey) -> str:
+    row = session.execute(
+        text(
+            """
+            insert into public.options_legs (
+              household_id, account_id, source_conid, underlying_symbol, option_symbol,
+              expiry, strike, "right", multiplier, currency, metadata
+            ) values (
+              :household_id, :account_id, :source_conid, :underlying_symbol, :option_symbol,
+              :expiry, :strike, :right, :multiplier, :currency, cast(:metadata as jsonb)
+            )
+            on conflict on constraint options_legs_natural_key do update set
+              option_symbol = excluded.option_symbol,
+              source_conid = coalesce(public.options_legs.source_conid, excluded.source_conid),
+              metadata = excluded.metadata,
+              updated_at = now()
+            returning id::text
+            """
+        ),
+        {
+            "household_id": household_id,
+            "account_id": leg.account_id,
+            "source_conid": leg.source_conid,
+            "underlying_symbol": leg.underlying_symbol,
+            "option_symbol": leg.option_symbol,
+            "expiry": leg.expiry,
+            "strike": leg.strike,
+            "right": leg.right,
+            "multiplier": leg.multiplier,
+            "currency": leg.currency,
+            "metadata": _json({}),
+        },
+    ).scalar_one()
+    return str(row)
+
+
+def _upsert_trade(session: Session, household_id: str, trade: FlexTradeConfirm, leg_id: str) -> None:
+    session.execute(
+        text(
+            """
+            insert into public.options_trades (
+              household_id, account_id, leg_id, source, source_trade_id, source_transaction_id, source_exec_id,
+              event_type, side, trade_time, trade_date, quantity, price, gross_amount, commission, fees,
+              net_cash_flow, realized_pnl, currency, raw_payload
+            ) values (
+              :household_id, :account_id, :leg_id, 'ibkr_flex', :source_trade_id, :source_transaction_id, :source_exec_id,
+              :event_type, :side, :trade_time, :trade_date, :quantity, :price, :gross_amount, :commission, :fees,
+              :net_cash_flow, :realized_pnl, :currency, cast(:raw_payload as jsonb)
+            )
+            on conflict on constraint options_trades_source_trade_key do update set
+              leg_id = excluded.leg_id,
+              source_transaction_id = excluded.source_transaction_id,
+              source_exec_id = excluded.source_exec_id,
+              event_type = excluded.event_type,
+              side = excluded.side,
+              trade_time = excluded.trade_time,
+              trade_date = excluded.trade_date,
+              quantity = excluded.quantity,
+              price = excluded.price,
+              gross_amount = excluded.gross_amount,
+              commission = excluded.commission,
+              fees = excluded.fees,
+              net_cash_flow = excluded.net_cash_flow,
+              realized_pnl = excluded.realized_pnl,
+              currency = excluded.currency,
+              raw_payload = excluded.raw_payload,
+              updated_at = now()
+            """
+        ),
+        {
+            "household_id": household_id,
+            "leg_id": leg_id,
+            **trade.model_dump(exclude={"leg"}),
+            "raw_payload": _json(trade.raw_payload),
+        },
+    )
+
+
+def _upsert_cash_event(session: Session, household_id: str, cash: FlexCashTransaction) -> None:
+    session.execute(
+        text(
+            """
+            insert into public.options_cash_events (
+              household_id, account_id, source, source_transaction_id, event_date, event_time,
+              event_category, description, amount, currency, raw_payload
+            ) values (
+              :household_id, :account_id, 'ibkr_flex', :source_transaction_id, :event_date, :event_time,
+              :event_category, :description, :amount, :currency, cast(:raw_payload as jsonb)
+            )
+            on conflict on constraint options_cash_events_source_transaction_key do update set
+              event_date = excluded.event_date,
+              event_time = excluded.event_time,
+              event_category = excluded.event_category,
+              description = excluded.description,
+              amount = excluded.amount,
+              currency = excluded.currency,
+              raw_payload = excluded.raw_payload,
+              updated_at = now()
+            """
+        ),
+        {"household_id": household_id, **cash.model_dump(), "raw_payload": _json(cash.raw_payload)},
+    )
+
+
+def _insert_position(session: Session, household_id: str, position: FlexOpenPosition, leg_id: str) -> None:
+    session.execute(
+        text(
+            """
+            insert into public.options_positions (
+              household_id, account_id, as_of_date, leg_id, opened_at, quantity_open,
+              average_open_price, open_cash_flow, ib_margin_requirement, last_broker_sync_at, raw_payload
+            ) values (
+              :household_id, :account_id, :as_of_date, :leg_id, :opened_at, :quantity_open,
+              :average_open_price, :open_cash_flow, :ib_margin_requirement, :last_broker_sync_at, cast(:raw_payload as jsonb)
+            )
+            """
+        ),
+        {
+            "household_id": household_id,
+            "leg_id": leg_id,
+            **position.model_dump(exclude={"leg"}),
+            "raw_payload": _json(position.raw_payload),
+        },
+    )
+
+
+def _upsert_sync_state(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    parsed: FlexParseResult,
+    from_date: date | None,
+    to_date: date | None,
+) -> None:
+    counts = {
+        "TradeConfirms": len(parsed.trades),
+        "CashTransactions": len(parsed.cash_transactions),
+        "OpenPositions": len(parsed.open_positions),
+        "OptionEAE": len(parsed.option_eae),
+        "AccountInformation": len(parsed.account_information),
+    }
+    rows_seen = sum(counts.values())
+    session.execute(
+        text(
+            """
+            insert into public.options_flex_sync_state (
+              household_id, account_id, query_name, source, status, last_sync_at,
+              last_from_date, last_through_date, rows_seen, rows_inserted, row_counts, metadata
+            ) values (
+              :household_id, :account_id, 'all', 'ibkr_flex', 'succeeded', now(),
+              :from_date, :to_date, :rows_seen, :rows_seen, cast(:row_counts as jsonb), cast(:metadata as jsonb)
+            )
+            on conflict on constraint options_flex_sync_state_account_query_key do update set
+              status = 'succeeded',
+              last_sync_at = now(),
+              last_from_date = excluded.last_from_date,
+              last_through_date = excluded.last_through_date,
+              rows_seen = excluded.rows_seen,
+              rows_inserted = excluded.rows_inserted,
+              row_counts = excluded.row_counts,
+              metadata = excluded.metadata,
+              error = null,
+              updated_at = now()
+            """
+        ),
+        {
+            "household_id": household_id,
+            "account_id": account_id,
+            "from_date": from_date,
+            "to_date": to_date,
+            "rows_seen": rows_seen,
+            "row_counts": _json(counts),
+            "metadata": _json({"accountInformation": [row.raw_payload for row in parsed.account_information]}),
+        },
+    )
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, default=str, sort_keys=True)
+
+
+def _optional_str(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "synthetic"}
+    return None
+
+
+def _optional_date(value: object) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return date.fromisoformat(value)

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -7,6 +7,8 @@ from typing import Literal
 from app.services.trading_batch import run_trading_sync_batch
 from app.worker.backtest_handler import run_backtest_job
 from app.worker.bonds_scanner import refresh_bond_scanner_results
+from app.worker.handlers.options_metrics import handle_compute_options_monthly_metrics
+from app.worker.handlers.options_sync import handle_flex_options_sync, run_scheduled_flex_options_sync
 from app.worker.pension_pdf_parse import handle_pension_pdf_parse
 
 JobPayload = dict[str, object]
@@ -29,6 +31,8 @@ class JobSchedule:
 JOB_HANDLERS: dict[str, JobHandler] = {
     "pension_pdf_parse": handle_pension_pdf_parse,
     "backtest": run_backtest_job,
+    "flex_options_sync": handle_flex_options_sync,
+    "compute_options_monthly_metrics": handle_compute_options_monthly_metrics,
 }
 JOB_SCHEDULES: list[JobSchedule] = [
     JobSchedule(
@@ -42,5 +46,11 @@ JOB_SCHEDULES: list[JobSchedule] = [
         kind="cron",
         handler=refresh_bond_scanner_results,
         cron_expr="0 4 * * *",
+    ),
+    JobSchedule(
+        job_id="flex_options_sync",
+        kind="cron",
+        handler=run_scheduled_flex_options_sync,
+        cron_expr="30 22 * * *",
     ),
 ]

--- a/apps/backend/scripts/backfill_options.py
+++ b/apps/backend/scripts/backfill_options.py
@@ -1,0 +1,89 @@
+"""Backfill options-income facts and monthly metrics from IBKR Flex XML."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from decimal import Decimal
+import os
+import sys
+from typing import Iterable
+
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.worker.handlers.options_metrics import compute_options_monthly_metrics
+from app.worker.handlers.options_sync import run_flex_options_sync
+
+DEFAULT_FROM = date(2025, 1, 1)
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse backfill CLI flags."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--from", dest="from_date", type=date.fromisoformat, default=DEFAULT_FROM)
+    parser.add_argument("--to", dest="to_date", type=date.fromisoformat, default=date.today())
+    parser.add_argument("--account", dest="account_id", help="Broker accountId; defaults to all enabled accounts")
+    parser.add_argument("--synthetic", action="store_true", help="Read tmp/flex/synthetic_*.xml instead of live Flex")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Run a synchronous Flex options backfill and print reconciliation totals."""
+
+    args = parse_args(argv)
+    if args.synthetic:
+        os.environ["OPTIONS_FLEX_SOURCE"] = "synthetic"
+    print(f"Backfilling options income from {args.from_date} to {args.to_date}")
+    with Session(engine) as session:
+        sync_result = run_flex_options_sync(
+            session,
+            from_date=args.from_date,
+            to_date=args.to_date,
+            account_id=args.account_id,
+            synthetic=args.synthetic,
+        )
+        metrics_result = compute_options_monthly_metrics(
+            session,
+            account_id=args.account_id,
+            from_date=args.from_date,
+            to_date=args.to_date,
+        )
+        session.commit()
+    print("Flex sync:", sync_result)
+    print("Monthly metrics:", metrics_result)
+    totals = _totals(metrics_result)
+    print(
+        "Reconciliation summary: "
+        f"accounts={totals['account_count']} trades={sync_result.get('trade_count', 0)} "
+        f"cash_events={sync_result.get('cash_event_count', 0)} "
+        f"cash_flow={totals['cash_flow']} realized_pnl={totals['realized_pnl']} "
+        f"variance_gap={totals['variance_gap']}"
+    )
+    return 0
+
+
+def _totals(metrics_result: dict[str, object]) -> dict[str, object]:
+    accounts = metrics_result.get("accounts")
+    if not isinstance(accounts, list):
+        return {
+            "account_count": 0,
+            "cash_flow": Decimal("0"),
+            "realized_pnl": Decimal("0"),
+            "variance_gap": Decimal("0"),
+        }
+    cash_flow = Decimal("0")
+    realized = Decimal("0")
+    variance = Decimal("0")
+    for account in accounts:
+        if not isinstance(account, dict):
+            continue
+        cash_flow += Decimal(str(account.get("cash_flow_total", "0")))
+        realized += Decimal(str(account.get("realized_pnl_total", "0")))
+        variance += Decimal(str(account.get("variance_gap_cumulative", "0")))
+    return {"account_count": len(accounts), "cash_flow": cash_flow, "realized_pnl": realized, "variance_gap": variance}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -1,0 +1,35 @@
+"""Tests for typed IBKR Flex options parser."""
+
+from __future__ import annotations
+
+import shutil
+from decimal import Decimal
+from pathlib import Path
+
+from app.services.options.flex_parser import parse_flex_files
+from scripts.flex_synthetic import write_synthetic_files
+
+
+def test_parse_synthetic_flex_rows_into_typed_models() -> None:
+    """Synthetic Phase 0 fixtures decode key financial fields as Decimals."""
+
+    output_dir = Path("tmp/test-options-flex-parser")
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    try:
+        paths = write_synthetic_files(output_dir)
+        parsed = parse_flex_files(paths)
+        assert len(parsed.trades) == 14
+        first = parsed.trades[0]
+        assert first.account_id == "U1234567"
+        assert first.leg.underlying_symbol == "SPY"
+        assert first.leg.right == "put"
+        assert first.net_cash_flow == Decimal("4000.000000")
+        assert first.realized_pnl == Decimal("0.000000")
+        losing_roll = next(row for row in parsed.trades if row.source_trade_id == "T-JONY-003")
+        assert losing_roll.realized_pnl == Decimal("-1000.000000")
+        assert parsed.open_positions[0].quantity_open == Decimal("-1.000000")
+        assert parsed.account_information[0].raw_payload["netLiquidation"] == "100000.000000"
+    finally:
+        if output_dir.exists():
+            shutil.rmtree(output_dir)

--- a/apps/backend/tests/services/options/test_metrics.py
+++ b/apps/backend/tests/services/options/test_metrics.py
@@ -1,0 +1,28 @@
+"""Tests for options monthly dashboard metric formulas."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.options.metrics import OptionMetricTrade, compute_monthly_metrics
+
+
+def test_jony_worked_example_variance_gap() -> None:
+    """Jony's example persists cumulative cash flow, realized P&L, and gap."""
+
+    rows = compute_monthly_metrics(
+        [
+            OptionMetricTrade(trade_date=date(2025, 1, 17), net_cash_flow=Decimal("3000"), realized_pnl=Decimal("0")),
+            OptionMetricTrade(
+                trade_date=date(2025, 2, 14), net_cash_flow=Decimal("200"), realized_pnl=Decimal("-1000")
+            ),
+            OptionMetricTrade(
+                trade_date=date(2025, 3, 21), net_cash_flow=Decimal("-500"), realized_pnl=Decimal("2000")
+            ),
+        ]
+    )
+    assert rows[-1].cash_flow_cumulative == Decimal("2700")
+    assert rows[-1].realized_pnl_cumulative == Decimal("1000")
+    assert rows[-1].variance_gap_cumulative == Decimal("1700")
+    assert [row.variance_gap_cumulative for row in rows] == [Decimal("3000"), Decimal("4200"), Decimal("1700")]

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -1,0 +1,99 @@
+"""Worker tests for synthetic Flex options sync."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from app.worker.handlers.options_sync import run_flex_options_sync
+
+
+class FakeScalar:
+    """Scalar wrapper for returning generated IDs."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def scalar_one(self) -> str:
+        """Return the fake scalar value."""
+
+        return self.value
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return no mappings for scalar statements."""
+
+        return []
+
+
+class FakeMappings:
+    """Mappings wrapper for fake SELECT statements."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class FakeSession:
+    """Small SQL recorder that mimics the worker's SQLModel session usage."""
+
+    def __init__(self) -> None:
+        self.legs: dict[tuple[Any, ...], str] = {}
+        self.trades: list[Mapping[str, Any]] = []
+        self.cash_events: list[Mapping[str, Any]] = []
+        self.positions: list[Mapping[str, Any]] = []
+        self.sync_states = 0
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeScalar | FakeMappings:
+        sql = str(statement)
+        params = params or {}
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "id": 1,
+                        "household_id": "10000000-0000-0000-0000-000000000001",
+                        "account_id": "U1234567",
+                        "name": "IBKR Synthetic",
+                    }
+                ]
+            )
+        if "insert into public.options_legs" in sql:
+            key = (
+                params["account_id"],
+                params["underlying_symbol"],
+                params["expiry"],
+                params["strike"],
+                params["right"],
+            )
+            self.legs.setdefault(key, f"leg-{len(self.legs) + 1}")
+            return FakeScalar(self.legs[key])
+        if "insert into public.options_trades" in sql:
+            self.trades.append(params)
+        elif "insert into public.options_cash_events" in sql:
+            self.cash_events.append(params)
+        elif "insert into public.options_positions" in sql:
+            self.positions.append(params)
+        elif "insert into public.options_flex_sync_state" in sql:
+            self.sync_states += 1
+        return FakeMappings([])
+
+
+def test_run_flex_options_sync_ingests_synthetic_source(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The worker parses synthetic XML and writes idempotent upsert statements."""
+
+    monkeypatch.setenv("OPTIONS_FLEX_SOURCE", "synthetic")
+    session = FakeSession()
+    result = run_flex_options_sync(session)  # type: ignore[arg-type]
+    assert result["trade_count"] == 14
+    assert result["cash_event_count"] == 2
+    assert result["position_count"] == 1
+    assert len(session.trades) == 14
+    assert (
+        session.trades[2]["realized_pnl"] == "-1000.000000" or str(session.trades[2]["realized_pnl"]) == "-1000.000000"
+    )
+    assert len(session.legs) >= 1
+    assert session.sync_states == 1

--- a/apps/frontend/src/app/trading/actions.test.ts
+++ b/apps/frontend/src/app/trading/actions.test.ts
@@ -173,6 +173,7 @@ describe('saveTradingConfig', () => {
       port: 4002,
       client_id: 2,
       linked_account_id: null,
+      compute_options_income: true,
       household_id: MOCK_HOUSEHOLD_ID,
     });
     expect(row).not.toHaveProperty('app_key');
@@ -200,9 +201,11 @@ describe('saveTradingConfig', () => {
       .mockResolvedValueOnce(actionClient)
       .mockResolvedValueOnce(householdClient());
 
-    const result = await saveTradingConfig({ id: 5, name: 'Updated', account_type: 'IBKR' });
+    const result = await saveTradingConfig({ id: 5, name: 'Updated', account_type: 'IBKR', compute_options_income: false });
 
     expect(result.ok).toBe(true);
+    const [row] = update.mock.calls[0] as [Record<string, unknown>];
+    expect(row.compute_options_income).toBe(false);
     expect(eqId).toHaveBeenCalledWith('id', 5);
     expect(eqHousehold).toHaveBeenCalledWith('household_id', MOCK_HOUSEHOLD_ID);
   });

--- a/apps/frontend/src/app/trading/actions.ts
+++ b/apps/frontend/src/app/trading/actions.ts
@@ -17,6 +17,7 @@ export interface TradingAccountConfig {
   account_id: string | null;
   last_synced: string | null;
   last_synced_at: string | null;
+  compute_options_income: boolean;
 }
 
 export interface TradingAccountConfigInput {
@@ -28,6 +29,7 @@ export interface TradingAccountConfigInput {
   client_id?: number | string | null;
   linked_account_id?: string | null;
   account_id?: string | null;
+  compute_options_income?: boolean | null;
   // Legacy Schwab credential fields may still be present in callers, but the
   // Supabase schema intentionally does not persist broker secrets.
   app_key?: string | null;
@@ -71,6 +73,7 @@ const CONFIG_SELECT = [
   'account_id',
   'last_synced',
   'last_synced_at',
+  'compute_options_income',
 ].join(', ');
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
@@ -120,6 +123,7 @@ function normalizeConfigInput(input: TradingAccountConfigInput, householdId: str
     port: normalizeNumber(input.port, 4001),
     client_id: normalizeNumber(input.client_id, 1),
     linked_account_id: normalizeOptionalText(input.linked_account_id),
+    compute_options_income: input.compute_options_income ?? true,
     household_id: householdId,
   };
 }

--- a/apps/frontend/src/components/trading/TradingAccountSettings.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountSettings.tsx
@@ -22,7 +22,8 @@ export default function TradingAccountSettings() {
         host: "127.0.0.1",
         port: 4001,
         client_id: 1,
-        linked_account_id: ""
+        linked_account_id: "",
+        compute_options_income: true,
     });
     const [financeAccounts, setFinanceAccounts] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
@@ -72,6 +73,7 @@ export default function TradingAccountSettings() {
                 port: editingConfig.port,
                 client_id: editingConfig.client_id,
                 linked_account_id: editingConfig.linked_account_id,
+                compute_options_income: editingConfig.compute_options_income ?? true,
             });
             if (result.ok) {
                 setMessage("Settings saved successfully!");
@@ -94,7 +96,8 @@ export default function TradingAccountSettings() {
             host: "127.0.0.1",
             port: 4001,
             client_id: 1,
-            linked_account_id: ""
+            linked_account_id: "",
+            compute_options_income: true,
         });
     };
 
@@ -247,6 +250,19 @@ export default function TradingAccountSettings() {
                             </>
                         )}
                     </div>
+
+                    <label className="flex items-start gap-3 rounded-lg border border-slate-800 bg-slate-950/40 p-4 text-sm text-slate-300">
+                        <input
+                            type="checkbox"
+                            className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-800 text-blue-600 focus:ring-blue-500"
+                            checked={editingConfig.compute_options_income ?? true}
+                            onChange={(e) => setEditingConfig({ ...editingConfig, compute_options_income: e.target.checked })}
+                        />
+                        <span>
+                            <span className="block font-medium text-slate-100">Compute options income for this account</span>
+                            <span className="block text-slate-500">Enabled by default. The worker will include this account in Flex options ingestion and monthly dashboard metrics.</span>
+                        </span>
+                    </label>
 
                     <div className="pt-4 flex items-center justify-between">
                         <p className={`text-sm ${message.includes("Error") ? "text-red-400" : "text-green-400"}`}>

--- a/supabase/migrations/20260504134437_add_trading_account_options_toggle.sql
+++ b/supabase/migrations/20260504134437_add_trading_account_options_toggle.sql
@@ -1,0 +1,8 @@
+-- Migration: add_trading_account_options_toggle
+-- Purpose: Allow households to opt trading accounts in/out of options-income computation.
+
+alter table public.trading_account_config
+  add column if not exists compute_options_income boolean not null default true;
+
+comment on column public.trading_account_config.compute_options_income is
+  'When true, the worker includes this broker account in options income Flex ingestion and monthly metrics.';

--- a/supabase/migrations/20260504134438_add_options_income_phase1_schema.sql
+++ b/supabase/migrations/20260504134438_add_options_income_phase1_schema.sql
@@ -1,0 +1,368 @@
+-- Migration: add_options_income_phase1_schema
+-- Purpose: Phase 1 options-income Flex ingestion and dashboard read models for #246.
+
+do $$ begin
+  create type public.options_sync_source as enum ('ibkr_flex', 'ib_gateway', 'snaptrade');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_sync_status as enum ('pending', 'running', 'succeeded', 'failed');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.option_right as enum ('call', 'put');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_strategy_kind as enum ('csp', 'vertical_spread', 'roll_chain', 'ungrouped');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_strategy_status as enum ('open', 'closed', 'expired', 'assigned', 'mixed');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_trade_event_type as enum ('open', 'close', 'expire', 'assign', 'exercise', 'cash_settle', 'adjustment');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_trade_side as enum ('buy', 'sell');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_cash_event_category as enum ('option_related', 'commission_fee', 'tax_withholding', 'interest', 'dividend', 'transfer', 'other');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_roll_classification as enum ('positive', 'negative', 'neutral');
+exception when duplicate_object then null; end $$;
+
+do $$ begin
+  create type public.options_roll_detection_status as enum ('detected', 'confirmed', 'rejected', 'manual');
+exception when duplicate_object then null; end $$;
+
+create table if not exists public.options_flex_sync_state (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  query_name text not null,
+  source public.options_sync_source not null default 'ibkr_flex',
+  status public.options_sync_status not null default 'pending',
+  last_sync_at timestamptz,
+  last_from_date date,
+  last_through_date date,
+  rows_seen integer not null default 0,
+  rows_inserted integer not null default 0,
+  rows_updated integer not null default 0,
+  row_counts jsonb not null default '{}'::jsonb,
+  error text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_flex_sync_state_account_query_key unique (household_id, account_id, query_name, source)
+);
+
+create table if not exists public.options_legs (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  source_conid bigint,
+  underlying_symbol text not null,
+  option_symbol text,
+  expiry date not null,
+  strike numeric(18,6) not null,
+  "right" public.option_right not null,
+  multiplier numeric(18,6) not null default 100,
+  currency text not null default 'USD',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_legs_natural_key unique (household_id, account_id, underlying_symbol, expiry, strike, "right", multiplier, currency)
+);
+
+create table if not exists public.options_strategy_groups (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  underlying_symbol text not null,
+  kind public.options_strategy_kind not null default 'ungrouped',
+  status public.options_strategy_status not null default 'open',
+  opened_at timestamptz not null,
+  closed_at timestamptz,
+  parent_group_id uuid references public.options_strategy_groups(id) on delete set null,
+  net_cash_flow numeric(18,6) not null default 0,
+  realized_pnl numeric(18,6) not null default 0,
+  capital_at_risk numeric(18,6),
+  notes text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.options_trades (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  strategy_group_id uuid references public.options_strategy_groups(id) on delete set null,
+  leg_id uuid not null references public.options_legs(id) on delete restrict,
+  source public.options_sync_source not null,
+  source_trade_id text,
+  source_transaction_id text,
+  source_exec_id text,
+  event_type public.options_trade_event_type not null,
+  side public.options_trade_side not null,
+  trade_time timestamptz not null,
+  trade_date date not null,
+  quantity numeric(18,6) not null,
+  price numeric(18,6) not null,
+  gross_amount numeric(18,6) not null,
+  commission numeric(18,6) not null default 0,
+  fees numeric(18,6) not null default 0,
+  net_cash_flow numeric(18,6) not null,
+  realized_pnl numeric(18,6) not null default 0,
+  matched_open_trade_id uuid references public.options_trades(id) on delete set null,
+  fifo_lot_id uuid,
+  currency text not null default 'USD',
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_trades_source_trade_key unique (source, source_trade_id)
+);
+
+create table if not exists public.options_cash_events (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  source public.options_sync_source not null,
+  source_transaction_id text not null,
+  event_date date not null,
+  event_time timestamptz,
+  event_category public.options_cash_event_category not null,
+  description text,
+  amount numeric(18,6) not null,
+  currency text not null default 'USD',
+  related_trade_id uuid references public.options_trades(id) on delete set null,
+  related_strategy_group_id uuid references public.options_strategy_groups(id) on delete set null,
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_cash_events_source_transaction_key unique (source, source_transaction_id)
+);
+
+create table if not exists public.options_positions (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  as_of_date date not null,
+  strategy_group_id uuid references public.options_strategy_groups(id) on delete set null,
+  leg_id uuid not null references public.options_legs(id) on delete restrict,
+  opened_at timestamptz not null,
+  quantity_open numeric(18,6) not null,
+  average_open_price numeric(18,6) not null,
+  open_cash_flow numeric(18,6) not null,
+  capital_at_risk numeric(18,6),
+  ib_margin_requirement numeric(18,6),
+  last_broker_sync_at timestamptz,
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_positions_snapshot_key unique (household_id, account_id, as_of_date, leg_id)
+);
+
+create table if not exists public.options_roll_events (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  strategy_group_id uuid not null references public.options_strategy_groups(id) on delete cascade,
+  closed_trade_id uuid not null references public.options_trades(id) on delete cascade,
+  opened_trade_id uuid not null references public.options_trades(id) on delete cascade,
+  detected_at timestamptz not null default now(),
+  detection_status public.options_roll_detection_status not null default 'detected',
+  classification public.options_roll_classification not null,
+  closed_leg_realized_pnl numeric(18,6) not null,
+  incremental_cash_flow numeric(18,6) not null,
+  old_expiry date,
+  new_expiry date,
+  old_strike numeric(18,6),
+  new_strike numeric(18,6),
+  heuristic_version text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_roll_events_trade_pair_key unique (household_id, closed_trade_id, opened_trade_id)
+);
+
+create table if not exists public.options_dashboard_monthly (
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  period_start date not null,
+  period_end date not null,
+  cash_flow_total numeric(18,6) not null default 0,
+  realized_pnl_total numeric(18,6) not null default 0,
+  cash_flow_cumulative numeric(18,6) not null default 0,
+  realized_pnl_cumulative numeric(18,6) not null default 0,
+  variance_gap numeric(18,6) not null default 0,
+  variance_gap_cumulative numeric(18,6) not null default 0,
+  trade_count integer not null default 0,
+  roll_efficiency_positive_count integer,
+  roll_efficiency_negative_count integer,
+  roll_efficiency_neutral_count integer,
+  roll_efficiency_score numeric(18,6),
+  capital_at_risk_avg numeric(18,6),
+  capital_at_risk_return numeric(18,6),
+  last_computed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (household_id, account_id, period_start)
+);
+
+create index if not exists options_flex_sync_state_account_idx on public.options_flex_sync_state (account_id, last_sync_at desc);
+create unique index if not exists options_legs_household_account_conid_key on public.options_legs (household_id, account_id, source_conid) where source_conid is not null;
+create index if not exists options_legs_account_underlying_idx on public.options_legs (household_id, account_id, underlying_symbol);
+create index if not exists options_strategy_groups_account_status_idx on public.options_strategy_groups (household_id, account_id, status);
+create index if not exists options_trades_account_trade_date_idx on public.options_trades (household_id, account_id, trade_date);
+create index if not exists options_trades_leg_id_idx on public.options_trades (leg_id);
+create index if not exists options_trades_strategy_group_id_idx on public.options_trades (strategy_group_id) where strategy_group_id is not null;
+create index if not exists options_trades_matched_open_trade_id_idx on public.options_trades (matched_open_trade_id) where matched_open_trade_id is not null;
+create index if not exists options_cash_events_account_event_date_idx on public.options_cash_events (household_id, account_id, event_date);
+create index if not exists options_cash_events_related_trade_id_idx on public.options_cash_events (related_trade_id) where related_trade_id is not null;
+create index if not exists options_cash_events_related_strategy_group_id_idx on public.options_cash_events (related_strategy_group_id) where related_strategy_group_id is not null;
+create index if not exists options_positions_account_as_of_idx on public.options_positions (household_id, account_id, as_of_date desc);
+create index if not exists options_positions_strategy_group_id_idx on public.options_positions (strategy_group_id) where strategy_group_id is not null;
+create index if not exists options_positions_leg_id_idx on public.options_positions (leg_id);
+create index if not exists options_roll_events_account_detected_idx on public.options_roll_events (household_id, account_id, detected_at desc);
+create index if not exists options_roll_events_strategy_group_id_idx on public.options_roll_events (strategy_group_id);
+create index if not exists options_roll_events_closed_trade_id_idx on public.options_roll_events (closed_trade_id);
+create index if not exists options_roll_events_opened_trade_id_idx on public.options_roll_events (opened_trade_id);
+create index if not exists options_strategy_groups_parent_group_id_idx on public.options_strategy_groups (parent_group_id) where parent_group_id is not null;
+create index if not exists options_dashboard_monthly_account_period_idx on public.options_dashboard_monthly (household_id, account_id, period_start desc);
+
+-- Keep updated_at consistent with the rest of the public schema.
+drop trigger if exists trg_options_flex_sync_state_updated_at on public.options_flex_sync_state;
+create trigger trg_options_flex_sync_state_updated_at before update on public.options_flex_sync_state for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_legs_updated_at on public.options_legs;
+create trigger trg_options_legs_updated_at before update on public.options_legs for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_strategy_groups_updated_at on public.options_strategy_groups;
+create trigger trg_options_strategy_groups_updated_at before update on public.options_strategy_groups for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_trades_updated_at on public.options_trades;
+create trigger trg_options_trades_updated_at before update on public.options_trades for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_cash_events_updated_at on public.options_cash_events;
+create trigger trg_options_cash_events_updated_at before update on public.options_cash_events for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_positions_updated_at on public.options_positions;
+create trigger trg_options_positions_updated_at before update on public.options_positions for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_roll_events_updated_at on public.options_roll_events;
+create trigger trg_options_roll_events_updated_at before update on public.options_roll_events for each row execute function public.tg_update_timestamp();
+drop trigger if exists trg_options_dashboard_monthly_updated_at on public.options_dashboard_monthly;
+create trigger trg_options_dashboard_monthly_updated_at before update on public.options_dashboard_monthly for each row execute function public.tg_update_timestamp();
+
+alter table public.options_flex_sync_state enable row level security;
+alter table public.options_legs enable row level security;
+alter table public.options_strategy_groups enable row level security;
+alter table public.options_trades enable row level security;
+alter table public.options_cash_events enable row level security;
+alter table public.options_positions enable row level security;
+alter table public.options_roll_events enable row level security;
+alter table public.options_dashboard_monthly enable row level security;
+
+revoke all on table public.options_flex_sync_state, public.options_legs, public.options_strategy_groups, public.options_trades,
+  public.options_cash_events, public.options_positions, public.options_roll_events, public.options_dashboard_monthly from anon;
+revoke all on table public.options_flex_sync_state, public.options_legs, public.options_strategy_groups, public.options_trades,
+  public.options_cash_events, public.options_positions, public.options_roll_events, public.options_dashboard_monthly from authenticated;
+grant select, insert, update, delete on table public.options_flex_sync_state, public.options_legs, public.options_strategy_groups,
+  public.options_trades, public.options_cash_events, public.options_positions, public.options_roll_events, public.options_dashboard_monthly to authenticated;
+grant select, insert, update, delete on table public.options_flex_sync_state, public.options_legs, public.options_strategy_groups,
+  public.options_trades, public.options_cash_events, public.options_positions, public.options_roll_events, public.options_dashboard_monthly to service_role;
+
+-- Household-scoped policies mirror public.options_income.
+drop policy if exists options_flex_sync_state_select on public.options_flex_sync_state;
+create policy options_flex_sync_state_select on public.options_flex_sync_state for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_flex_sync_state_insert on public.options_flex_sync_state;
+create policy options_flex_sync_state_insert on public.options_flex_sync_state for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_flex_sync_state_update on public.options_flex_sync_state;
+create policy options_flex_sync_state_update on public.options_flex_sync_state for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_flex_sync_state_delete on public.options_flex_sync_state;
+create policy options_flex_sync_state_delete on public.options_flex_sync_state for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_legs_select on public.options_legs;
+create policy options_legs_select on public.options_legs for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_legs_insert on public.options_legs;
+create policy options_legs_insert on public.options_legs for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_legs_update on public.options_legs;
+create policy options_legs_update on public.options_legs for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_legs_delete on public.options_legs;
+create policy options_legs_delete on public.options_legs for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_strategy_groups_select on public.options_strategy_groups;
+create policy options_strategy_groups_select on public.options_strategy_groups for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_strategy_groups_insert on public.options_strategy_groups;
+create policy options_strategy_groups_insert on public.options_strategy_groups for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_strategy_groups_update on public.options_strategy_groups;
+create policy options_strategy_groups_update on public.options_strategy_groups for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_strategy_groups_delete on public.options_strategy_groups;
+create policy options_strategy_groups_delete on public.options_strategy_groups for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_trades_select on public.options_trades;
+create policy options_trades_select on public.options_trades for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_trades_insert on public.options_trades;
+create policy options_trades_insert on public.options_trades for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_trades_update on public.options_trades;
+create policy options_trades_update on public.options_trades for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_trades_delete on public.options_trades;
+create policy options_trades_delete on public.options_trades for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_cash_events_select on public.options_cash_events;
+create policy options_cash_events_select on public.options_cash_events for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_cash_events_insert on public.options_cash_events;
+create policy options_cash_events_insert on public.options_cash_events for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_cash_events_update on public.options_cash_events;
+create policy options_cash_events_update on public.options_cash_events for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_cash_events_delete on public.options_cash_events;
+create policy options_cash_events_delete on public.options_cash_events for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_positions_select on public.options_positions;
+create policy options_positions_select on public.options_positions for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_positions_insert on public.options_positions;
+create policy options_positions_insert on public.options_positions for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_positions_update on public.options_positions;
+create policy options_positions_update on public.options_positions for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_positions_delete on public.options_positions;
+create policy options_positions_delete on public.options_positions for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_roll_events_select on public.options_roll_events;
+create policy options_roll_events_select on public.options_roll_events for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_roll_events_insert on public.options_roll_events;
+create policy options_roll_events_insert on public.options_roll_events for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_roll_events_update on public.options_roll_events;
+create policy options_roll_events_update on public.options_roll_events for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_roll_events_delete on public.options_roll_events;
+create policy options_roll_events_delete on public.options_roll_events for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+drop policy if exists options_dashboard_monthly_select on public.options_dashboard_monthly;
+create policy options_dashboard_monthly_select on public.options_dashboard_monthly for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_dashboard_monthly_insert on public.options_dashboard_monthly;
+create policy options_dashboard_monthly_insert on public.options_dashboard_monthly for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_dashboard_monthly_update on public.options_dashboard_monthly;
+create policy options_dashboard_monthly_update on public.options_dashboard_monthly for update to authenticated using (household_id is not null and public.is_household_writer(household_id)) with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_dashboard_monthly_delete on public.options_dashboard_monthly;
+create policy options_dashboard_monthly_delete on public.options_dashboard_monthly for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+do $$
+begin
+  alter publication supabase_realtime add table public.options_flex_sync_state;
+exception when duplicate_object then null; when undefined_object then null; end $$;
+do $$
+begin
+  alter publication supabase_realtime add table public.options_strategy_groups;
+exception when duplicate_object then null; when undefined_object then null; end $$;
+do $$
+begin
+  alter publication supabase_realtime add table public.options_positions;
+exception when duplicate_object then null; when undefined_object then null; end $$;
+do $$
+begin
+  alter publication supabase_realtime add table public.options_roll_events;
+exception when duplicate_object then null; when undefined_object then null; end $$;
+do $$
+begin
+  alter publication supabase_realtime add table public.options_dashboard_monthly;
+exception when duplicate_object then null; when undefined_object then null; end $$;


### PR DESCRIPTION
## Summary
- Adds Phase 1 options-income Supabase schema, RLS, realtime publication, and per-account compute_options_income toggle.
- Adds typed IBKR Flex parsers, flex_options_sync and compute_options_monthly_metrics worker handlers/schedule, and synchronous backfill CLI.
- Adds trading account UI toggle and parser/metrics/worker tests.

Working as Hockney (Backend lead), with McManus (Data/Finance) and Rabin (Security) concerns applied.

Closes #246

## Validation
- uv run --project apps/backend ruff check apps/backend/
- cd apps/backend && uv run pytest -q (297 passed)
- cd apps/frontend && npm test -- --run src/app/trading/actions.test.ts
- cd apps/frontend && npm run build
- Supabase security/performance advisors reviewed; new options tables have RLS and indexed FKs.

## Notes
- Synthetic backfill CLI is implemented, but local execution is blocked by stale DATABASE_URL credentials in apps/backend/.env (password auth failed). Parser-level synthetic reconciliation was verified locally.
- Walkthrough E2E is blocked locally by the existing production Supabase safety guard for the configured project ref; no allow-list changes were added.