### PR TITLE
feat(options): #247 phase 2 — roll detection + strategy groups + roll metrics

### DIFF
--- a/apps/backend/app/services/options/metrics.py
+++ b/apps/backend/app/services/options/metrics.py
@@ -20,6 +20,15 @@ class OptionMetricTrade(BaseModel):
     trade_count: int = 1
 
 
+class OptionMetricRoll(BaseModel):
+    """Minimal dated roll fact required for roll-efficiency metrics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    detected_date: date
+    classification: str
+
+
 class MonthlyMetric(BaseModel):
     """Persistable monthly options dashboard row."""
 
@@ -34,13 +43,20 @@ class MonthlyMetric(BaseModel):
     variance_gap: Decimal
     variance_gap_cumulative: Decimal
     trade_count: int
+    roll_count: int = 0
+    roll_positive_count: int = 0
+    roll_negative_count: int = 0
+    roll_neutral_count: int = 0
+    roll_efficiency_pct: Decimal | None = None
 
 
-def compute_monthly_metrics(trades: Iterable[OptionMetricTrade]) -> list[MonthlyMetric]:
-    """Aggregate trades by calendar month and persist rolling cash-vs-P&L gap."""
+def compute_monthly_metrics(
+    trades: Iterable[OptionMetricTrade], rolls: Iterable[OptionMetricRoll] | None = None
+) -> list[MonthlyMetric]:
+    """Aggregate trades and rolls by month for cash, P&L, gap, and roll efficiency."""
 
     buckets: dict[date, dict[str, Decimal | int]] = defaultdict(
-        lambda: {"cash": Decimal("0"), "pnl": Decimal("0"), "count": 0}
+        lambda: {"cash": Decimal("0"), "pnl": Decimal("0"), "count": 0, "positive": 0, "negative": 0, "neutral": 0}
     )
     for trade in trades:
         month = date(trade.trade_date.year, trade.trade_date.month, 1)
@@ -48,12 +64,25 @@ def compute_monthly_metrics(trades: Iterable[OptionMetricTrade]) -> list[Monthly
         buckets[month]["pnl"] = Decimal(buckets[month]["pnl"]) + trade.realized_pnl
         buckets[month]["count"] = int(buckets[month]["count"]) + trade.trade_count
 
+    for roll in rolls or []:
+        month = date(roll.detected_date.year, roll.detected_date.month, 1)
+        if roll.classification == "positive":
+            buckets[month]["positive"] = int(buckets[month]["positive"]) + 1
+        elif roll.classification == "negative":
+            buckets[month]["negative"] = int(buckets[month]["negative"]) + 1
+        elif roll.classification == "neutral":
+            buckets[month]["neutral"] = int(buckets[month]["neutral"]) + 1
+
     rows: list[MonthlyMetric] = []
     cumulative_cash = Decimal("0")
     cumulative_pnl = Decimal("0")
     for month in sorted(buckets):
         cash = Decimal(buckets[month]["cash"])
         pnl = Decimal(buckets[month]["pnl"])
+        positive = int(buckets[month]["positive"])
+        negative = int(buckets[month]["negative"])
+        neutral = int(buckets[month]["neutral"])
+        roll_count = positive + negative + neutral
         cumulative_cash += cash
         cumulative_pnl += pnl
         rows.append(
@@ -67,6 +96,13 @@ def compute_monthly_metrics(trades: Iterable[OptionMetricTrade]) -> list[Monthly
                 variance_gap=cash - pnl,
                 variance_gap_cumulative=cumulative_cash - cumulative_pnl,
                 trade_count=int(buckets[month]["count"]),
+                roll_count=roll_count,
+                roll_positive_count=positive,
+                roll_negative_count=negative,
+                roll_neutral_count=neutral,
+                roll_efficiency_pct=(Decimal(positive) / Decimal(roll_count) * Decimal("100")).quantize(Decimal("0.01"))
+                if roll_count
+                else None,
             )
         )
     return rows

--- a/apps/backend/app/services/options/roll_detector.py
+++ b/apps/backend/app/services/options/roll_detector.py
@@ -1,0 +1,105 @@
+"""Pure roll-detection heuristics for options-income trades."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Literal
+
+RollClassification = Literal["positive", "negative", "neutral"]
+NEUTRAL_THRESHOLD = Decimal("25.00")
+CLOSE_EVENT_TYPES = frozenset({"close", "expire", "assign", "exercise"})
+HEURISTIC_VERSION = "phase2_same_day_v1"
+
+
+@dataclass(frozen=True, slots=True)
+class RollCandidateTrade:
+    """Minimal option trade facts needed to detect a same-day roll."""
+
+    trade_id: str
+    account_id: str
+    trade_date: date
+    underlying_symbol: str
+    right: str
+    side: str
+    open_close_indicator: str | None
+    event_type: str
+    strike: Decimal
+    expiry: date
+    quantity: Decimal
+    realized_pnl: Decimal
+    net_cash_flow: Decimal = Decimal("0")
+    currency: str = "USD"
+
+
+RollDetection = tuple[str, str, Decimal, RollClassification]
+
+
+def detect_rolls(trades: list[RollCandidateTrade]) -> list[RollDetection]:
+    """Detect same-trading-day rolls as closed/opened/P&L/classification tuples."""
+
+    if not trades:
+        return []
+
+    closes = [trade for trade in trades if _is_close_trade(trade)]
+    opens = [trade for trade in trades if _is_open_trade(trade)]
+    scored: list[tuple[Decimal, str, str, RollCandidateTrade, RollCandidateTrade]] = []
+    for closed in closes:
+        for opened in opens:
+            if not _is_candidate_pair(closed, opened):
+                continue
+            score = abs(closed.strike - opened.strike) + Decimal(abs((opened.expiry - closed.expiry).days))
+            scored.append((score, closed.trade_id, opened.trade_id, closed, opened))
+
+    linked_closes: set[str] = set()
+    linked_opens: set[str] = set()
+    matches: list[RollDetection] = []
+    for _, _, _, closed, opened in sorted(scored, key=lambda item: (item[0], item[1], item[2])):
+        if closed.trade_id in linked_closes or opened.trade_id in linked_opens:
+            continue
+        linked_closes.add(closed.trade_id)
+        linked_opens.add(opened.trade_id)
+        matches.append((closed.trade_id, opened.trade_id, closed.realized_pnl, classify_roll(closed.realized_pnl)))
+    return matches
+
+
+def classify_roll(realized_pnl_at_close: Decimal) -> RollClassification:
+    """Classify roll quality from closed-leg realized P&L with a ±$25 neutral band."""
+
+    if abs(realized_pnl_at_close) <= NEUTRAL_THRESHOLD:
+        return "neutral"
+    if realized_pnl_at_close > NEUTRAL_THRESHOLD:
+        return "positive"
+    return "negative"
+
+
+def _is_candidate_pair(closed: RollCandidateTrade, opened: RollCandidateTrade) -> bool:
+    return (
+        closed.account_id == opened.account_id
+        and closed.trade_date == opened.trade_date
+        and closed.underlying_symbol == opened.underlying_symbol
+        and closed.currency == opened.currency
+        and closed.right == opened.right
+        and closed.side != opened.side
+        and (closed.strike != opened.strike or closed.expiry != opened.expiry)
+        and _quantity_overlap(closed, opened) >= Decimal("0.80")
+    )
+
+
+def _is_close_trade(trade: RollCandidateTrade) -> bool:
+    indicator = (trade.open_close_indicator or "").upper()
+    return indicator == "C" or trade.event_type in CLOSE_EVENT_TYPES
+
+
+def _is_open_trade(trade: RollCandidateTrade) -> bool:
+    indicator = (trade.open_close_indicator or "").upper()
+    return indicator == "O" or trade.event_type == "open"
+
+
+def _quantity_overlap(closed: RollCandidateTrade, opened: RollCandidateTrade) -> Decimal:
+    closed_qty = abs(closed.quantity)
+    opened_qty = abs(opened.quantity)
+    if closed_qty == 0 or opened_qty == 0:
+        return Decimal("0")
+    return min(closed_qty, opened_qty) / closed_qty

--- a/apps/backend/app/services/options/strategy_grouper.py
+++ b/apps/backend/app/services/options/strategy_grouper.py
@@ -1,0 +1,268 @@
+"""Pure strategy grouping heuristics for options-income trades."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Literal
+from uuid import UUID, uuid5
+
+from app.services.options.roll_detector import HEURISTIC_VERSION, RollCandidateTrade, detect_rolls
+
+StrategyKind = Literal["csp", "vertical_spread", "roll_chain", "ungrouped"]
+StrategyStatus = Literal["open", "closed", "expired", "assigned", "mixed"]
+GROUP_NAMESPACE = UUID("f6288d91-31d7-4eaf-94f5-090bda327f8e")
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyTrade(RollCandidateTrade):
+    """Trade facts needed for deterministic strategy grouping."""
+
+    household_id: str = ""
+    trade_time: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyGroup:
+    """Persistable grouped options strategy summary."""
+
+    group_id: str
+    household_id: str
+    account_id: str
+    underlying_symbol: str
+    kind: StrategyKind
+    status: StrategyStatus
+    trade_ids: tuple[str, ...]
+    opened_at: datetime
+    closed_at: datetime | None
+    net_cash_flow: Decimal
+    realized_pnl: Decimal
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyRollEvent:
+    """Persistable roll linkage attached to a strategy group."""
+
+    group_id: str
+    closed_trade_id: str
+    opened_trade_id: str
+    classification: str
+    closed_leg_realized_pnl: Decimal
+    incremental_cash_flow: Decimal
+    old_expiry: date
+    new_expiry: date
+    old_strike: Decimal
+    new_strike: Decimal
+    heuristic_version: str = HEURISTIC_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyGroupingResult:
+    """Pure grouping output for worker persistence."""
+
+    groups: list[StrategyGroup]
+    roll_events: list[StrategyRollEvent]
+    trade_group_ids: dict[str, str]
+
+
+def group_option_strategies(trades: list[StrategyTrade]) -> StrategyGroupingResult:
+    """Classify trades into deterministic Phase 2 strategy groups."""
+
+    ordered = sorted(trades, key=lambda trade: (trade.trade_date, trade.trade_time or datetime.min, trade.trade_id))
+    if not ordered:
+        return StrategyGroupingResult(groups=[], roll_events=[], trade_group_ids={})
+
+    by_id = {trade.trade_id: trade for trade in ordered}
+    rolls = detect_rolls([_roll_trade(trade) for trade in ordered])
+    rolled_open_ids = {opened_trade_id for _, opened_trade_id, _, _ in rolls}
+    builders: list[_GroupBuilder] = []
+    assigned_open_ids: set[str] = set()
+
+    for first, second in _vertical_open_pairs(ordered):
+        trade_ids = tuple(sorted((first.trade_id, second.trade_id)))
+        builders.append(_GroupBuilder(anchor_ids=trade_ids, kind="vertical_spread", trade_ids=set(trade_ids)))
+        assigned_open_ids.update(trade_ids)
+
+    for trade in ordered:
+        if trade.trade_id in assigned_open_ids or trade.trade_id in rolled_open_ids or not _is_open_short_put(trade):
+            continue
+        builders.append(_GroupBuilder(anchor_ids=(trade.trade_id,), kind="csp", trade_ids={trade.trade_id}))
+        assigned_open_ids.add(trade.trade_id)
+
+    _attach_matching_closes(builders, ordered)
+    roll_events: list[StrategyRollEvent] = []
+    for closed_trade_id, opened_trade_id, realized_pnl_at_close, classification in rolls:
+        builder = _find_builder_containing(builders, closed_trade_id)
+        if builder is None:
+            continue
+        builder.kind = "roll_chain"
+        builder.trade_ids.add(opened_trade_id)
+        opened = by_id[opened_trade_id]
+        closed = by_id[closed_trade_id]
+        roll_events.append(
+            StrategyRollEvent(
+                group_id=_group_id(builder.anchor_ids),
+                closed_trade_id=closed_trade_id,
+                opened_trade_id=opened_trade_id,
+                classification=classification,
+                closed_leg_realized_pnl=realized_pnl_at_close,
+                incremental_cash_flow=closed.net_cash_flow + opened.net_cash_flow,
+                old_expiry=closed.expiry,
+                new_expiry=opened.expiry,
+                old_strike=closed.strike,
+                new_strike=opened.strike,
+            )
+        )
+    _attach_matching_closes(builders, ordered)
+
+    assigned = {trade_id for builder in builders for trade_id in builder.trade_ids}
+    for trade in ordered:
+        if trade.trade_id in assigned:
+            continue
+        builders.append(_GroupBuilder(anchor_ids=(trade.trade_id,), kind="ungrouped", trade_ids={trade.trade_id}))
+        assigned.add(trade.trade_id)
+
+    groups = [_build_group(builder, by_id) for builder in builders]
+    trade_group_ids = {trade_id: group.group_id for group in groups for trade_id in group.trade_ids}
+    return StrategyGroupingResult(groups=groups, roll_events=roll_events, trade_group_ids=trade_group_ids)
+
+
+@dataclass(slots=True)
+class _GroupBuilder:
+    anchor_ids: tuple[str, ...]
+    kind: StrategyKind
+    trade_ids: set[str]
+
+
+def _vertical_open_pairs(trades: list[StrategyTrade]) -> list[tuple[StrategyTrade, StrategyTrade]]:
+    opens = [trade for trade in trades if _is_open(trade)]
+    buckets: dict[tuple[str, str, date, str, str, date], list[StrategyTrade]] = defaultdict(list)
+    for trade in opens:
+        buckets[
+            (trade.household_id, trade.account_id, trade.trade_date, trade.underlying_symbol, trade.right, trade.expiry)
+        ].append(trade)
+
+    used: set[str] = set()
+    pairs: list[tuple[StrategyTrade, StrategyTrade]] = []
+    for bucket in buckets.values():
+        sorted_bucket = sorted(bucket, key=lambda trade: (trade.trade_time or datetime.min, trade.trade_id))
+        for first in sorted_bucket:
+            if first.trade_id in used:
+                continue
+            candidates = [
+                trade
+                for trade in sorted_bucket
+                if trade.trade_id not in used
+                and trade.trade_id != first.trade_id
+                and trade.side != first.side
+                and trade.strike != first.strike
+            ]
+            if not candidates:
+                continue
+            second = min(candidates, key=lambda trade: (abs(trade.strike - first.strike), trade.trade_id))
+            used.update({first.trade_id, second.trade_id})
+            pairs.append((first, second))
+    return pairs
+
+
+def _attach_matching_closes(builders: list[_GroupBuilder], trades: list[StrategyTrade]) -> None:
+    by_id = {trade.trade_id: trade for trade in trades}
+    changed = True
+    while changed:
+        changed = False
+        for builder in builders:
+            contracts = {_contract_key(by_id[trade_id]) for trade_id in builder.trade_ids if _is_open(by_id[trade_id])}
+            for trade in trades:
+                if trade.trade_id in builder.trade_ids or not _is_close(trade):
+                    continue
+                if _contract_key(trade) in contracts:
+                    builder.trade_ids.add(trade.trade_id)
+                    changed = True
+
+
+def _build_group(builder: _GroupBuilder, by_id: dict[str, StrategyTrade]) -> StrategyGroup:
+    group_trades = [by_id[trade_id] for trade_id in sorted(builder.trade_ids)]
+    times = [trade.trade_time or datetime.combine(trade.trade_date, datetime.min.time()) for trade in group_trades]
+    close_times = [time for trade, time in zip(group_trades, times, strict=True) if _is_close(trade)]
+    return StrategyGroup(
+        group_id=_group_id(builder.anchor_ids),
+        household_id=group_trades[0].household_id,
+        account_id=group_trades[0].account_id,
+        underlying_symbol=group_trades[0].underlying_symbol,
+        kind=builder.kind,
+        status=_status(group_trades),
+        trade_ids=tuple(sorted(builder.trade_ids)),
+        opened_at=min(times),
+        closed_at=max(close_times)
+        if close_times and all(_is_close(trade) or _has_close(trade, group_trades) for trade in group_trades)
+        else None,
+        net_cash_flow=sum((trade.net_cash_flow for trade in group_trades), Decimal("0")),
+        realized_pnl=sum((trade.realized_pnl for trade in group_trades), Decimal("0")),
+        metadata={"trade_ids": sorted(builder.trade_ids), "anchor_trade_ids": list(builder.anchor_ids)},
+    )
+
+
+def _status(trades: list[StrategyTrade]) -> StrategyStatus:
+    if any(trade.event_type == "assign" for trade in trades):
+        return "assigned"
+    if any(trade.event_type == "expire" for trade in trades):
+        return "expired"
+    opens = [trade for trade in trades if _is_open(trade)]
+    if opens and all(_has_close(trade, trades) for trade in opens):
+        return "closed"
+    return "open"
+
+
+def _has_close(open_trade: StrategyTrade, trades: list[StrategyTrade]) -> bool:
+    return any(_is_close(trade) and _contract_key(trade) == _contract_key(open_trade) for trade in trades)
+
+
+def _find_builder_containing(builders: list[_GroupBuilder], trade_id: str) -> _GroupBuilder | None:
+    return next((builder for builder in builders if trade_id in builder.trade_ids), None)
+
+
+def _group_id(anchor_ids: tuple[str, ...]) -> str:
+    return str(uuid5(GROUP_NAMESPACE, ":".join(sorted(anchor_ids))))
+
+
+def _contract_key(trade: StrategyTrade) -> tuple[str, str, str, date, Decimal]:
+    return (trade.account_id, trade.underlying_symbol, trade.right, trade.expiry, trade.strike)
+
+
+def _is_open_short_put(trade: StrategyTrade) -> bool:
+    return _is_open(trade) and trade.right == "put" and trade.side == "sell"
+
+
+def _is_open(trade: StrategyTrade) -> bool:
+    return (trade.open_close_indicator or "").upper() == "O" or trade.event_type == "open"
+
+
+def _is_close(trade: StrategyTrade) -> bool:
+    return (trade.open_close_indicator or "").upper() == "C" or trade.event_type in {
+        "close",
+        "expire",
+        "assign",
+        "exercise",
+    }
+
+
+def _roll_trade(trade: StrategyTrade) -> RollCandidateTrade:
+    return RollCandidateTrade(
+        trade_id=trade.trade_id,
+        account_id=trade.account_id,
+        trade_date=trade.trade_date,
+        underlying_symbol=trade.underlying_symbol,
+        right=trade.right,
+        side=trade.side,
+        open_close_indicator=trade.open_close_indicator,
+        event_type=trade.event_type,
+        strike=trade.strike,
+        expiry=trade.expiry,
+        quantity=trade.quantity,
+        realized_pnl=trade.realized_pnl,
+        net_cash_flow=trade.net_cash_flow,
+        currency=trade.currency,
+    )

--- a/apps/backend/app/worker/handlers/options_grouping.py
+++ b/apps/backend/app/worker/handlers/options_grouping.py
@@ -1,0 +1,255 @@
+"""Worker handler that populates options strategy groups and roll events."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from datetime import date
+from decimal import Decimal
+import json
+from typing import Any
+
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.options.strategy_grouper import StrategyGroupingResult, StrategyTrade, group_option_strategies
+from app.worker.handlers.options_sync import OptionsAccount, _load_accounts
+
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a worker database session."""
+
+    return Session(engine)
+
+
+def handle_compute_options_strategy_groups(
+    payload: JobPayload,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> JobResult:
+    """Populate options strategy groups and roll events for one or more accounts."""
+
+    with (session_factory or _default_session_factory)() as session:
+        result = compute_options_strategy_groups(
+            session,
+            household_id=_optional_str(payload.get("household_id")),
+            account_id=_optional_str(payload.get("account_id")),
+            from_date=_optional_date(payload.get("from")),
+            to_date=_optional_date(payload.get("to")),
+        )
+        session.commit()
+        return result
+
+
+def compute_options_strategy_groups(
+    session: Session,
+    *,
+    household_id: str | None = None,
+    account_id: str | None = None,
+    from_date: date | None = None,
+    to_date: date | None = None,
+) -> JobResult:
+    """Rebuild deterministic strategy grouping for enabled options accounts."""
+
+    accounts = _grouping_accounts(session, household_id=household_id, account_id=account_id)
+    output: dict[str, Any] = {"accounts": [], "group_count": 0, "roll_event_count": 0, "trade_count": 0}
+    for account in accounts:
+        trades = _load_strategy_trades(session, account.household_id, account.account_id, from_date, to_date)
+        result = group_option_strategies(trades)
+        _persist_grouping(session, result)
+        output["accounts"].append(
+            {
+                "household_id": account.household_id,
+                "account_id": account.account_id,
+                "groups": len(result.groups),
+                "roll_events": len(result.roll_events),
+                "trades": len(result.trade_group_ids),
+            }
+        )
+        output["group_count"] += len(result.groups)
+        output["roll_event_count"] += len(result.roll_events)
+        output["trade_count"] += len(result.trade_group_ids)
+    return output
+
+
+def _grouping_accounts(session: Session, *, household_id: str | None, account_id: str | None) -> list[OptionsAccount]:
+    accounts = _load_accounts(session, account_id=account_id)
+    if household_id:
+        return [account for account in accounts if account.household_id == household_id]
+    return accounts
+
+
+def _load_strategy_trades(
+    session: Session,
+    household_id: str,
+    account_id: str | None,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[StrategyTrade]:
+    if account_id is None:
+        return []
+    where = ["t.household_id = :household_id", "t.account_id = :account_id"]
+    params: dict[str, Any] = {"household_id": household_id, "account_id": account_id}
+    if from_date:
+        where.append("t.trade_date >= :from_date")
+        params["from_date"] = from_date
+    if to_date:
+        where.append("t.trade_date <= :to_date")
+        params["to_date"] = to_date
+    rows = session.execute(
+        text(
+            f"""
+            select t.id::text as trade_id,
+                   t.household_id::text as household_id,
+                   t.account_id,
+                   t.trade_time,
+                   t.trade_date,
+                   t.event_type::text as event_type,
+                   t.side::text as side,
+                   t.quantity,
+                   t.net_cash_flow,
+                   t.realized_pnl,
+                   t.currency,
+                   t.raw_payload ->> 'openCloseIndicator' as open_close_indicator,
+                   l.underlying_symbol,
+                   l."right"::text as right,
+                   l.strike,
+                   l.expiry
+              from public.options_trades t
+              join public.options_legs l on l.id = t.leg_id
+             where {" and ".join(where)}
+             order by t.trade_date, t.trade_time, t.id
+            """
+        ),
+        params,
+    ).mappings()
+    return [
+        StrategyTrade(
+            trade_id=str(row["trade_id"]),
+            household_id=str(row["household_id"]),
+            account_id=str(row["account_id"]),
+            trade_time=row["trade_time"],
+            trade_date=row["trade_date"],
+            event_type=str(row["event_type"]),
+            side=str(row["side"]),
+            open_close_indicator=str(row["open_close_indicator"] or "") or None,
+            quantity=Decimal(str(row["quantity"])),
+            net_cash_flow=Decimal(str(row["net_cash_flow"])),
+            realized_pnl=Decimal(str(row["realized_pnl"])),
+            currency=str(row["currency"]),
+            underlying_symbol=str(row["underlying_symbol"]),
+            right=str(row["right"]),
+            strike=Decimal(str(row["strike"])),
+            expiry=row["expiry"],
+        )
+        for row in rows
+    ]
+
+
+def _persist_grouping(session: Session, result: StrategyGroupingResult) -> None:
+    for group in result.groups:
+        session.execute(
+            text(
+                """
+                insert into public.options_strategy_groups (
+                  id, household_id, account_id, underlying_symbol, kind, status, opened_at, closed_at,
+                  net_cash_flow, realized_pnl, metadata
+                ) values (
+                  :id, :household_id, :account_id, :underlying_symbol, :kind, :status, :opened_at, :closed_at,
+                  :net_cash_flow, :realized_pnl, cast(:metadata as jsonb)
+                )
+                on conflict (id) do update set
+                  underlying_symbol = excluded.underlying_symbol,
+                  kind = excluded.kind,
+                  status = excluded.status,
+                  opened_at = excluded.opened_at,
+                  closed_at = excluded.closed_at,
+                  net_cash_flow = excluded.net_cash_flow,
+                  realized_pnl = excluded.realized_pnl,
+                  metadata = excluded.metadata,
+                  updated_at = now()
+                """
+            ),
+            {
+                "id": group.group_id,
+                "household_id": group.household_id,
+                "account_id": group.account_id,
+                "underlying_symbol": group.underlying_symbol,
+                "kind": group.kind,
+                "status": group.status,
+                "opened_at": group.opened_at,
+                "closed_at": group.closed_at,
+                "net_cash_flow": group.net_cash_flow,
+                "realized_pnl": group.realized_pnl,
+                "metadata": _json(group.metadata),
+            },
+        )
+    for trade_id, group_id in result.trade_group_ids.items():
+        session.execute(
+            text(
+                "update public.options_trades set strategy_group_id = :group_id, updated_at = now() where id = :trade_id"
+            ),
+            {"group_id": group_id, "trade_id": trade_id},
+        )
+    for roll in result.roll_events:
+        session.execute(
+            text(
+                """
+                insert into public.options_roll_events (
+                  household_id, account_id, strategy_group_id, closed_trade_id, opened_trade_id,
+                  classification, closed_leg_realized_pnl, incremental_cash_flow, old_expiry,
+                  new_expiry, old_strike, new_strike, heuristic_version, metadata
+                )
+                select g.household_id, g.account_id, :group_id, :closed_trade_id, :opened_trade_id,
+                       :classification, :closed_leg_realized_pnl, :incremental_cash_flow, :old_expiry,
+                       :new_expiry, :old_strike, :new_strike, :heuristic_version, cast(:metadata as jsonb)
+                  from public.options_strategy_groups g
+                 where g.id = :group_id
+                on conflict on constraint options_roll_events_trade_pair_key do update set
+                  strategy_group_id = excluded.strategy_group_id,
+                  classification = excluded.classification,
+                  closed_leg_realized_pnl = excluded.closed_leg_realized_pnl,
+                  incremental_cash_flow = excluded.incremental_cash_flow,
+                  old_expiry = excluded.old_expiry,
+                  new_expiry = excluded.new_expiry,
+                  old_strike = excluded.old_strike,
+                  new_strike = excluded.new_strike,
+                  heuristic_version = excluded.heuristic_version,
+                  metadata = excluded.metadata,
+                  updated_at = now()
+                """
+            ),
+            {
+                "group_id": roll.group_id,
+                "closed_trade_id": roll.closed_trade_id,
+                "opened_trade_id": roll.opened_trade_id,
+                "classification": roll.classification,
+                "closed_leg_realized_pnl": roll.closed_leg_realized_pnl,
+                "incremental_cash_flow": roll.incremental_cash_flow,
+                "old_expiry": roll.old_expiry,
+                "new_expiry": roll.new_expiry,
+                "old_strike": roll.old_strike,
+                "new_strike": roll.new_strike,
+                "heuristic_version": roll.heuristic_version,
+                "metadata": _json({}),
+            },
+        )
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, default=str, sort_keys=True)
+
+
+def _optional_str(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_date(value: object) -> date | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return date.fromisoformat(value)

--- a/apps/backend/app/worker/handlers/options_metrics.py
+++ b/apps/backend/app/worker/handlers/options_metrics.py
@@ -12,7 +12,7 @@ from sqlalchemy import text
 from sqlmodel import Session
 
 from app.dal.database import engine
-from app.services.options.metrics import OptionMetricTrade, compute_monthly_metrics
+from app.services.options.metrics import OptionMetricRoll, OptionMetricTrade, compute_monthly_metrics
 
 JobPayload = dict[str, object]
 JobResult = dict[str, object]
@@ -58,7 +58,8 @@ def compute_options_monthly_metrics(
     output: dict[str, Any] = {"accounts": [], "row_count": 0}
     for account in accounts:
         rows = _load_trade_facts(session, account["household_id"], account["account_id"], from_date, to_date)
-        metrics = compute_monthly_metrics(rows)
+        rolls = _load_roll_facts(session, account["household_id"], account["account_id"], from_date, to_date)
+        metrics = compute_monthly_metrics(rows, rolls)
         if metrics:
             start = metrics[0].period_start
             end = metrics[-1].period_start
@@ -86,12 +87,16 @@ def compute_options_monthly_metrics(
                           household_id, account_id, period_start, period_end,
                           cash_flow_total, realized_pnl_total,
                           cash_flow_cumulative, realized_pnl_cumulative,
-                          variance_gap, variance_gap_cumulative, trade_count, last_computed_at
+                          variance_gap, variance_gap_cumulative, trade_count,
+                          roll_count, roll_positive_count, roll_negative_count,
+                          roll_neutral_count, roll_efficiency_pct, last_computed_at
                         ) values (
                           :household_id, :account_id, :period_start, :period_end,
                           :cash_flow_total, :realized_pnl_total,
                           :cash_flow_cumulative, :realized_pnl_cumulative,
-                          :variance_gap, :variance_gap_cumulative, :trade_count, now()
+                          :variance_gap, :variance_gap_cumulative, :trade_count,
+                          :roll_count, :roll_positive_count, :roll_negative_count,
+                          :roll_neutral_count, :roll_efficiency_pct, now()
                         )
                         """
                     ),
@@ -109,6 +114,19 @@ def compute_options_monthly_metrics(
                 "cash_flow_total": str(sum((m.cash_flow_total for m in metrics), Decimal("0"))),
                 "realized_pnl_total": str(sum((m.realized_pnl_total for m in metrics), Decimal("0"))),
                 "variance_gap_cumulative": str(metrics[-1].variance_gap_cumulative if metrics else Decimal("0")),
+                "roll_count": sum(m.roll_count for m in metrics),
+                "roll_positive_count": sum(m.roll_positive_count for m in metrics),
+                "roll_negative_count": sum(m.roll_negative_count for m in metrics),
+                "roll_neutral_count": sum(m.roll_neutral_count for m in metrics),
+                "roll_efficiency_pct": str(
+                    (
+                        Decimal(sum(m.roll_positive_count for m in metrics))
+                        / Decimal(sum(m.roll_count for m in metrics))
+                        * Decimal("100")
+                    ).quantize(Decimal("0.01"))
+                    if sum(m.roll_count for m in metrics)
+                    else Decimal("0.00")
+                ),
             }
         )
         output["row_count"] += len(metrics)
@@ -177,6 +195,38 @@ def _load_trade_facts(
             trade_count=int(row["trade_count"]),
         )
         for row in rows
+    ]
+
+
+def _load_roll_facts(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[OptionMetricRoll]:
+    where = ["r.household_id = :household_id", "r.account_id = :account_id", "r.detection_status != 'rejected'"]
+    params: dict[str, Any] = {"household_id": household_id, "account_id": account_id}
+    if from_date:
+        where.append("t.trade_date >= :from_date")
+        params["from_date"] = from_date
+    if to_date:
+        where.append("t.trade_date <= :to_date")
+        params["to_date"] = to_date
+    rows = session.execute(
+        text(
+            f"""
+            select t.trade_date as detected_date, r.classification::text as classification
+              from public.options_roll_events r
+              join public.options_trades t on t.id = r.closed_trade_id
+             where {" and ".join(where)}
+             order by t.trade_date, r.id
+            """
+        ),
+        params,
+    ).mappings()
+    return [
+        OptionMetricRoll(detected_date=row["detected_date"], classification=str(row["classification"])) for row in rows
     ]
 
 

--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -65,6 +65,15 @@ def handle_flex_options_sync(
             account_id=_optional_str(payload.get("account_id")),
             synthetic=_optional_bool(payload.get("synthetic")),
         )
+        from app.worker.handlers.options_grouping import compute_options_strategy_groups
+
+        grouping_result = compute_options_strategy_groups(
+            session,
+            household_id=_optional_str(payload.get("household_id")),
+            account_id=_optional_str(payload.get("account_id")),
+            from_date=_optional_date(payload.get("from")),
+            to_date=_optional_date(payload.get("to")),
+        )
         metric_result = compute_options_monthly_metrics(
             session,
             household_id=_optional_str(payload.get("household_id")),
@@ -73,14 +82,17 @@ def handle_flex_options_sync(
             to_date=_optional_date(payload.get("to")),
         )
         session.commit()
-        return {**result, "monthly_metrics": metric_result}
+        return {**result, "strategy_groups": grouping_result, "monthly_metrics": metric_result}
 
 
 def run_scheduled_flex_options_sync() -> None:
     """Run the daily scheduled Flex sync with configured source selection."""
 
     with _default_session_factory() as session:
+        from app.worker.handlers.options_grouping import compute_options_strategy_groups
+
         result = run_flex_options_sync(session)
+        compute_options_strategy_groups(session)
         compute_options_monthly_metrics(session)
         session.commit()
     logger.info("Scheduled flex_options_sync completed: %s", result)

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -7,6 +7,7 @@ from typing import Literal
 from app.services.trading_batch import run_trading_sync_batch
 from app.worker.backtest_handler import run_backtest_job
 from app.worker.bonds_scanner import refresh_bond_scanner_results
+from app.worker.handlers.options_grouping import handle_compute_options_strategy_groups
 from app.worker.handlers.options_metrics import handle_compute_options_monthly_metrics
 from app.worker.handlers.options_sync import handle_flex_options_sync, run_scheduled_flex_options_sync
 from app.worker.pension_pdf_parse import handle_pension_pdf_parse
@@ -32,6 +33,7 @@ JOB_HANDLERS: dict[str, JobHandler] = {
     "pension_pdf_parse": handle_pension_pdf_parse,
     "backtest": run_backtest_job,
     "flex_options_sync": handle_flex_options_sync,
+    "compute_options_strategy_groups": handle_compute_options_strategy_groups,
     "compute_options_monthly_metrics": handle_compute_options_monthly_metrics,
 }
 JOB_SCHEDULES: list[JobSchedule] = [

--- a/apps/backend/scripts/backfill_options.py
+++ b/apps/backend/scripts/backfill_options.py
@@ -12,6 +12,7 @@ from typing import Iterable
 from sqlmodel import Session
 
 from app.dal.database import engine
+from app.worker.handlers.options_grouping import compute_options_strategy_groups
 from app.worker.handlers.options_metrics import compute_options_monthly_metrics
 from app.worker.handlers.options_sync import run_flex_options_sync
 
@@ -44,6 +45,12 @@ def main(argv: Iterable[str] | None = None) -> int:
             account_id=args.account_id,
             synthetic=args.synthetic,
         )
+        grouping_result = compute_options_strategy_groups(
+            session,
+            account_id=args.account_id,
+            from_date=args.from_date,
+            to_date=args.to_date,
+        )
         metrics_result = compute_options_monthly_metrics(
             session,
             account_id=args.account_id,
@@ -52,6 +59,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         )
         session.commit()
     print("Flex sync:", sync_result)
+    print("Strategy grouping:", grouping_result)
     print("Monthly metrics:", metrics_result)
     totals = _totals(metrics_result)
     print(

--- a/apps/backend/tests/services/options/test_jony_phase2_e2e.py
+++ b/apps/backend/tests/services/options/test_jony_phase2_e2e.py
@@ -1,0 +1,73 @@
+"""End-to-end synthetic checks for Jony's Phase 2 options worked example."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from pathlib import Path
+import shutil
+
+from app.services.options.metrics import OptionMetricRoll, OptionMetricTrade, compute_monthly_metrics
+from app.services.options.strategy_grouper import StrategyTrade, group_option_strategies
+from app.services.options.flex_parser import parse_flex_files
+from scripts.flex_synthetic import write_synthetic_files
+
+
+def test_jony_synthetic_roll_chain_and_roll_metrics_reconcile() -> None:
+    """Synthetic Flex fixtures produce Jony's documented cash/P&L/gap and roll metrics."""
+
+    output_dir = Path("tmp/test-jony-phase2-e2e")
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    try:
+        parsed = parse_flex_files(write_synthetic_files(output_dir))
+        jony_trades = [trade for trade in parsed.trades if trade.raw_payload.get("scenario") == "jony_worked_example"]
+        strategy_trades = [
+            StrategyTrade(
+                trade_id=trade.source_trade_id,
+                household_id="10000000-0000-0000-0000-000000000001",
+                account_id=trade.account_id,
+                trade_time=trade.trade_time,
+                trade_date=trade.trade_date,
+                underlying_symbol=trade.leg.underlying_symbol,
+                right=trade.leg.right,
+                side=trade.side,
+                open_close_indicator=trade.raw_payload.get("openCloseIndicator"),
+                event_type=trade.event_type,
+                strike=trade.leg.strike,
+                expiry=trade.leg.expiry,
+                quantity=trade.quantity,
+                realized_pnl=trade.realized_pnl,
+                net_cash_flow=trade.net_cash_flow,
+                currency=trade.currency,
+            )
+            for trade in jony_trades
+        ]
+        grouped = group_option_strategies(strategy_trades)
+        assert len(grouped.groups) == 1
+        assert grouped.groups[0].kind == "roll_chain"
+        assert set(grouped.groups[0].trade_ids) == {trade.source_trade_id for trade in jony_trades}
+        assert len(grouped.roll_events) == 1
+        assert grouped.roll_events[0].classification == "negative"
+        assert grouped.roll_events[0].closed_leg_realized_pnl == Decimal("-1000.000000")
+
+        metrics = compute_monthly_metrics(
+            [
+                OptionMetricTrade(
+                    trade_date=trade.trade_date,
+                    net_cash_flow=trade.net_cash_flow,
+                    realized_pnl=trade.realized_pnl,
+                )
+                for trade in jony_trades
+            ],
+            [OptionMetricRoll(detected_date=date(2025, 2, 14), classification="negative")],
+        )
+        assert metrics[-1].cash_flow_cumulative == Decimal("2700.000000")
+        assert metrics[-1].realized_pnl_cumulative == Decimal("1000.000000")
+        assert metrics[-1].variance_gap_cumulative == Decimal("1700.000000")
+        assert sum(row.roll_count for row in metrics) == 1
+        assert sum(row.roll_negative_count for row in metrics) == 1
+        assert metrics[1].roll_efficiency_pct == Decimal("0.00")
+    finally:
+        if output_dir.exists():
+            shutil.rmtree(output_dir)

--- a/apps/backend/tests/services/options/test_metrics.py
+++ b/apps/backend/tests/services/options/test_metrics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from app.services.options.metrics import OptionMetricTrade, compute_monthly_metrics
+from app.services.options.metrics import OptionMetricRoll, OptionMetricTrade, compute_monthly_metrics
 
 
 def test_jony_worked_example_variance_gap() -> None:
@@ -26,3 +26,26 @@ def test_jony_worked_example_variance_gap() -> None:
     assert rows[-1].realized_pnl_cumulative == Decimal("1000")
     assert rows[-1].variance_gap_cumulative == Decimal("1700")
     assert [row.variance_gap_cumulative for row in rows] == [Decimal("3000"), Decimal("4200"), Decimal("1700")]
+
+
+def test_jony_roll_efficiency_counts_negative_roll() -> None:
+    """Jony's Month 1 roll contributes one negative roll and 0% efficiency."""
+
+    rows = compute_monthly_metrics(
+        [
+            OptionMetricTrade(trade_date=date(2025, 1, 17), net_cash_flow=Decimal("3000"), realized_pnl=Decimal("0")),
+            OptionMetricTrade(
+                trade_date=date(2025, 2, 14), net_cash_flow=Decimal("200"), realized_pnl=Decimal("-1000")
+            ),
+            OptionMetricTrade(
+                trade_date=date(2025, 3, 21), net_cash_flow=Decimal("-500"), realized_pnl=Decimal("2000")
+            ),
+        ],
+        [OptionMetricRoll(detected_date=date(2025, 2, 14), classification="negative")],
+    )
+    assert rows[1].roll_count == 1
+    assert rows[1].roll_negative_count == 1
+    assert rows[1].roll_efficiency_pct == Decimal("0.00")
+    assert rows[-1].cash_flow_cumulative == Decimal("2700")
+    assert rows[-1].realized_pnl_cumulative == Decimal("1000")
+    assert rows[-1].variance_gap_cumulative == Decimal("1700")

--- a/apps/backend/tests/services/options/test_roll_detector.py
+++ b/apps/backend/tests/services/options/test_roll_detector.py
@@ -1,0 +1,110 @@
+"""Tests for Phase 2 same-day options roll detection."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from app.services.options.roll_detector import RollCandidateTrade, detect_rolls
+
+
+def trade(
+    trade_id: str,
+    *,
+    trade_date: date = date(2025, 2, 14),
+    side: str,
+    indicator: str,
+    strike: str,
+    expiry: date = date(2025, 3, 21),
+    pnl: str = "0",
+    quantity: str | None = None,
+) -> RollCandidateTrade:
+    """Build a minimal roll candidate trade."""
+
+    return RollCandidateTrade(
+        trade_id=trade_id,
+        account_id="U1234567",
+        trade_date=trade_date,
+        underlying_symbol="SPY",
+        right="put",
+        side=side,
+        open_close_indicator=indicator,
+        event_type="close" if indicator == "C" else "open",
+        strike=Decimal(strike),
+        expiry=expiry,
+        quantity=Decimal(quantity or ("10" if side == "buy" else "-10")),
+        realized_pnl=Decimal(pnl),
+    )
+
+
+def test_same_day_roll_jony_losing_leg_reconciles() -> None:
+    """Jony's worked-example leg roll is detected and classified negative."""
+
+    rolls = detect_rolls(
+        [
+            trade("closed", side="buy", indicator="C", strike="550", pnl="-1000"),
+            trade("opened", side="sell", indicator="O", strike="535", expiry=date(2025, 4, 18)),
+        ]
+    )
+    assert rolls == [("closed", "opened", Decimal("-1000"), "negative")]
+
+
+def test_same_day_duplicate_fill_is_not_roll() -> None:
+    """Same strike and expiry is a duplicate/close-open pair, not a roll."""
+
+    assert (
+        detect_rolls(
+            [
+                trade("closed", side="buy", indicator="C", strike="550"),
+                trade("opened", side="sell", indicator="O", strike="550"),
+            ]
+        )
+        == []
+    )
+
+
+def test_multi_day_reposition_is_not_roll() -> None:
+    """Phase 2 uses a strict same-calendar-trading-day window."""
+
+    assert (
+        detect_rolls(
+            [
+                trade("closed", side="buy", indicator="C", strike="550", trade_date=date(2025, 2, 14)),
+                trade("opened", side="sell", indicator="O", strike="535", trade_date=date(2025, 2, 15)),
+            ]
+        )
+        == []
+    )
+
+
+def test_multiple_candidates_closest_match_wins_without_double_linking() -> None:
+    """The closest combined strike/expiry change wins and each leg links once."""
+
+    rolls = detect_rolls(
+        [
+            trade("closed", side="buy", indicator="C", strike="550"),
+            trade("far", side="sell", indicator="O", strike="500", expiry=date(2025, 6, 20)),
+            trade("near", side="sell", indicator="O", strike="545", expiry=date(2025, 3, 28)),
+        ]
+    )
+    assert [(closed_id, opened_id) for closed_id, opened_id, _, _ in rolls] == [("closed", "near")]
+
+
+def test_threshold_edges() -> None:
+    """The neutral threshold is inclusive at exactly ±$25.00."""
+
+    cases = [("25.00", "neutral"), ("25.01", "positive"), ("-25.00", "neutral"), ("-25.01", "negative")]
+    for pnl, expected in cases:
+        rolls = detect_rolls(
+            [
+                trade("closed", side="buy", indicator="C", strike="550", pnl=pnl),
+                trade("opened", side="sell", indicator="O", strike="535"),
+            ]
+        )
+        assert rolls[0][3] == expected
+
+
+def test_empty_input_returns_empty_list() -> None:
+    """No trades means no roll candidates."""
+
+    assert detect_rolls([]) == []

--- a/apps/backend/tests/services/options/test_strategy_grouper.py
+++ b/apps/backend/tests/services/options/test_strategy_grouper.py
@@ -1,0 +1,101 @@
+"""Tests for Phase 2 options strategy grouping heuristics."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from app.services.options.strategy_grouper import StrategyTrade, group_option_strategies
+
+
+def trade(
+    trade_id: str,
+    *,
+    day: date = date(2025, 1, 17),
+    minute: int = 0,
+    underlying: str = "SPY",
+    right: str = "put",
+    side: str = "sell",
+    indicator: str = "O",
+    strike: str = "550",
+    expiry: date = date(2025, 3, 21),
+    cash: str = "0",
+    pnl: str = "0",
+    quantity: str | None = None,
+) -> StrategyTrade:
+    """Build a minimal strategy trade."""
+
+    return StrategyTrade(
+        trade_id=trade_id,
+        household_id="10000000-0000-0000-0000-000000000001",
+        account_id="U1234567",
+        trade_time=datetime(day.year, day.month, day.day, 10, minute, tzinfo=timezone.utc),
+        trade_date=day,
+        underlying_symbol=underlying,
+        right=right,
+        side=side,
+        open_close_indicator=indicator,
+        event_type="close" if indicator == "C" else "open",
+        strike=Decimal(strike),
+        expiry=expiry,
+        quantity=Decimal(quantity or ("1" if side == "buy" else "-1")),
+        realized_pnl=Decimal(pnl),
+        net_cash_flow=Decimal(cash),
+    )
+
+
+def test_single_short_put_groups_as_csp() -> None:
+    """Standalone short puts are classified as cash-secured puts for v1."""
+
+    result = group_option_strategies([trade("short-put")])
+    assert len(result.groups) == 1
+    assert result.groups[0].kind == "csp"
+    assert result.trade_group_ids["short-put"] == result.groups[0].group_id
+
+
+def test_two_opposite_same_expiry_puts_group_as_vertical_spread() -> None:
+    """Same-day same-expiry opposite-side puts with different strikes form one spread."""
+
+    result = group_option_strategies(
+        [trade("short", strike="550", side="sell"), trade("long", strike="545", side="buy", minute=1)]
+    )
+    assert len(result.groups) == 1
+    assert result.groups[0].kind == "vertical_spread"
+    assert set(result.groups[0].trade_ids) == {"short", "long"}
+
+
+def test_vertical_spread_roll_extends_original_group_as_roll_chain() -> None:
+    """A same-day close/open roll extends the original spread instead of creating a new group."""
+
+    result = group_option_strategies(
+        [
+            trade("open-short", strike="550", side="sell", cash="4000"),
+            trade("open-long", strike="545", side="buy", minute=1, cash="-1000"),
+            trade(
+                "close-short", day=date(2025, 2, 14), side="buy", indicator="C", strike="550", cash="-5000", pnl="-1000"
+            ),
+            trade(
+                "open-rolled",
+                day=date(2025, 2, 14),
+                minute=1,
+                side="sell",
+                strike="535",
+                expiry=date(2025, 4, 18),
+                cash="5200",
+            ),
+        ]
+    )
+    assert len(result.groups) == 1
+    assert result.groups[0].kind == "roll_chain"
+    assert set(result.groups[0].trade_ids) == {"open-short", "open-long", "close-short", "open-rolled"}
+    assert len(result.roll_events) == 1
+    assert result.roll_events[0].classification == "negative"
+
+
+def test_idempotent_rerun_produces_same_group_ids() -> None:
+    """Deterministic UUIDs keep reruns stable."""
+
+    trades = [trade("short", strike="550", side="sell"), trade("long", strike="545", side="buy", minute=1)]
+    first = group_option_strategies(trades)
+    second = group_option_strategies(list(reversed(trades)))
+    assert [group.group_id for group in first.groups] == [group.group_id for group in second.groups]

--- a/apps/backend/tests/worker/test_options_grouping.py
+++ b/apps/backend/tests/worker/test_options_grouping.py
@@ -1,0 +1,119 @@
+"""Worker tests for options strategy grouping persistence."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+from app.worker.handlers.options_grouping import compute_options_strategy_groups
+
+
+class FakeMappings:
+    """Mappings wrapper for fake SELECT statements."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class FakeSession:
+    """Small SQL recorder that mimics SQLModel session usage."""
+
+    def __init__(self) -> None:
+        self.groups: list[dict[str, Any]] = []
+        self.rolls: list[dict[str, Any]] = []
+        self.trade_updates: dict[str, str] = {}
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        """Record writes and return deterministic account/trade fixtures."""
+
+        sql = str(statement)
+        params = params or {}
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "id": 1,
+                        "household_id": "10000000-0000-0000-0000-000000000001",
+                        "account_id": "U1234567",
+                        "name": "IBKR Synthetic",
+                    }
+                ]
+            )
+        if "from public.options_trades t" in sql:
+            return FakeMappings(_trade_rows())
+        if "insert into public.options_strategy_groups" in sql:
+            self.groups.append(params)
+        elif "update public.options_trades" in sql:
+            self.trade_updates[str(params["trade_id"])] = str(params["group_id"])
+        elif "insert into public.options_roll_events" in sql:
+            self.rolls.append(params)
+        return FakeMappings([])
+
+
+def test_compute_options_strategy_groups_persists_groups_rolls_and_trade_links() -> None:
+    """The grouping worker upserts groups, roll events, and trade FK updates."""
+
+    session = FakeSession()
+    result = compute_options_strategy_groups(session)  # type: ignore[arg-type]
+    assert result["group_count"] == 1
+    assert result["roll_event_count"] == 1
+    assert session.groups[0]["kind"] == "roll_chain"
+    assert session.rolls[0]["classification"] == "negative"
+    assert session.rolls[0]["closed_leg_realized_pnl"] == Decimal("-1000")
+    assert set(session.trade_updates) == {
+        "open-short",
+        "open-long",
+        "close-short",
+        "open-rolled",
+        "close-rolled",
+        "close-long",
+    }
+
+
+def _trade_rows() -> list[dict[str, Any]]:
+    household_id = "10000000-0000-0000-0000-000000000001"
+
+    def row(
+        trade_id: str,
+        day: date,
+        side: str,
+        indicator: str,
+        strike: str,
+        expiry: date,
+        cash: str,
+        pnl: str,
+        minute: int,
+    ) -> dict[str, Any]:
+        return {
+            "trade_id": trade_id,
+            "household_id": household_id,
+            "account_id": "U1234567",
+            "trade_time": datetime(day.year, day.month, day.day, 10, minute, tzinfo=timezone.utc),
+            "trade_date": day,
+            "event_type": "close" if indicator == "C" else "open",
+            "side": side,
+            "quantity": Decimal("10") if side == "buy" else Decimal("-10"),
+            "net_cash_flow": Decimal(cash),
+            "realized_pnl": Decimal(pnl),
+            "currency": "USD",
+            "open_close_indicator": indicator,
+            "underlying_symbol": "SPY",
+            "right": "put",
+            "strike": Decimal(strike),
+            "expiry": expiry,
+        }
+
+    return [
+        row("open-short", date(2025, 1, 17), "sell", "O", "550", date(2025, 3, 21), "4000", "0", 0),
+        row("open-long", date(2025, 1, 17), "buy", "O", "545", date(2025, 3, 21), "-1000", "0", 1),
+        row("close-short", date(2025, 2, 14), "buy", "C", "550", date(2025, 3, 21), "-5000", "-1000", 0),
+        row("open-rolled", date(2025, 2, 14), "sell", "O", "535", date(2025, 4, 18), "5200", "0", 1),
+        row("close-rolled", date(2025, 3, 21), "buy", "C", "535", date(2025, 4, 18), "-3200", "2000", 0),
+        row("close-long", date(2025, 3, 21), "sell", "C", "545", date(2025, 3, 21), "2700", "0", 1),
+    ]

--- a/supabase/migrations/20260504141814_add_options_phase2_roll_metrics.sql
+++ b/supabase/migrations/20260504141814_add_options_phase2_roll_metrics.sql
@@ -1,0 +1,13 @@
+-- Migration: add_options_phase2_roll_metrics
+-- Purpose: Phase 2 roll-efficiency metrics for #247.
+
+alter table public.options_dashboard_monthly
+  add column if not exists roll_count integer not null default 0,
+  add column if not exists roll_positive_count integer not null default 0,
+  add column if not exists roll_negative_count integer not null default 0,
+  add column if not exists roll_neutral_count integer not null default 0,
+  add column if not exists roll_efficiency_pct numeric(5,2);
+
+create index if not exists options_roll_events_account_closed_trade_idx
+  on public.options_roll_events (household_id, account_id, closed_trade_id)
+  where detection_status != 'rejected';


### PR DESCRIPTION
Closes #247

Working as McManus (Data/Finance lead) with Hockney backend plumbing and Redfoot test coverage.

## Summary
- Added pure same-day roll detection with Decimal P&L classification and ±$25 neutral threshold.
- Added deterministic strategy grouping for CSPs, vertical spreads, roll chains, and ungrouped trades.
- Added compute_options_strategy_groups worker and wired it between Flex sync and monthly metrics.
- Added roll metrics columns to options_dashboard_monthly via Supabase migration and extended monthly aggregation.
- Extended synthetic backfill to run sync → grouping → metrics.

## Verification
- Supabase migration applied via MCP and mirrored in supabase/migrations/.
- cd apps/backend && uv run pytest -x -q tests/ → 307 passed.
- cd apps/backend && uv run ruff check . → clean.
- Jony synthetic E2E: cash_flow=2700.000000, realized_pnl=1000.000000, variance_gap=1700.000000, roll_count=1, roll_negative_count=1, roll_efficiency_pct=0.00.
- npx playwright test e2e/walkthrough/all-pages.spec.ts is blocked by existing E2E production-Supabase safety guard for current env (SUPABASE_E2E_ALLOW_PROD not set).
- uv run python scripts/backfill_options.py --synthetic is blocked by local DB password authentication failure to Supabase pooler.

## Phase 3 readiness
The backend now populates read-only strategy groups, roll events, and monthly roll-efficiency metrics. Phase 3 can build UI directly on existing tables without override/edit flows.
