### PR TITLE
feat(options): #249 phase 4 — capital-at-risk + margin utilization gauges

### DIFF
--- a/apps/backend/app/services/options/metrics.py
+++ b/apps/backend/app/services/options/metrics.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterable
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 from pydantic import BaseModel, ConfigDict
+
+ZERO = Decimal("0")
+ONE_HUNDRED = Decimal("100")
 
 
 class OptionMetricTrade(BaseModel):
@@ -29,6 +32,26 @@ class OptionMetricRoll(BaseModel):
     classification: str
 
 
+class OptionCapitalHistory(BaseModel):
+    """Capital-at-risk amount effective from a timestamp until superseded."""
+
+    model_config = ConfigDict(frozen=True)
+
+    group_id: str
+    effective_at: datetime
+    capital_at_risk: Decimal | None
+
+
+class OptionMarginSnapshot(BaseModel):
+    """Account-wide margin snapshot used for monthly utilization metrics."""
+
+    model_config = ConfigDict(frozen=True)
+
+    captured_at: datetime
+    margin_used: Decimal | None
+    margin_available: Decimal | None
+
+
 class MonthlyMetric(BaseModel):
     """Persistable monthly options dashboard row."""
 
@@ -48,15 +71,23 @@ class MonthlyMetric(BaseModel):
     roll_negative_count: int = 0
     roll_neutral_count: int = 0
     roll_efficiency_pct: Decimal | None = None
+    avg_capital_at_risk: Decimal | None = None
+    return_on_capital_at_risk_pct: Decimal | None = None
+    latest_margin_used: Decimal | None = None
+    latest_margin_available: Decimal | None = None
+    margin_utilization_pct: Decimal | None = None
 
 
 def compute_monthly_metrics(
-    trades: Iterable[OptionMetricTrade], rolls: Iterable[OptionMetricRoll] | None = None
+    trades: Iterable[OptionMetricTrade],
+    rolls: Iterable[OptionMetricRoll] | None = None,
+    capital_history: Iterable[OptionCapitalHistory] | None = None,
+    margin_snapshots: Iterable[OptionMarginSnapshot] | None = None,
 ) -> list[MonthlyMetric]:
-    """Aggregate trades and rolls by month for cash, P&L, gap, and roll efficiency."""
+    """Aggregate trades, rolls, capital risk, and margin snapshots by month."""
 
     buckets: dict[date, dict[str, Decimal | int]] = defaultdict(
-        lambda: {"cash": Decimal("0"), "pnl": Decimal("0"), "count": 0, "positive": 0, "negative": 0, "neutral": 0}
+        lambda: {"cash": ZERO, "pnl": ZERO, "count": 0, "positive": 0, "negative": 0, "neutral": 0}
     )
     for trade in trades:
         month = date(trade.trade_date.year, trade.trade_date.month, 1)
@@ -73,9 +104,14 @@ def compute_monthly_metrics(
         elif roll.classification == "neutral":
             buckets[month]["neutral"] = int(buckets[month]["neutral"]) + 1
 
+    capital_rows = list(capital_history or [])
+    margin_rows = sorted(margin_snapshots or [], key=lambda row: row.captured_at)
+    for month in _months_from_capital_and_margin(capital_rows, margin_rows):
+        buckets.setdefault(month, {"cash": ZERO, "pnl": ZERO, "count": 0, "positive": 0, "negative": 0, "neutral": 0})
+
     rows: list[MonthlyMetric] = []
-    cumulative_cash = Decimal("0")
-    cumulative_pnl = Decimal("0")
+    cumulative_cash = ZERO
+    cumulative_pnl = ZERO
     for month in sorted(buckets):
         cash = Decimal(buckets[month]["cash"])
         pnl = Decimal(buckets[month]["pnl"])
@@ -85,6 +121,10 @@ def compute_monthly_metrics(
         roll_count = positive + negative + neutral
         cumulative_cash += cash
         cumulative_pnl += pnl
+        avg_capital = compute_time_weighted_avg_capital(capital_rows, month, _month_end(month))
+        latest_margin = latest_margin_snapshot_for_month(margin_rows, month, _month_end(month))
+        margin_used = latest_margin.margin_used if latest_margin else None
+        margin_available = latest_margin.margin_available if latest_margin else None
         rows.append(
             MonthlyMetric(
                 period_start=month,
@@ -100,12 +140,93 @@ def compute_monthly_metrics(
                 roll_positive_count=positive,
                 roll_negative_count=negative,
                 roll_neutral_count=neutral,
-                roll_efficiency_pct=(Decimal(positive) / Decimal(roll_count) * Decimal("100")).quantize(Decimal("0.01"))
+                roll_efficiency_pct=(Decimal(positive) / Decimal(roll_count) * ONE_HUNDRED).quantize(Decimal("0.01"))
                 if roll_count
                 else None,
+                avg_capital_at_risk=avg_capital,
+                return_on_capital_at_risk_pct=return_on_capital_at_risk_pct(pnl, avg_capital),
+                latest_margin_used=margin_used,
+                latest_margin_available=margin_available,
+                margin_utilization_pct=margin_utilization_pct(margin_used, margin_available),
             )
         )
     return rows
+
+
+def compute_time_weighted_avg_capital(
+    capital_history: Iterable[OptionCapitalHistory], month_start: date, month_end: date
+) -> Decimal | None:
+    """Compute Σ(CaR × days active in month) / days in month across strategy groups."""
+
+    start_dt = datetime.combine(month_start, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(month_end + timedelta(days=1), time.min, tzinfo=timezone.utc)
+    days_in_month = Decimal((end_dt - start_dt).days)
+    total = ZERO
+    by_group: dict[str, list[OptionCapitalHistory]] = defaultdict(list)
+    for row in capital_history:
+        if row.capital_at_risk is None:
+            continue
+        by_group[row.group_id].append(row)
+
+    for entries in by_group.values():
+        ordered = sorted(entries, key=lambda row: row.effective_at)
+        for index, entry in enumerate(ordered):
+            period_start = max(_aware(entry.effective_at), start_dt)
+            next_effective = _aware(ordered[index + 1].effective_at) if index + 1 < len(ordered) else end_dt
+            period_end = min(next_effective, end_dt)
+            if period_end <= start_dt or period_start >= end_dt or period_end <= period_start:
+                continue
+            active_days = Decimal(str((period_end - period_start).total_seconds())) / Decimal("86400")
+            total += entry.capital_at_risk * active_days
+
+    if total == ZERO:
+        return None
+    return (total / days_in_month).quantize(Decimal("0.000001"))
+
+
+def return_on_capital_at_risk_pct(realized_pnl: Decimal, avg_capital_at_risk: Decimal | None) -> Decimal | None:
+    """Return realized P&L divided by average capital at risk as a percentage."""
+
+    if avg_capital_at_risk is None or avg_capital_at_risk == ZERO:
+        return None
+    return (realized_pnl / avg_capital_at_risk * ONE_HUNDRED).quantize(Decimal("0.0001"))
+
+
+def margin_utilization_pct(margin_used: Decimal | None, margin_available: Decimal | None) -> Decimal | None:
+    """Return account-wide margin used / margin available as a percentage."""
+
+    if margin_used is None or margin_available is None or margin_available == ZERO:
+        return None
+    return (margin_used / margin_available * ONE_HUNDRED).quantize(Decimal("0.01"))
+
+
+def latest_margin_snapshot_for_month(
+    snapshots: Iterable[OptionMarginSnapshot], month_start: date, month_end: date
+) -> OptionMarginSnapshot | None:
+    """Return the newest margin snapshot captured inside a month."""
+
+    return next(
+        (
+            row
+            for row in sorted(snapshots, key=lambda item: item.captured_at, reverse=True)
+            if month_start <= row.captured_at.date() <= month_end
+        ),
+        None,
+    )
+
+
+def _months_from_capital_and_margin(
+    capital_history: list[OptionCapitalHistory], margin_rows: list[OptionMarginSnapshot]
+) -> set[date]:
+    months = {date(row.effective_at.year, row.effective_at.month, 1) for row in capital_history}
+    months.update(date(row.captured_at.year, row.captured_at.month, 1) for row in margin_rows)
+    return months
+
+
+def _aware(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
 
 
 def _month_end(month_start: date) -> date:

--- a/apps/backend/app/services/options/strategy_grouper.py
+++ b/apps/backend/app/services/options/strategy_grouper.py
@@ -1,4 +1,4 @@
-"""Pure strategy grouping heuristics for options-income trades."""
+"""Pure strategy grouping and capital-at-risk heuristics for options-income trades."""
 
 from __future__ import annotations
 
@@ -13,15 +13,29 @@ from app.services.options.roll_detector import HEURISTIC_VERSION, RollCandidateT
 
 StrategyKind = Literal["csp", "vertical_spread", "roll_chain", "ungrouped"]
 StrategyStatus = Literal["open", "closed", "expired", "assigned", "mixed"]
+RiskCalculationMethod = Literal["csp_net_premium", "vertical_spread_max_loss", "roll_chain_latest_leg", "ungrouped"]
 GROUP_NAMESPACE = UUID("f6288d91-31d7-4eaf-94f5-090bda327f8e")
+ZERO = Decimal("0")
+DEFAULT_MULTIPLIER = Decimal("100")
 
 
 @dataclass(frozen=True, slots=True)
 class StrategyTrade(RollCandidateTrade):
-    """Trade facts needed for deterministic strategy grouping."""
+    """Trade facts needed for deterministic strategy grouping and risk math."""
 
     household_id: str = ""
     trade_time: datetime | None = None
+    multiplier: Decimal = DEFAULT_MULTIPLIER
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyCapitalHistory:
+    """Time-varying capital-at-risk value for one strategy group."""
+
+    group_id: str
+    effective_at: datetime
+    capital_at_risk: Decimal | None
+    risk_calculation_method: RiskCalculationMethod
 
 
 @dataclass(frozen=True, slots=True)
@@ -39,6 +53,8 @@ class StrategyGroup:
     closed_at: datetime | None
     net_cash_flow: Decimal
     realized_pnl: Decimal
+    capital_at_risk_open: Decimal | None = None
+    risk_calculation_method: RiskCalculationMethod = "ungrouped"
     metadata: dict[str, object] = field(default_factory=dict)
 
 
@@ -65,15 +81,16 @@ class StrategyGroupingResult:
 
     groups: list[StrategyGroup]
     roll_events: list[StrategyRollEvent]
+    capital_history: list[StrategyCapitalHistory]
     trade_group_ids: dict[str, str]
 
 
 def group_option_strategies(trades: list[StrategyTrade]) -> StrategyGroupingResult:
-    """Classify trades into deterministic Phase 2 strategy groups."""
+    """Classify trades into deterministic strategy groups and risk history."""
 
     ordered = sorted(trades, key=lambda trade: (trade.trade_date, trade.trade_time or datetime.min, trade.trade_id))
     if not ordered:
-        return StrategyGroupingResult(groups=[], roll_events=[], trade_group_ids={})
+        return StrategyGroupingResult(groups=[], roll_events=[], capital_history=[], trade_group_ids={})
 
     by_id = {trade.trade_id: trade for trade in ordered}
     rolls = detect_rolls([_roll_trade(trade) for trade in ordered])
@@ -83,13 +100,19 @@ def group_option_strategies(trades: list[StrategyTrade]) -> StrategyGroupingResu
 
     for first, second in _vertical_open_pairs(ordered):
         trade_ids = tuple(sorted((first.trade_id, second.trade_id)))
-        builders.append(_GroupBuilder(anchor_ids=trade_ids, kind="vertical_spread", trade_ids=set(trade_ids)))
+        builders.append(
+            _GroupBuilder(
+                anchor_ids=trade_ids, kind="vertical_spread", base_kind="vertical_spread", trade_ids=set(trade_ids)
+            )
+        )
         assigned_open_ids.update(trade_ids)
 
     for trade in ordered:
         if trade.trade_id in assigned_open_ids or trade.trade_id in rolled_open_ids or not _is_open_short_put(trade):
             continue
-        builders.append(_GroupBuilder(anchor_ids=(trade.trade_id,), kind="csp", trade_ids={trade.trade_id}))
+        builders.append(
+            _GroupBuilder(anchor_ids=(trade.trade_id,), kind="csp", base_kind="csp", trade_ids={trade.trade_id})
+        )
         assigned_open_ids.add(trade.trade_id)
 
     _attach_matching_closes(builders, ordered)
@@ -99,6 +122,7 @@ def group_option_strategies(trades: list[StrategyTrade]) -> StrategyGroupingResu
         if builder is None:
             continue
         builder.kind = "roll_chain"
+        builder.roll_open_ids.append(opened_trade_id)
         builder.trade_ids.add(opened_trade_id)
         opened = by_id[opened_trade_id]
         closed = by_id[closed_trade_id]
@@ -122,19 +146,69 @@ def group_option_strategies(trades: list[StrategyTrade]) -> StrategyGroupingResu
     for trade in ordered:
         if trade.trade_id in assigned:
             continue
-        builders.append(_GroupBuilder(anchor_ids=(trade.trade_id,), kind="ungrouped", trade_ids={trade.trade_id}))
+        builders.append(
+            _GroupBuilder(
+                anchor_ids=(trade.trade_id,), kind="ungrouped", base_kind="ungrouped", trade_ids={trade.trade_id}
+            )
+        )
         assigned.add(trade.trade_id)
 
     groups = [_build_group(builder, by_id) for builder in builders]
+    history = [entry for builder in builders for entry in _build_capital_history(builder, by_id)]
     trade_group_ids = {trade_id: group.group_id for group in groups for trade_id in group.trade_ids}
-    return StrategyGroupingResult(groups=groups, roll_events=roll_events, trade_group_ids=trade_group_ids)
+    return StrategyGroupingResult(
+        groups=groups, roll_events=roll_events, capital_history=history, trade_group_ids=trade_group_ids
+    )
 
 
 @dataclass(slots=True)
 class _GroupBuilder:
     anchor_ids: tuple[str, ...]
     kind: StrategyKind
+    base_kind: StrategyKind
     trade_ids: set[str]
+    roll_open_ids: list[str] = field(default_factory=list)
+
+
+def calculate_capital_at_risk(
+    kind: StrategyKind,
+    trades: list[StrategyTrade],
+    *,
+    roll_chain: bool = False,
+) -> tuple[Decimal | None, RiskCalculationMethod]:
+    """Return max-loss capital at risk net of premium received for a strategy."""
+
+    if kind == "ungrouped" or not trades:
+        return None, "ungrouped"
+
+    open_trades = [trade for trade in trades if _is_open(trade)]
+    if not open_trades:
+        return None, "ungrouped"
+
+    method: RiskCalculationMethod = "roll_chain_latest_leg" if roll_chain else "csp_net_premium"
+    short_puts = [trade for trade in open_trades if trade.right == "put" and trade.side == "sell"]
+    if kind == "csp" or (kind == "roll_chain" and len(open_trades) == 1 and short_puts):
+        short = short_puts[-1] if short_puts else open_trades[-1]
+        contracts = abs(short.quantity)
+        premium_received = _net_credit(open_trades)
+        risk = (short.strike * _multiplier(short) * contracts) - premium_received
+        return max(risk, ZERO), method if roll_chain else "csp_net_premium"
+
+    if kind == "vertical_spread" or kind == "roll_chain":
+        if len(open_trades) < 2:
+            return calculate_capital_at_risk("csp", open_trades, roll_chain=roll_chain)
+        short_leg = next((trade for trade in open_trades if trade.side == "sell"), open_trades[0])
+        long_leg = next(
+            (trade for trade in open_trades if trade.trade_id != short_leg.trade_id and trade.side == "buy"),
+            open_trades[1],
+        )
+        width = abs(short_leg.strike - long_leg.strike)
+        contracts = min(abs(short_leg.quantity), abs(long_leg.quantity)) or abs(short_leg.quantity)
+        premium_received = _net_credit(open_trades)
+        risk = (width * _multiplier(short_leg) * contracts) - premium_received
+        return max(risk, ZERO), method if roll_chain else "vertical_spread_max_loss"
+
+    return None, "ungrouped"
 
 
 def _vertical_open_pairs(trades: list[StrategyTrade]) -> list[tuple[StrategyTrade, StrategyTrade]]:
@@ -187,6 +261,10 @@ def _build_group(builder: _GroupBuilder, by_id: dict[str, StrategyTrade]) -> Str
     group_trades = [by_id[trade_id] for trade_id in sorted(builder.trade_ids)]
     times = [trade.trade_time or datetime.combine(trade.trade_date, datetime.min.time()) for trade in group_trades]
     close_times = [time for trade, time in zip(group_trades, times, strict=True) if _is_close(trade)]
+    initial_trades = [by_id[trade_id] for trade_id in builder.anchor_ids]
+    capital_at_risk, method = calculate_capital_at_risk(builder.base_kind, initial_trades)
+    if builder.kind == "roll_chain" and method != "ungrouped":
+        method = "roll_chain_latest_leg"
     return StrategyGroup(
         group_id=_group_id(builder.anchor_ids),
         household_id=group_trades[0].household_id,
@@ -199,10 +277,54 @@ def _build_group(builder: _GroupBuilder, by_id: dict[str, StrategyTrade]) -> Str
         closed_at=max(close_times)
         if close_times and all(_is_close(trade) or _has_close(trade, group_trades) for trade in group_trades)
         else None,
-        net_cash_flow=sum((trade.net_cash_flow for trade in group_trades), Decimal("0")),
-        realized_pnl=sum((trade.realized_pnl for trade in group_trades), Decimal("0")),
+        net_cash_flow=sum((trade.net_cash_flow for trade in group_trades), ZERO),
+        realized_pnl=sum((trade.realized_pnl for trade in group_trades), ZERO),
+        capital_at_risk_open=capital_at_risk,
+        risk_calculation_method=method,
         metadata={"trade_ids": sorted(builder.trade_ids), "anchor_trade_ids": list(builder.anchor_ids)},
     )
+
+
+def _build_capital_history(builder: _GroupBuilder, by_id: dict[str, StrategyTrade]) -> list[StrategyCapitalHistory]:
+    group_id = _group_id(builder.anchor_ids)
+    anchor_trades = [by_id[trade_id] for trade_id in builder.anchor_ids]
+    opened_at = min(
+        trade.trade_time or datetime.combine(trade.trade_date, datetime.min.time()) for trade in anchor_trades
+    )
+    initial_risk, initial_method = calculate_capital_at_risk(builder.base_kind, anchor_trades)
+    if builder.kind == "roll_chain" and initial_method != "ungrouped":
+        initial_method = "roll_chain_latest_leg"
+    entries = [StrategyCapitalHistory(group_id, opened_at, initial_risk, initial_method)]
+
+    group_trades = [by_id[trade_id] for trade_id in builder.trade_ids]
+    for opened_id in builder.roll_open_ids:
+        opened = by_id[opened_id]
+        effective_at = opened.trade_time or datetime.combine(opened.trade_date, datetime.min.time())
+        active = _active_open_trades(group_trades, effective_at)
+        risk, method = calculate_capital_at_risk("roll_chain", active, roll_chain=True)
+        entries.append(StrategyCapitalHistory(group_id, effective_at, risk, method))
+    return entries
+
+
+def _active_open_trades(trades: list[StrategyTrade], as_of: datetime) -> list[StrategyTrade]:
+    active: dict[tuple[str, str, str, date, Decimal], StrategyTrade] = {}
+    for trade in sorted(
+        trades,
+        key=lambda item: (
+            item.trade_time or datetime.combine(item.trade_date, datetime.min.time()),
+            0 if _is_open(item) else 1,
+            item.trade_id,
+        ),
+    ):
+        trade_time = trade.trade_time or datetime.combine(trade.trade_date, datetime.min.time())
+        if trade_time > as_of:
+            continue
+        key = _contract_key(trade)
+        if _is_open(trade):
+            active[key] = trade
+        elif _is_close(trade):
+            active.pop(key, None)
+    return list(active.values())
 
 
 def _status(trades: list[StrategyTrade]) -> StrategyStatus:
@@ -247,6 +369,14 @@ def _is_close(trade: StrategyTrade) -> bool:
         "assign",
         "exercise",
     }
+
+
+def _net_credit(trades: list[StrategyTrade]) -> Decimal:
+    return sum((trade.net_cash_flow for trade in trades), ZERO)
+
+
+def _multiplier(trade: StrategyTrade) -> Decimal:
+    return trade.multiplier or DEFAULT_MULTIPLIER
 
 
 def _roll_trade(trade: StrategyTrade) -> RollCandidateTrade:

--- a/apps/backend/app/worker/handlers/options_grouping.py
+++ b/apps/backend/app/worker/handlers/options_grouping.py
@@ -119,7 +119,8 @@ def _load_strategy_trades(
                    l.underlying_symbol,
                    l."right"::text as right,
                    l.strike,
-                   l.expiry
+                   l.expiry,
+                   l.multiplier
               from public.options_trades t
               join public.options_legs l on l.id = t.leg_id
              where {" and ".join(where)}
@@ -146,6 +147,7 @@ def _load_strategy_trades(
             right=str(row["right"]),
             strike=Decimal(str(row["strike"])),
             expiry=row["expiry"],
+            multiplier=Decimal(str(row["multiplier"])),
         )
         for row in rows
     ]
@@ -158,10 +160,10 @@ def _persist_grouping(session: Session, result: StrategyGroupingResult) -> None:
                 """
                 insert into public.options_strategy_groups (
                   id, household_id, account_id, underlying_symbol, kind, status, opened_at, closed_at,
-                  net_cash_flow, realized_pnl, metadata
+                  net_cash_flow, realized_pnl, capital_at_risk_open, risk_calculation_method, metadata
                 ) values (
                   :id, :household_id, :account_id, :underlying_symbol, :kind, :status, :opened_at, :closed_at,
-                  :net_cash_flow, :realized_pnl, cast(:metadata as jsonb)
+                  :net_cash_flow, :realized_pnl, :capital_at_risk_open, :risk_calculation_method, cast(:metadata as jsonb)
                 )
                 on conflict (id) do update set
                   underlying_symbol = excluded.underlying_symbol,
@@ -171,6 +173,8 @@ def _persist_grouping(session: Session, result: StrategyGroupingResult) -> None:
                   closed_at = excluded.closed_at,
                   net_cash_flow = excluded.net_cash_flow,
                   realized_pnl = excluded.realized_pnl,
+                  capital_at_risk_open = excluded.capital_at_risk_open,
+                  risk_calculation_method = excluded.risk_calculation_method,
                   metadata = excluded.metadata,
                   updated_at = now()
                 """
@@ -186,7 +190,35 @@ def _persist_grouping(session: Session, result: StrategyGroupingResult) -> None:
                 "closed_at": group.closed_at,
                 "net_cash_flow": group.net_cash_flow,
                 "realized_pnl": group.realized_pnl,
+                "capital_at_risk_open": group.capital_at_risk_open,
+                "risk_calculation_method": group.risk_calculation_method,
                 "metadata": _json(group.metadata),
+            },
+        )
+        session.execute(
+            text("delete from public.options_strategy_capital_history where group_id = :group_id"),
+            {"group_id": group.group_id},
+        )
+    for history in result.capital_history:
+        session.execute(
+            text(
+                """
+                insert into public.options_strategy_capital_history (
+                  group_id, effective_at, capital_at_risk, risk_calculation_method
+                ) values (
+                  :group_id, :effective_at, :capital_at_risk, :risk_calculation_method
+                )
+                on conflict on constraint options_strategy_capital_history_group_effective_key do update set
+                  capital_at_risk = excluded.capital_at_risk,
+                  risk_calculation_method = excluded.risk_calculation_method,
+                  updated_at = now()
+                """
+            ),
+            {
+                "group_id": history.group_id,
+                "effective_at": history.effective_at,
+                "capital_at_risk": history.capital_at_risk,
+                "risk_calculation_method": history.risk_calculation_method,
             },
         )
     for trade_id, group_id in result.trade_group_ids.items():

--- a/apps/backend/app/worker/handlers/options_margin_sync.py
+++ b/apps/backend/app/worker/handlers/options_margin_sync.py
@@ -1,0 +1,241 @@
+"""Worker handler for account-wide options margin snapshots."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from contextlib import AbstractContextManager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal, InvalidOperation
+import logging
+from typing import Literal
+
+from ib_async import IB
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.services.trading_batch import ib_gateway_endpoint, is_ib_gateway_available
+from app.worker.handlers.options_sync import OptionsAccount, _load_accounts
+
+logger = logging.getLogger(__name__)
+JobPayload = dict[str, object]
+JobResult = dict[str, object]
+SessionFactory = Callable[[], AbstractContextManager[Session]]
+MarginSource = Literal["ib_gateway", "flex", "synthetic"]
+ZERO = Decimal("0")
+
+
+@dataclass(frozen=True)
+class MarginSnapshot:
+    """Account-wide margin figures for one options-enabled account."""
+
+    household_id: str
+    account_id: str
+    account_config_id: int | None
+    captured_at: datetime
+    margin_used: Decimal | None
+    margin_available: Decimal | None
+    buying_power: Decimal | None
+    source: MarginSource
+
+
+def _default_session_factory() -> AbstractContextManager[Session]:
+    """Return a worker database session."""
+
+    return Session(engine)
+
+
+def handle_options_margin_sync(
+    payload: JobPayload,
+    *,
+    session_factory: SessionFactory | None = None,
+) -> JobResult:
+    """Persist live IB Gateway margin snapshots or synthetic fallbacks."""
+
+    with (session_factory or _default_session_factory)() as session:
+        result = run_options_margin_sync(session, account_id=_optional_str(payload.get("account_id")))
+        session.commit()
+        return result
+
+
+def run_scheduled_options_margin_sync() -> None:
+    """Scheduled entry point for the daily post-Flex margin refresh."""
+
+    with _default_session_factory() as session:
+        result = run_options_margin_sync(session)
+        session.commit()
+    logger.info("Scheduled options_margin_sync completed: %s", result)
+
+
+def run_intraday_options_margin_sync() -> None:
+    """Scheduled entry point for 15-minute IB Gateway margin refreshes."""
+
+    host, port = ib_gateway_endpoint()
+    if not is_ib_gateway_available(host, port, timeout=1.5):
+        logger.info("IB Gateway offline, skipping intraday options margin sync")
+        return
+    run_scheduled_options_margin_sync()
+
+
+def run_options_margin_sync(session: Session, *, account_id: str | None = None) -> JobResult:
+    """Capture margin snapshots for options-enabled accounts with graceful fallback."""
+
+    accounts = [account for account in _load_accounts(session, account_id=account_id) if account.account_id]
+    if not accounts:
+        return {"status": "skipped", "reason": "no_options_accounts", "snapshots": 0, "source": None}
+
+    captured_at = _captured_minute()
+    live_snapshots = _try_ib_gateway_snapshots(accounts, captured_at)
+    snapshots: list[MarginSnapshot]
+    source: MarginSource
+    if live_snapshots:
+        snapshots = live_snapshots
+        source = "ib_gateway"
+    else:
+        snapshots = [_synthetic_snapshot(session, account, captured_at) for account in accounts if account.account_id]
+        source = "synthetic"
+
+    for snapshot in snapshots:
+        _upsert_snapshot(session, snapshot)
+    return {"status": "succeeded", "snapshots": len(snapshots), "source": source}
+
+
+def _try_ib_gateway_snapshots(accounts: list[OptionsAccount], captured_at: datetime) -> list[MarginSnapshot]:
+    host, port = ib_gateway_endpoint()
+    if not is_ib_gateway_available(host, port, timeout=1.5):
+        return []
+    try:
+        return asyncio.run(_load_ib_gateway_snapshots(accounts, captured_at, host, port))
+    except Exception as exc:  # noqa: BLE001 - margin sync must fall back in CI/dev
+        logger.warning("IB Gateway margin snapshot failed; using synthetic fallback: %s", exc)
+        return []
+
+
+async def _load_ib_gateway_snapshots(
+    accounts: list[OptionsAccount], captured_at: datetime, host: str, port: int
+) -> list[MarginSnapshot]:
+    ib = IB()
+    client_id = _margin_client_id(accounts)
+    await ib.connectAsync(host, port, clientId=client_id, timeout=5)
+    try:
+        summary = await ib.accountSummaryAsync()
+        by_account: dict[str, dict[str, Decimal]] = {}
+        for item in summary:
+            account = str(getattr(item, "account", "") or "")
+            tag = str(getattr(item, "tag", ""))
+            value = _decimal(getattr(item, "value", None))
+            if not account or value is None:
+                continue
+            by_account.setdefault(account, {})[tag] = value
+
+        snapshots: list[MarginSnapshot] = []
+        for account in accounts:
+            if not account.account_id:
+                continue
+            values = by_account.get(account.account_id, {})
+            if not values:
+                continue
+            margin_used = values.get("MaintMarginReq") or values.get("FullMaintMarginReq")
+            net_liq = values.get("NetLiquidation")
+            buying_power = values.get("BuyingPower")
+            margin_available = (net_liq - margin_used) if net_liq is not None and margin_used is not None else None
+            snapshots.append(
+                MarginSnapshot(
+                    household_id=account.household_id,
+                    account_id=account.account_id,
+                    account_config_id=account.config_id,
+                    captured_at=captured_at,
+                    margin_used=margin_used,
+                    margin_available=margin_available,
+                    buying_power=buying_power,
+                    source="ib_gateway",
+                )
+            )
+        return snapshots
+    finally:
+        if ib.isConnected():
+            ib.disconnect()
+
+
+def _synthetic_snapshot(session: Session, account: OptionsAccount, captured_at: datetime) -> MarginSnapshot:
+    account_id = account.account_id or ""
+    margin_used = session.execute(
+        text(
+            """
+            select coalesce(sum(capital_at_risk_open), 0)::numeric as margin_used
+              from public.options_strategy_groups
+             where household_id = :household_id
+               and account_id = :account_id
+               and status = 'open'
+               and capital_at_risk_open is not null
+            """
+        ),
+        {"household_id": account.household_id, "account_id": account_id},
+    ).scalar_one_or_none()
+    used = Decimal(str(margin_used or ZERO))
+    available = used * Decimal("3") if used > ZERO else ZERO
+    return MarginSnapshot(
+        household_id=account.household_id,
+        account_id=account_id,
+        account_config_id=account.config_id,
+        captured_at=captured_at,
+        margin_used=used,
+        margin_available=available,
+        buying_power=available,
+        source="synthetic",
+    )
+
+
+def _upsert_snapshot(session: Session, snapshot: MarginSnapshot) -> None:
+    session.execute(
+        text(
+            """
+            insert into public.options_margin_snapshots (
+              household_id, account_id, account_config_id, captured_at,
+              margin_used, margin_available, buying_power, source
+            ) values (
+              :household_id, :account_id, :account_config_id, :captured_at,
+              :margin_used, :margin_available, :buying_power, :source
+            )
+            on conflict on constraint options_margin_snapshots_account_captured_key do update set
+              account_config_id = excluded.account_config_id,
+              margin_used = excluded.margin_used,
+              margin_available = excluded.margin_available,
+              buying_power = excluded.buying_power,
+              source = excluded.source,
+              updated_at = now()
+            """
+        ),
+        {
+            "household_id": snapshot.household_id,
+            "account_id": snapshot.account_id,
+            "account_config_id": snapshot.account_config_id,
+            "captured_at": snapshot.captured_at,
+            "margin_used": snapshot.margin_used,
+            "margin_available": snapshot.margin_available,
+            "buying_power": snapshot.buying_power,
+            "source": snapshot.source,
+        },
+    )
+
+
+def _margin_client_id(accounts: list[OptionsAccount]) -> int:
+    base = next((account.config_id for account in accounts if account.config_id is not None), 7)
+    return int(base) + 1000
+
+
+def _captured_minute() -> datetime:
+    return datetime.now(timezone.utc).replace(second=0, microsecond=0)
+
+
+def _decimal(value: object) -> Decimal | None:
+    try:
+        return Decimal(str(value).replace(",", ""))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def _optional_str(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None

--- a/apps/backend/app/worker/handlers/options_metrics.py
+++ b/apps/backend/app/worker/handlers/options_metrics.py
@@ -12,7 +12,13 @@ from sqlalchemy import text
 from sqlmodel import Session
 
 from app.dal.database import engine
-from app.services.options.metrics import OptionMetricRoll, OptionMetricTrade, compute_monthly_metrics
+from app.services.options.metrics import (
+    OptionCapitalHistory,
+    OptionMarginSnapshot,
+    OptionMetricRoll,
+    OptionMetricTrade,
+    compute_monthly_metrics,
+)
 
 JobPayload = dict[str, object]
 JobResult = dict[str, object]
@@ -59,7 +65,13 @@ def compute_options_monthly_metrics(
     for account in accounts:
         rows = _load_trade_facts(session, account["household_id"], account["account_id"], from_date, to_date)
         rolls = _load_roll_facts(session, account["household_id"], account["account_id"], from_date, to_date)
-        metrics = compute_monthly_metrics(rows, rolls)
+        capital_history = _load_capital_history(
+            session, account["household_id"], account["account_id"], from_date, to_date
+        )
+        margin_snapshots = _load_margin_snapshots(
+            session, account["household_id"], account["account_id"], from_date, to_date
+        )
+        metrics = compute_monthly_metrics(rows, rolls, capital_history, margin_snapshots)
         if metrics:
             start = metrics[0].period_start
             end = metrics[-1].period_start
@@ -89,14 +101,18 @@ def compute_options_monthly_metrics(
                           cash_flow_cumulative, realized_pnl_cumulative,
                           variance_gap, variance_gap_cumulative, trade_count,
                           roll_count, roll_positive_count, roll_negative_count,
-                          roll_neutral_count, roll_efficiency_pct, last_computed_at
+                          roll_neutral_count, roll_efficiency_pct, avg_capital_at_risk,
+                          return_on_capital_at_risk_pct, latest_margin_used,
+                          latest_margin_available, margin_utilization_pct, last_computed_at
                         ) values (
                           :household_id, :account_id, :period_start, :period_end,
                           :cash_flow_total, :realized_pnl_total,
                           :cash_flow_cumulative, :realized_pnl_cumulative,
                           :variance_gap, :variance_gap_cumulative, :trade_count,
                           :roll_count, :roll_positive_count, :roll_negative_count,
-                          :roll_neutral_count, :roll_efficiency_pct, now()
+                          :roll_neutral_count, :roll_efficiency_pct, :avg_capital_at_risk,
+                          :return_on_capital_at_risk_pct, :latest_margin_used,
+                          :latest_margin_available, :margin_utilization_pct, now()
                         )
                         """
                     ),
@@ -127,6 +143,15 @@ def compute_options_monthly_metrics(
                     if sum(m.roll_count for m in metrics)
                     else Decimal("0.00")
                 ),
+                "avg_capital_at_risk": str(metrics[-1].avg_capital_at_risk)
+                if metrics and metrics[-1].avg_capital_at_risk is not None
+                else None,
+                "return_on_capital_at_risk_pct": str(metrics[-1].return_on_capital_at_risk_pct)
+                if metrics and metrics[-1].return_on_capital_at_risk_pct is not None
+                else None,
+                "margin_utilization_pct": str(metrics[-1].margin_utilization_pct)
+                if metrics and metrics[-1].margin_utilization_pct is not None
+                else None,
             }
         )
         output["row_count"] += len(metrics)
@@ -227,6 +252,79 @@ def _load_roll_facts(
     ).mappings()
     return [
         OptionMetricRoll(detected_date=row["detected_date"], classification=str(row["classification"])) for row in rows
+    ]
+
+
+def _load_capital_history(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[OptionCapitalHistory]:
+    where = ["g.household_id = :household_id", "g.account_id = :account_id", "h.capital_at_risk is not null"]
+    params: dict[str, Any] = {"household_id": household_id, "account_id": account_id}
+    if to_date:
+        where.append("h.effective_at::date <= :to_date")
+        params["to_date"] = to_date
+    rows = session.execute(
+        text(
+            f"""
+            select h.group_id::text as group_id, h.effective_at, h.capital_at_risk
+              from public.options_strategy_capital_history h
+              join public.options_strategy_groups g on g.id = h.group_id
+             where {" and ".join(where)}
+             order by h.group_id, h.effective_at
+            """
+        ),
+        params,
+    ).mappings()
+    history = [
+        OptionCapitalHistory(
+            group_id=str(row["group_id"]),
+            effective_at=row["effective_at"],
+            capital_at_risk=Decimal(str(row["capital_at_risk"])),
+        )
+        for row in rows
+    ]
+    if from_date:
+        return [row for row in history if row.effective_at.date() <= to_date] if to_date else history
+    return history
+
+
+def _load_margin_snapshots(
+    session: Session,
+    household_id: str,
+    account_id: str,
+    from_date: date | None,
+    to_date: date | None,
+) -> list[OptionMarginSnapshot]:
+    where = ["household_id = :household_id", "account_id = :account_id"]
+    params: dict[str, Any] = {"household_id": household_id, "account_id": account_id}
+    if from_date:
+        where.append("captured_at::date >= :from_date")
+        params["from_date"] = from_date
+    if to_date:
+        where.append("captured_at::date <= :to_date")
+        params["to_date"] = to_date
+    rows = session.execute(
+        text(
+            f"""
+            select captured_at, margin_used, margin_available
+              from public.options_margin_snapshots
+             where {" and ".join(where)}
+             order by captured_at
+            """
+        ),
+        params,
+    ).mappings()
+    return [
+        OptionMarginSnapshot(
+            captured_at=row["captured_at"],
+            margin_used=Decimal(str(row["margin_used"])) if row["margin_used"] is not None else None,
+            margin_available=Decimal(str(row["margin_available"])) if row["margin_available"] is not None else None,
+        )
+        for row in rows
     ]
 
 

--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from contextlib import AbstractContextManager
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime, timezone
+from decimal import Decimal
 import json
 import logging
 import os
@@ -74,6 +75,9 @@ def handle_flex_options_sync(
             from_date=_optional_date(payload.get("from")),
             to_date=_optional_date(payload.get("to")),
         )
+        from app.worker.handlers.options_margin_sync import run_options_margin_sync
+
+        margin_result = run_options_margin_sync(session, account_id=_optional_str(payload.get("account_id")))
         metric_result = compute_options_monthly_metrics(
             session,
             household_id=_optional_str(payload.get("household_id")),
@@ -82,7 +86,7 @@ def handle_flex_options_sync(
             to_date=_optional_date(payload.get("to")),
         )
         session.commit()
-        return {**result, "strategy_groups": grouping_result, "monthly_metrics": metric_result}
+        return {**result, "strategy_groups": grouping_result, "margin": margin_result, "monthly_metrics": metric_result}
 
 
 def run_scheduled_flex_options_sync() -> None:
@@ -93,6 +97,9 @@ def run_scheduled_flex_options_sync() -> None:
 
         result = run_flex_options_sync(session)
         compute_options_strategy_groups(session)
+        from app.worker.handlers.options_margin_sync import run_options_margin_sync
+
+        run_options_margin_sync(session)
         compute_options_monthly_metrics(session)
         session.commit()
     logger.info("Scheduled flex_options_sync completed: %s", result)
@@ -241,6 +248,8 @@ def _ingest_account(
         leg_id = leg_ids.get(position.leg) or _upsert_leg(session, household_id, position.leg)
         leg_ids[position.leg] = leg_id
         _insert_position(session, household_id, position, leg_id)
+    for account_info in parsed.account_information:
+        _upsert_flex_margin_snapshot(session, household_id, account_info)
     _upsert_sync_state(session, household_id, account_id, parsed, from_date, to_date)
     return {
         "trade_count": len(trades_to_insert),
@@ -373,6 +382,55 @@ def _insert_position(session: Session, household_id: str, position: FlexOpenPosi
             "raw_payload": _json(position.raw_payload),
         },
     )
+
+
+def _upsert_flex_margin_snapshot(session: Session, household_id: str, account_info: Any) -> None:
+    raw = account_info.raw_payload
+    margin_used = _first_decimal(raw, ("MaintMarginReq", "maintenanceMargin", "maintMarginReq"))
+    net_liq = _first_decimal(raw, ("NetLiquidation", "netLiquidation", "netLiq"))
+    margin_available = _first_decimal(raw, ("AvailableFunds", "availableFunds", "ExcessLiquidity"))
+    buying_power = _first_decimal(raw, ("BuyingPower", "buyingPower"))
+    if margin_used is None and margin_available is None and buying_power is None:
+        return
+    if margin_available is None and net_liq is not None and margin_used is not None:
+        margin_available = net_liq - margin_used
+    captured_at = (account_info.as_of or datetime.now(timezone.utc)).replace(second=0, microsecond=0)
+    session.execute(
+        text(
+            """
+            insert into public.options_margin_snapshots (
+              household_id, account_id, captured_at, margin_used, margin_available, buying_power, source
+            ) values (
+              :household_id, :account_id, :captured_at, :margin_used, :margin_available, :buying_power, 'flex'
+            )
+            on conflict on constraint options_margin_snapshots_account_captured_key do update set
+              margin_used = excluded.margin_used,
+              margin_available = excluded.margin_available,
+              buying_power = excluded.buying_power,
+              source = 'flex',
+              updated_at = now()
+            """
+        ),
+        {
+            "household_id": household_id,
+            "account_id": account_info.account_id,
+            "captured_at": captured_at,
+            "margin_used": margin_used,
+            "margin_available": margin_available,
+            "buying_power": buying_power,
+        },
+    )
+
+
+def _first_decimal(raw: dict[str, str], names: tuple[str, ...]) -> Decimal | None:
+    for name in names:
+        value = raw.get(name)
+        if value not in (None, ""):
+            try:
+                return Decimal(str(value).replace(",", ""))
+            except Exception:  # noqa: BLE001 - ignore malformed optional Flex account fields
+                return None
+    return None
 
 
 def _upsert_sync_state(

--- a/apps/backend/app/worker/registry.py
+++ b/apps/backend/app/worker/registry.py
@@ -9,6 +9,11 @@ from app.worker.backtest_handler import run_backtest_job
 from app.worker.bonds_scanner import refresh_bond_scanner_results
 from app.worker.handlers.options_grouping import handle_compute_options_strategy_groups
 from app.worker.handlers.options_metrics import handle_compute_options_monthly_metrics
+from app.worker.handlers.options_margin_sync import (
+    handle_options_margin_sync,
+    run_intraday_options_margin_sync,
+    run_scheduled_options_margin_sync,
+)
 from app.worker.handlers.options_sync import handle_flex_options_sync, run_scheduled_flex_options_sync
 from app.worker.pension_pdf_parse import handle_pension_pdf_parse
 
@@ -35,6 +40,7 @@ JOB_HANDLERS: dict[str, JobHandler] = {
     "flex_options_sync": handle_flex_options_sync,
     "compute_options_strategy_groups": handle_compute_options_strategy_groups,
     "compute_options_monthly_metrics": handle_compute_options_monthly_metrics,
+    "options_margin_sync": handle_options_margin_sync,
 }
 JOB_SCHEDULES: list[JobSchedule] = [
     JobSchedule(
@@ -54,5 +60,17 @@ JOB_SCHEDULES: list[JobSchedule] = [
         kind="cron",
         handler=run_scheduled_flex_options_sync,
         cron_expr="30 22 * * *",
+    ),
+    JobSchedule(
+        job_id="options_margin_sync_intraday",
+        kind="interval",
+        seconds=15 * 60,
+        handler=run_intraday_options_margin_sync,
+    ),
+    JobSchedule(
+        job_id="options_margin_sync_daily",
+        kind="cron",
+        handler=run_scheduled_options_margin_sync,
+        cron_expr="35 22 * * *",
     ),
 ]

--- a/apps/backend/scripts/backfill_options.py
+++ b/apps/backend/scripts/backfill_options.py
@@ -13,6 +13,7 @@ from sqlmodel import Session
 
 from app.dal.database import engine
 from app.worker.handlers.options_grouping import compute_options_strategy_groups
+from app.worker.handlers.options_margin_sync import run_options_margin_sync
 from app.worker.handlers.options_metrics import compute_options_monthly_metrics
 from app.worker.handlers.options_sync import run_flex_options_sync
 
@@ -51,6 +52,7 @@ def main(argv: Iterable[str] | None = None) -> int:
             from_date=args.from_date,
             to_date=args.to_date,
         )
+        margin_result = run_options_margin_sync(session, account_id=args.account_id)
         metrics_result = compute_options_monthly_metrics(
             session,
             account_id=args.account_id,
@@ -60,6 +62,7 @@ def main(argv: Iterable[str] | None = None) -> int:
         session.commit()
     print("Flex sync:", sync_result)
     print("Strategy grouping:", grouping_result)
+    print("Margin sync:", margin_result)
     print("Monthly metrics:", metrics_result)
     totals = _totals(metrics_result)
     print(

--- a/apps/backend/tests/services/options/test_capital_at_risk.py
+++ b/apps/backend/tests/services/options/test_capital_at_risk.py
@@ -1,0 +1,73 @@
+"""Capital-at-risk examples for Phase 4 options gauges."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from app.services.options.strategy_grouper import StrategyTrade, calculate_capital_at_risk, group_option_strategies
+
+
+def trade(
+    trade_id: str, side: str, strike: str, cash: str, quantity: str = "-1", indicator: str = "O"
+) -> StrategyTrade:
+    """Build a minimal option strategy trade fixture."""
+
+    return StrategyTrade(
+        trade_id=trade_id,
+        household_id="hh",
+        account_id="acct",
+        trade_date=date(2025, 1, 2),
+        trade_time=datetime(2025, 1, 2, 15, 30, tzinfo=timezone.utc),
+        underlying_symbol="SPY",
+        right="put",
+        side=side,
+        open_close_indicator=indicator,
+        event_type="open" if indicator == "O" else "close",
+        strike=Decimal(strike),
+        expiry=date(2025, 2, 21),
+        quantity=Decimal(quantity),
+        net_cash_flow=Decimal(cash),
+        realized_pnl=Decimal("0"),
+        currency="USD",
+        multiplier=Decimal("100"),
+    )
+
+
+def test_csp_capital_at_risk_is_max_loss_net_of_premium() -> None:
+    """A short 50 put collecting $125 has $4,875 at risk."""
+
+    risk, method = calculate_capital_at_risk("csp", [trade("short", "sell", "50", "125")])
+    assert risk == Decimal("4875")
+    assert method == "csp_net_premium"
+
+
+def test_vertical_spread_capital_at_risk_caps_at_zero() -> None:
+    """A 50/45 put credit spread collecting $150 has $350 at risk."""
+
+    risk, method = calculate_capital_at_risk(
+        "vertical_spread",
+        [trade("short", "sell", "50", "200"), trade("long", "buy", "45", "-50", quantity="1")],
+    )
+    assert risk == Decimal("350")
+    assert method == "vertical_spread_max_loss"
+
+    zero_risk, _ = calculate_capital_at_risk(
+        "vertical_spread",
+        [trade("short-rich", "sell", "50", "700"), trade("long-rich", "buy", "45", "-50", quantity="1")],
+    )
+    assert zero_risk == Decimal("0")
+
+
+def test_roll_chain_emits_capital_history_for_latest_open_leg() -> None:
+    """Rolling a CSP stores initial and replacement risk points."""
+
+    opened = trade("open-short", "sell", "50", "125")
+    closed = trade("close-short", "buy", "50", "-250", quantity="1", indicator="C")
+    replacement = replace(
+        trade("open-roll", "sell", "45", "175"), trade_time=datetime(2025, 1, 2, 15, 31, tzinfo=timezone.utc)
+    )
+    result = group_option_strategies([opened, closed, replacement])
+    assert result.groups[0].kind == "roll_chain"
+    assert [entry.capital_at_risk for entry in result.capital_history] == [Decimal("4875"), Decimal("4325")]

--- a/apps/backend/tests/services/options/test_margin_calculations.py
+++ b/apps/backend/tests/services/options/test_margin_calculations.py
@@ -1,0 +1,21 @@
+"""Margin utilization edge cases for Phase 4 gauges."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from app.services.options.metrics import margin_utilization_pct
+
+
+def test_margin_utilization_pct_uses_used_over_available() -> None:
+    """Margin utilization is account-wide margin used divided by margin available."""
+
+    assert margin_utilization_pct(Decimal("2500"), Decimal("10000")) == Decimal("25.00")
+
+
+def test_margin_utilization_pct_returns_none_for_zero_or_missing_denominator() -> None:
+    """Unavailable margin snapshots must not render as zero or infinity."""
+
+    assert margin_utilization_pct(Decimal("2500"), Decimal("0")) is None
+    assert margin_utilization_pct(None, Decimal("10000")) is None
+    assert margin_utilization_pct(Decimal("2500"), None) is None

--- a/apps/backend/tests/services/options/test_metrics_rocar.py
+++ b/apps/backend/tests/services/options/test_metrics_rocar.py
@@ -1,0 +1,25 @@
+"""Time-weighted RoCaR examples for Phase 4 monthly metrics."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from decimal import Decimal
+
+from app.services.options.metrics import OptionCapitalHistory, OptionMetricTrade, compute_monthly_metrics
+
+
+def test_time_weighted_rocar_for_jony_spread_example() -> None:
+    """A $10k spread active for half of January averages $5k of capital at risk."""
+
+    metrics = compute_monthly_metrics(
+        [OptionMetricTrade(trade_date=date(2025, 1, 31), net_cash_flow=Decimal("0"), realized_pnl=Decimal("1000"))],
+        capital_history=[
+            OptionCapitalHistory(
+                group_id="spread-1",
+                effective_at=datetime(2025, 1, 16, tzinfo=timezone.utc),
+                capital_at_risk=Decimal("10000"),
+            )
+        ],
+    )
+    assert metrics[0].avg_capital_at_risk == Decimal("5161.290323")
+    assert metrics[0].return_on_capital_at_risk_pct == Decimal("19.3750")

--- a/apps/backend/tests/worker/test_options_grouping.py
+++ b/apps/backend/tests/worker/test_options_grouping.py
@@ -107,6 +107,7 @@ def _trade_rows() -> list[dict[str, Any]]:
             "right": "put",
             "strike": Decimal(strike),
             "expiry": expiry,
+            "multiplier": Decimal("100"),
         }
 
     return [

--- a/apps/backend/tests/worker/test_options_margin_sync.py
+++ b/apps/backend/tests/worker/test_options_margin_sync.py
@@ -1,0 +1,92 @@
+"""Worker tests for Phase 4 options margin snapshots."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+from app.worker.handlers import options_margin_sync
+
+
+class FakeScalar:
+    """Scalar wrapper for fake aggregate selects."""
+
+    def __init__(self, value: Decimal | None = None) -> None:
+        self.value = value
+
+    def scalar_one_or_none(self) -> Decimal | None:
+        """Return the aggregate value."""
+
+        return self.value
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return empty mappings."""
+
+        return []
+
+
+class FakeMappings:
+    """Mappings wrapper for fake account query."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return rows."""
+
+        return self.rows
+
+
+class FakeSession:
+    """Small SQL recorder for synthetic margin fallback."""
+
+    def __init__(self) -> None:
+        self.snapshots: list[dict[str, Any]] = []
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeScalar | FakeMappings:
+        """Return account/risk rows and record snapshot upserts."""
+
+        sql = str(statement)
+        params = params or {}
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "id": 1,
+                        "household_id": "10000000-0000-0000-0000-000000000001",
+                        "account_id": "U123",
+                        "name": "IBKR",
+                    }
+                ]
+            )
+        if "sum(capital_at_risk_open)" in sql:
+            return FakeScalar(Decimal("5000"))
+        if "insert into public.options_margin_snapshots" in sql:
+            existing = next(
+                (
+                    row
+                    for row in self.snapshots
+                    if row["account_id"] == params["account_id"] and row["captured_at"] == params["captured_at"]
+                ),
+                None,
+            )
+            if existing:
+                existing.update(params)
+            else:
+                self.snapshots.append(params)
+        return FakeScalar()
+
+
+def test_synthetic_fallback_produces_idempotent_margin_row(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """When IB Gateway is offline, synthetic margin uses open capital at risk."""
+
+    monkeypatch.setattr(options_margin_sync, "is_ib_gateway_available", lambda *args, **kwargs: False)
+    session = FakeSession()
+    first = options_margin_sync.run_options_margin_sync(session)  # type: ignore[arg-type]
+    second = options_margin_sync.run_options_margin_sync(session)  # type: ignore[arg-type]
+
+    assert first["source"] == "synthetic"
+    assert second["source"] == "synthetic"
+    assert len(session.snapshots) == 1
+    assert session.snapshots[0]["margin_used"] == Decimal("5000")
+    assert session.snapshots[0]["margin_available"] == Decimal("15000")

--- a/apps/frontend/e2e/fixtures/seed-data.ts
+++ b/apps/frontend/e2e/fixtures/seed-data.ts
@@ -303,6 +303,8 @@ export async function seedOptionsDashboard(householdId: string): Promise<Options
     net_cash_flow: 2700,
     realized_pnl: 1000,
     capital_at_risk: 2300,
+    capital_at_risk_open: 10000,
+    risk_calculation_method: 'vertical_spread_max_loss',
   }).select('id').single();
   if (groupError || !group) throw new Error(`[seed-data] insert options_strategy_groups failed: ${groupError?.message ?? 'no row'}`);
 
@@ -365,9 +367,20 @@ export async function seedOptionsDashboard(householdId: string): Promise<Options
   const { error: metricsError } = await admin.from('options_dashboard_monthly').insert([
     { household_id: householdId, account_id: accountId, period_start: '2026-01-01', period_end: '2026-01-31', cash_flow_total: 3000, realized_pnl_total: 0, cash_flow_cumulative: 3000, realized_pnl_cumulative: 0, variance_gap: 3000, variance_gap_cumulative: 3000, trade_count: 1, roll_count: 0, roll_positive_count: 0, roll_negative_count: 0, roll_neutral_count: 0 },
     { household_id: householdId, account_id: accountId, period_start: '2026-02-01', period_end: '2026-02-28', cash_flow_total: 200, realized_pnl_total: -1000, cash_flow_cumulative: 3200, realized_pnl_cumulative: -1000, variance_gap: 1200, variance_gap_cumulative: 4200, trade_count: 2, roll_count: 1, roll_positive_count: 0, roll_negative_count: 1, roll_neutral_count: 0, roll_efficiency_pct: 0 },
-    { household_id: householdId, account_id: accountId, period_start: '2026-03-01', period_end: '2026-03-31', cash_flow_total: -500, realized_pnl_total: 2000, cash_flow_cumulative: 2700, realized_pnl_cumulative: 1000, variance_gap: -2500, variance_gap_cumulative: 1700, trade_count: 1, roll_count: 0, roll_positive_count: 0, roll_negative_count: 0, roll_neutral_count: 0 },
+    { household_id: householdId, account_id: accountId, period_start: '2026-03-01', period_end: '2026-03-31', cash_flow_total: -500, realized_pnl_total: 2000, cash_flow_cumulative: 2700, realized_pnl_cumulative: 1000, variance_gap: -2500, variance_gap_cumulative: 1700, trade_count: 1, roll_count: 0, roll_positive_count: 0, roll_negative_count: 0, roll_neutral_count: 0, avg_capital_at_risk: 10000, return_on_capital_at_risk_pct: 20.0, latest_margin_used: 5000, latest_margin_available: 15000, margin_utilization_pct: 33.33 },
   ]);
   if (metricsError) throw new Error(`[seed-data] insert options_dashboard_monthly failed: ${metricsError.message}`);
+
+  const { error: marginError } = await admin.from('options_margin_snapshots').insert({
+    household_id: householdId,
+    account_id: accountId,
+    captured_at: new Date().toISOString(),
+    margin_used: 5000,
+    margin_available: 15000,
+    buying_power: 15000,
+    source: 'synthetic',
+  });
+  if (marginError) throw new Error(`[seed-data] insert options_margin_snapshots failed: ${marginError.message}`);
 
   return { accountId, groupId: group.id as string };
 }
@@ -387,6 +400,7 @@ export async function cleanupHouseholdData(householdId: string): Promise<void> {
   const admin = getAdminClient();
 
   const results = await Promise.allSettled([
+    admin.from('options_margin_snapshots').delete().eq('household_id', householdId),
     admin.from('options_roll_events').delete().eq('household_id', householdId),
     admin.from('options_trades').delete().eq('household_id', householdId),
     admin.from('options_dashboard_monthly').delete().eq('household_id', householdId),

--- a/apps/frontend/e2e/options-dashboard.spec.ts
+++ b/apps/frontend/e2e/options-dashboard.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from './fixtures/test-user';
 import { cleanupHouseholdData, seedOptionsDashboard } from './fixtures/seed-data';
 
-test.describe('Options Income Dashboard Phase 3', () => {
-  test('renders all dashboard widgets from cooked Supabase tables', async ({ testUser: { page, householdId } }) => {
+test.describe('Options Income Dashboard Phase 4', () => {
+  test('renders all dashboard widgets and live gauges from cooked Supabase tables', async ({ testUser: { page, householdId } }) => {
     const consoleErrors: string[] = [];
     page.on('console', (msg) => {
       if (msg.type() === 'error') consoleErrors.push(msg.text());
@@ -16,7 +16,9 @@ test.describe('Options Income Dashboard Phase 3', () => {
       await expect(page.getByRole('heading', { name: /Options Income Dashboard/i })).toBeVisible({ timeout: 10_000 });
       await expect(page.getByTestId('freshness-badge')).toBeVisible();
       await expect(page.getByTestId('variance-gap-badge')).toBeVisible();
-      await expect(page.getByTestId('efficiency-gauges')).toContainText('Pending — Phase 4');
+      await expect(page.getByTestId('efficiency-gauges')).not.toContainText('Pending — Phase 4');
+      await expect(page.getByTestId('efficiency-gauges')).toContainText('20.00%');
+      await expect(page.getByTestId('efficiency-gauges')).toContainText('synthetic');
       await expect(page.getByTestId('net-cash-flow-chart')).toBeVisible();
       await expect(page.getByTestId('trade-lifecycle-timeline')).toBeVisible();
       await expect(page.getByTestId('roll-efficiency-donut')).toBeVisible();

--- a/apps/frontend/src/app/options/actions.ts
+++ b/apps/frontend/src/app/options/actions.ts
@@ -1,10 +1,12 @@
 'use server';
 
+import Decimal from 'decimal.js';
 import { createClient } from '@/lib/supabase/server';
 import type {
   MonthlyMetric,
   OptionsEnabledAccount,
   OptionsFreshness,
+  OptionsMarginSource,
   OptionsTradeSummary,
   RollEvent,
   StrategyGroup,
@@ -41,6 +43,16 @@ function toInt(value: unknown): number {
 
 function dateKey(date: Date): string {
   return date.toISOString().slice(0, 10);
+}
+
+function marginSource(value: unknown): OptionsMarginSource | null {
+  return value === 'ib_gateway' || value === 'flex' || value === 'synthetic' ? value : null;
+}
+
+function isOlderThanOneHour(value: string | null): boolean {
+  if (!value) return false;
+  const ageMs = new Decimal(Date.now()).minus(new Date(value).getTime());
+  return ageMs.gt(new Decimal(60 * 60 * 1000));
 }
 
 /** Resolves household scope from the authenticated session; never from caller input. */
@@ -370,4 +382,68 @@ export async function getOptionsTrades(
   }
 
   return ((data ?? []) as Record<string, unknown>[]).map(normalizeTrade).filter((trade): trade is OptionsTradeSummary => trade !== null);
+}
+
+
+/** Reads live capital-efficiency gauge values for the selected options account. */
+export async function getEfficiencyGaugesData(accountId?: string): Promise<import('@/types/options').EfficiencyGaugesData> {
+  const { householdId } = await getAuthenticatedHousehold();
+  if (!householdId) {
+    return { rocaR_pct: null, marginUtilization_pct: null, marginSource: null, marginAsOf: null, marginUsed: null, marginAvailable: null, isStale: false };
+  }
+
+  const supabase = await createClient();
+  const accountFilter = typeof accountId === 'string' && accountId.trim() ? accountId.trim() : null;
+  const monthlyQuery = accountFilter
+    ? supabase
+      .from('options_dashboard_monthly')
+      .select('return_on_capital_at_risk_pct')
+      .eq('household_id', householdId)
+      .eq('account_id', accountFilter)
+      .not('return_on_capital_at_risk_pct', 'is', null)
+      .order('period_start', { ascending: false })
+      .limit(1)
+    : supabase
+      .from('options_dashboard_monthly')
+      .select('return_on_capital_at_risk_pct')
+      .eq('household_id', householdId)
+      .not('return_on_capital_at_risk_pct', 'is', null)
+      .order('period_start', { ascending: false })
+      .limit(1);
+
+  const marginQuery = accountFilter
+    ? supabase
+      .from('options_margin_snapshots')
+      .select('captured_at, margin_used, margin_available, source')
+      .eq('household_id', householdId)
+      .eq('account_id', accountFilter)
+      .order('captured_at', { ascending: false })
+      .limit(1)
+    : supabase
+      .from('options_margin_snapshots')
+      .select('captured_at, margin_used, margin_available, source')
+      .eq('household_id', householdId)
+      .order('captured_at', { ascending: false })
+      .limit(1);
+
+  const [monthlyResult, marginResult] = await Promise.all([monthlyQuery.maybeSingle(), marginQuery.maybeSingle()]);
+
+  if (monthlyResult.error) console.error('[getEfficiencyGaugesData] monthly query error:', monthlyResult.error.message);
+  if (marginResult.error) console.error('[getEfficiencyGaugesData] margin query error:', marginResult.error.message);
+
+  const monthly = monthlyResult.data as Record<string, unknown> | null;
+  const margin = marginResult.data as Record<string, unknown> | null;
+  const marginAsOf = margin ? text(margin.captured_at) || null : null;
+
+  return {
+    rocaR_pct: monthly ? nullableDecimalString(monthly.return_on_capital_at_risk_pct as NumericLike) : null,
+    marginUtilization_pct: margin && margin.margin_used !== null && margin.margin_available !== null && new Decimal(decimalString(margin.margin_available as NumericLike)).gt(0)
+      ? new Decimal(decimalString(margin.margin_used as NumericLike)).div(decimalString(margin.margin_available as NumericLike)).times(100).toFixed(2)
+      : null,
+    marginSource: margin ? marginSource(margin.source) : null,
+    marginAsOf,
+    marginUsed: margin ? nullableDecimalString(margin.margin_used as NumericLike) : null,
+    marginAvailable: margin ? nullableDecimalString(margin.margin_available as NumericLike) : null,
+    isStale: isOlderThanOneHour(marginAsOf),
+  };
 }

--- a/apps/frontend/src/app/options/page.tsx
+++ b/apps/frontend/src/app/options/page.tsx
@@ -10,8 +10,9 @@ import RollEfficiencyDonut from '@/components/Options/roll-efficiency-donut';
 import TradeLifecycleTimeline from '@/components/Options/trade-lifecycle-timeline';
 import VarianceGapBadge from '@/components/Options/variance-gap-badge';
 import { formatDate, formatSignedUsd } from '@/components/Options/options-format';
-import type { MonthlyMetric, OptionsEnabledAccount, OptionsFreshness, OptionsTradeSummary, RollEvent, StrategyGroup } from '@/types/options';
+import type { EfficiencyGaugesData, MonthlyMetric, OptionsEnabledAccount, OptionsFreshness, OptionsTradeSummary, RollEvent, StrategyGroup } from '@/types/options';
 import {
+  getEfficiencyGaugesData,
   getOptionsFreshness,
   getOptionsMonthlyMetrics,
   getOptionsRollEvents,
@@ -27,6 +28,7 @@ interface DashboardState {
   groups: StrategyGroup[];
   freshness: OptionsFreshness;
   trades: OptionsTradeSummary[];
+  gauges: EfficiencyGaugesData;
 }
 
 const EMPTY_STATE: DashboardState = {
@@ -36,6 +38,7 @@ const EMPTY_STATE: DashboardState = {
   groups: [],
   freshness: { asOf: null, source: null, status: null },
   trades: [],
+  gauges: { rocaR_pct: null, marginUtilization_pct: null, marginSource: null, marginAsOf: null, marginUsed: null, marginAvailable: null, isStale: false },
 };
 
 function yearRange(): number[] {
@@ -146,16 +149,17 @@ export default function OptionsPage() {
       setError(null);
       try {
         const accountFilter = selectedAccount || undefined;
-        const [accounts, months, rolls, groups, freshness, trades] = await Promise.all([
+        const [accounts, months, rolls, groups, freshness, trades, gauges] = await Promise.all([
           getUserAccountsWithOptionsEnabled(),
           getOptionsMonthlyMetrics(selectedYear, accountFilter),
           getOptionsRollEvents(start, end, accountFilter),
           getOptionsStrategyTimeline(start, end, accountFilter),
           getOptionsFreshness(),
           getOptionsTrades(start, end, accountFilter),
+          getEfficiencyGaugesData(accountFilter),
         ]);
 
-        if (!cancelled) setData({ accounts, months, rolls, groups, freshness, trades });
+        if (!cancelled) setData({ accounts, months, rolls, groups, freshness, trades, gauges });
       } catch (err) {
         console.error('Failed to load options dashboard:', err);
         if (!cancelled) setError('Failed to load options dashboard. Please refresh and try again.');
@@ -199,7 +203,7 @@ export default function OptionsPage() {
     <div className="mx-auto max-w-7xl space-y-6 p-6">
       <header className="flex flex-col gap-4 rounded-3xl border border-slate-800 bg-[radial-gradient(circle_at_top_left,rgba(59,130,246,0.18),transparent_35%),#020617] p-6 md:flex-row md:items-center md:justify-between">
         <div>
-          <p className="text-xs uppercase tracking-[0.34em] text-blue-300">Phase 3</p>
+          <p className="text-xs uppercase tracking-[0.34em] text-blue-300">Phase 4</p>
           <h1 className="mt-2 text-4xl font-black tracking-tight text-slate-50">Options Income Dashboard</h1>
           <p className="mt-2 text-slate-400">Read-only Flex metrics: cash flow, realized P&amp;L, strategy lifecycle, and roll quality.</p>
         </div>
@@ -240,7 +244,7 @@ export default function OptionsPage() {
         <>
           <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
             <VarianceGapBadge cumulativeCashFlow={totals.cashFlow} cumulativeRealizedPnl={totals.realized} gap={totals.gap} asOf={totals.asOf} />
-            <div className="lg:col-span-2"><EfficiencyGauges /></div>
+            <div className="lg:col-span-2"><EfficiencyGauges data={data.gauges} /></div>
           </div>
 
           <NetCashFlowVsRealizedChart months={data.months} />

--- a/apps/frontend/src/components/Options/__tests__/EfficiencyGauges.test.tsx
+++ b/apps/frontend/src/components/Options/__tests__/EfficiencyGauges.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import EfficiencyGauges from '../efficiency-gauges';
+
+const baseData = {
+  rocaR_pct: '19.3750',
+  marginUtilization_pct: '25.00',
+  marginSource: 'synthetic' as const,
+  marginAsOf: '2025-01-31T22:35:00Z',
+  marginUsed: '5000',
+  marginAvailable: '15000',
+  isStale: true,
+};
+
+describe('EfficiencyGauges', () => {
+  it('renders live gauge values, stale badges, source pill, and needles', () => {
+    render(<EfficiencyGauges data={baseData} />);
+
+    expect(screen.getByTestId('efficiency-gauges')).toBeInTheDocument();
+    expect(screen.getByText('19.38%')).toBeInTheDocument();
+    expect(screen.getByText('25.00%')).toBeInTheDocument();
+    expect(screen.getAllByText('Stale')).toHaveLength(2);
+    expect(screen.getByText('synthetic')).toBeInTheDocument();
+    expect(screen.getByTestId('return-on-capital-at-risk-needle')).toBeInTheDocument();
+    expect(screen.getByTestId('margin-utilization-needle')).toBeInTheDocument();
+  });
+
+  it('renders first-sync empty state when both gauges are null', () => {
+    render(<EfficiencyGauges data={{ ...baseData, rocaR_pct: null, marginUtilization_pct: null }} />);
+
+    expect(screen.getByText('Waiting for first sync — see /options/setup')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/Options/efficiency-gauges.tsx
+++ b/apps/frontend/src/components/Options/efficiency-gauges.tsx
@@ -1,24 +1,143 @@
-function GaugeSkeleton({ title }: { title: string }) {
+'use client';
+
+import Decimal from 'decimal.js';
+import type { ReactNode } from 'react';
+import type { EfficiencyGaugesData, OptionsMarginSource } from '@/types/options';
+
+interface EfficiencyGaugesProps {
+  data: EfficiencyGaugesData;
+}
+
+interface GaugeProps {
+  title: string;
+  value: string | null;
+  suffix: string;
+  min: Decimal;
+  max: Decimal;
+  zones: { label: string; from: number; to: number; color: string }[];
+  tooltip: string;
+  stale: boolean;
+  footer?: ReactNode;
+}
+
+const SOURCE_LABELS: Record<OptionsMarginSource, string> = {
+  ib_gateway: 'live (IB Gateway)',
+  flex: 'flex',
+  synthetic: 'synthetic',
+};
+
+function clamp(value: Decimal, min: Decimal, max: Decimal): Decimal {
+  return Decimal.max(min, Decimal.min(max, value));
+}
+
+function needleRotation(value: string | null, min: Decimal, max: Decimal): number {
+  if (value === null) return -90;
+  const decimal = new Decimal(value);
+  const ratio = clamp(decimal.minus(min).div(max.minus(min)), new Decimal(0), new Decimal(1));
+  return ratio.times(180).minus(90).toNumber();
+}
+
+function formatPct(value: string | null): string {
+  if (value === null) return '—';
+  return `${new Decimal(value).toFixed(2)}%`;
+}
+
+function SemicircleGauge({ title, value, suffix, min, max, zones, tooltip, stale, footer }: GaugeProps) {
+  const rotation = needleRotation(value, min, max);
+  const displayValue = value === null ? '—' : `${new Decimal(value).toFixed(2)}${suffix}`;
   return (
-    <div className="rounded-3xl border border-slate-700/70 bg-slate-950/70 p-6" data-testid={`gauge-${title.toLowerCase().replaceAll(' ', '-')}`}>
-      <p className="text-sm font-semibold text-slate-200">{title}</p>
-      <div className="mt-6 flex justify-center">
-        <svg viewBox="0 0 220 120" className="h-28 w-full max-w-64" role="img" aria-label={`${title} pending gauge`}>
-          <path d="M 30 100 A 80 80 0 0 1 190 100" fill="none" stroke="rgb(51 65 85)" strokeWidth="18" strokeLinecap="round" />
-          <path d="M 30 100 A 80 80 0 0 1 190 100" fill="none" stroke="rgba(148, 163, 184, 0.22)" strokeWidth="10" strokeLinecap="round" strokeDasharray="8 12" />
-          <circle cx="110" cy="100" r="6" fill="rgb(100 116 139)" />
+    <div className="rounded-3xl border border-slate-700/70 bg-slate-950/70 p-6" data-testid={`gauge-${title.toLowerCase().replaceAll(' ', '-')}`} title={tooltip}>
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-sm font-semibold text-slate-200">{title}</p>
+        {stale && <span className="rounded-full border border-amber-400/40 bg-amber-400/10 px-2 py-0.5 text-xs font-semibold text-amber-200">Stale</span>}
+      </div>
+      <div className="mt-5 flex justify-center">
+        <svg viewBox="0 0 220 130" className="h-32 w-full max-w-64" role="img" aria-label={`${title} gauge ${displayValue}`}>
+          <path d="M 30 105 A 80 80 0 0 1 190 105" fill="none" stroke="rgb(30 41 59)" strokeWidth="20" strokeLinecap="round" />
+          {zones.map((zone, index) => (
+            <path
+              key={zone.label}
+              d="M 30 105 A 80 80 0 0 1 190 105"
+              fill="none"
+              stroke={zone.color}
+              strokeWidth="12"
+              strokeLinecap="round"
+              pathLength={100}
+              strokeDasharray={`${zone.to - zone.from} ${100 - (zone.to - zone.from)}`}
+              strokeDashoffset={100 - zone.from}
+              opacity={0.9 - index * 0.05}
+            />
+          ))}
+          <g transform={`rotate(${rotation} 110 105)`} data-testid={`${title.toLowerCase().replaceAll(' ', '-')}-needle`}>
+            <line x1="110" y1="105" x2="110" y2="32" stroke="rgb(226 232 240)" strokeWidth="4" strokeLinecap="round" />
+            <circle cx="110" cy="105" r="7" fill="rgb(226 232 240)" />
+          </g>
         </svg>
       </div>
-      <div className="mt-3 rounded-2xl bg-slate-900/80 px-4 py-3 text-center text-sm font-medium text-slate-400">Pending — Phase 4</div>
+      <div className="mt-2 text-center text-3xl font-black tabular-nums text-slate-50">{displayValue}</div>
+      <p className="mt-1 text-center text-xs text-slate-500">{tooltip}</p>
+      {footer && <div className="mt-3 flex justify-center">{footer}</div>}
     </div>
   );
 }
 
-export default function EfficiencyGauges() {
+function SourcePill({ source }: { source: OptionsMarginSource | null }) {
+  if (!source) return null;
+  const synthetic = source === 'synthetic';
+  return (
+    <span className={`rounded-full px-3 py-1 text-xs font-semibold ${synthetic ? 'bg-slate-700 text-slate-300' : 'bg-emerald-400/15 text-emerald-200'}`}>
+      {SOURCE_LABELS[source]}
+    </span>
+  );
+}
+
+export default function EfficiencyGauges({ data }: EfficiencyGaugesProps) {
+  const noData = data.rocaR_pct === null && data.marginUtilization_pct === null;
+  if (noData) {
+    return (
+      <section className="h-full rounded-3xl border border-dashed border-slate-700 bg-slate-950/70 p-8 text-center" data-testid="efficiency-gauges">
+        <h2 className="text-xl font-bold text-slate-100">Capital efficiency gauges</h2>
+        <p className="mt-3 text-slate-400">Waiting for first sync — see /options/setup</p>
+      </section>
+    );
+  }
+
+  const marginTooltip = data.marginUsed && data.marginAvailable
+    ? `Margin used / available = ${new Decimal(data.marginUsed).toFixed(2)} / ${new Decimal(data.marginAvailable).toFixed(2)} (${data.marginSource ?? 'unknown'})`
+    : 'Margin used / margin available; unavailable until the first margin snapshot.';
+
   return (
     <section className="grid h-full grid-cols-1 gap-4 md:grid-cols-2" data-testid="efficiency-gauges">
-      <GaugeSkeleton title="Return on Capital at Risk" />
-      <GaugeSkeleton title="Margin Utilization" />
+      <SemicircleGauge
+        title="Return on Capital at Risk"
+        value={data.rocaR_pct}
+        suffix="%"
+        min={new Decimal(-10)}
+        max={new Decimal(25)}
+        zones={[
+          { label: 'negative', from: 0, to: 29, color: 'rgb(239 68 68)' },
+          { label: 'low', from: 29, to: 43, color: 'rgb(100 116 139)' },
+          { label: 'target', from: 43, to: 71, color: 'rgb(34 197 94)' },
+          { label: 'high', from: 71, to: 100, color: 'rgb(59 130 246)' },
+        ]}
+        tooltip={`Realized P&L / time-weighted capital at risk = ${formatPct(data.rocaR_pct)}`}
+        stale={data.isStale}
+      />
+      <SemicircleGauge
+        title="Margin Utilization"
+        value={data.marginUtilization_pct}
+        suffix="%"
+        min={new Decimal(0)}
+        max={new Decimal(100)}
+        zones={[
+          { label: 'comfortable', from: 0, to: 50, color: 'rgb(34 197 94)' },
+          { label: 'watch', from: 50, to: 75, color: 'rgb(245 158 11)' },
+          { label: 'high', from: 75, to: 100, color: 'rgb(239 68 68)' },
+        ]}
+        tooltip={marginTooltip}
+        stale={data.isStale}
+        footer={<SourcePill source={data.marginSource} />}
+      />
     </section>
   );
 }

--- a/apps/frontend/src/types/options.ts
+++ b/apps/frontend/src/types/options.ts
@@ -96,3 +96,15 @@ export interface RollEfficiencyCounts {
   negative: number;
   neutral: number;
 }
+
+export type OptionsMarginSource = 'ib_gateway' | 'flex' | 'synthetic';
+
+export interface EfficiencyGaugesData {
+  rocaR_pct: MoneyString | null;
+  marginUtilization_pct: MoneyString | null;
+  marginSource: OptionsMarginSource | null;
+  marginAsOf: string | null;
+  marginUsed: MoneyString | null;
+  marginAvailable: MoneyString | null;
+  isStale: boolean;
+}

--- a/supabase/migrations/20260504150112_options_phase4_capital_margin.sql
+++ b/supabase/migrations/20260504150112_options_phase4_capital_margin.sql
@@ -1,0 +1,145 @@
+-- Migration: options_phase4_capital_margin
+-- Purpose: Phase 4 capital-at-risk history and account-wide margin utilization gauges for #249.
+
+alter table public.options_strategy_groups
+  add column if not exists capital_at_risk_open numeric(18,6),
+  add column if not exists risk_calculation_method text;
+
+alter table public.options_strategy_groups
+  drop constraint if exists options_strategy_groups_risk_calculation_method_check,
+  add constraint options_strategy_groups_risk_calculation_method_check
+    check (risk_calculation_method is null or risk_calculation_method in (
+      'csp_net_premium', 'vertical_spread_max_loss', 'roll_chain_latest_leg', 'ungrouped'
+    ));
+
+update public.options_strategy_groups
+   set capital_at_risk_open = coalesce(capital_at_risk_open, capital_at_risk),
+       risk_calculation_method = coalesce(risk_calculation_method, 'ungrouped')
+ where capital_at_risk is not null
+    or risk_calculation_method is null;
+
+create table if not exists public.options_strategy_capital_history (
+  id uuid primary key default gen_random_uuid(),
+  group_id uuid not null references public.options_strategy_groups(id) on delete cascade,
+  effective_at timestamptz not null,
+  capital_at_risk numeric(18,6),
+  risk_calculation_method text not null check (risk_calculation_method in (
+    'csp_net_premium', 'vertical_spread_max_loss', 'roll_chain_latest_leg', 'ungrouped'
+  )),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_strategy_capital_history_group_effective_key unique (group_id, effective_at)
+);
+
+create index if not exists options_strategy_capital_history_group_effective_idx
+  on public.options_strategy_capital_history (group_id, effective_at desc);
+
+create table if not exists public.options_margin_snapshots (
+  id uuid primary key default gen_random_uuid(),
+  household_id uuid not null references public.households(id) on delete cascade,
+  account_id text not null,
+  account_config_id integer references public.trading_account_config(id) on delete cascade,
+  captured_at timestamptz not null,
+  margin_used numeric(18,6),
+  margin_available numeric(18,6),
+  buying_power numeric(18,6),
+  source text not null check (source in ('ib_gateway', 'flex', 'synthetic')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint options_margin_snapshots_account_captured_key unique (account_id, captured_at)
+);
+
+create index if not exists options_margin_snapshots_account_captured_idx
+  on public.options_margin_snapshots (account_id, captured_at desc);
+create index if not exists options_margin_snapshots_household_account_captured_idx
+  on public.options_margin_snapshots (household_id, account_id, captured_at desc);
+
+alter table public.options_dashboard_monthly
+  add column if not exists avg_capital_at_risk numeric(18,6),
+  add column if not exists return_on_capital_at_risk_pct numeric(8,4),
+  add column if not exists latest_margin_used numeric(18,6),
+  add column if not exists latest_margin_available numeric(18,6),
+  add column if not exists margin_utilization_pct numeric(5,2);
+
+-- Keep updated_at consistent with the rest of the public schema.
+drop trigger if exists trg_options_strategy_capital_history_updated_at on public.options_strategy_capital_history;
+create trigger trg_options_strategy_capital_history_updated_at
+  before update on public.options_strategy_capital_history
+  for each row execute function public.tg_update_timestamp();
+
+drop trigger if exists trg_options_margin_snapshots_updated_at on public.options_margin_snapshots;
+create trigger trg_options_margin_snapshots_updated_at
+  before update on public.options_margin_snapshots
+  for each row execute function public.tg_update_timestamp();
+
+alter table public.options_strategy_capital_history enable row level security;
+alter table public.options_margin_snapshots enable row level security;
+
+revoke all on table public.options_strategy_capital_history, public.options_margin_snapshots from anon;
+revoke all on table public.options_strategy_capital_history, public.options_margin_snapshots from authenticated;
+grant select, insert, update, delete on table public.options_strategy_capital_history, public.options_margin_snapshots to authenticated;
+grant select, insert, update, delete on table public.options_strategy_capital_history, public.options_margin_snapshots to service_role;
+
+-- Capital history inherits household scope through its strategy group.
+drop policy if exists options_strategy_capital_history_select on public.options_strategy_capital_history;
+create policy options_strategy_capital_history_select on public.options_strategy_capital_history
+  for select to authenticated using (
+    exists (
+      select 1 from public.options_strategy_groups g
+       where g.id = group_id and g.household_id is not null and public.is_household_member(g.household_id)
+    )
+  );
+drop policy if exists options_strategy_capital_history_insert on public.options_strategy_capital_history;
+create policy options_strategy_capital_history_insert on public.options_strategy_capital_history
+  for insert to authenticated with check (
+    exists (
+      select 1 from public.options_strategy_groups g
+       where g.id = group_id and g.household_id is not null and public.is_household_writer(g.household_id)
+    )
+  );
+drop policy if exists options_strategy_capital_history_update on public.options_strategy_capital_history;
+create policy options_strategy_capital_history_update on public.options_strategy_capital_history
+  for update to authenticated using (
+    exists (
+      select 1 from public.options_strategy_groups g
+       where g.id = group_id and g.household_id is not null and public.is_household_writer(g.household_id)
+    )
+  ) with check (
+    exists (
+      select 1 from public.options_strategy_groups g
+       where g.id = group_id and g.household_id is not null and public.is_household_writer(g.household_id)
+    )
+  );
+drop policy if exists options_strategy_capital_history_delete on public.options_strategy_capital_history;
+create policy options_strategy_capital_history_delete on public.options_strategy_capital_history
+  for delete to authenticated using (
+    exists (
+      select 1 from public.options_strategy_groups g
+       where g.id = group_id and g.household_id is not null and public.is_household_writer(g.household_id)
+    )
+  );
+
+-- Margin snapshots are account-wide, scoped directly by household for efficient latest-snapshot reads.
+drop policy if exists options_margin_snapshots_select on public.options_margin_snapshots;
+create policy options_margin_snapshots_select on public.options_margin_snapshots
+  for select to authenticated using (household_id is not null and public.is_household_member(household_id));
+drop policy if exists options_margin_snapshots_insert on public.options_margin_snapshots;
+create policy options_margin_snapshots_insert on public.options_margin_snapshots
+  for insert to authenticated with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_margin_snapshots_update on public.options_margin_snapshots;
+create policy options_margin_snapshots_update on public.options_margin_snapshots
+  for update to authenticated using (household_id is not null and public.is_household_writer(household_id))
+  with check (household_id is not null and public.is_household_writer(household_id));
+drop policy if exists options_margin_snapshots_delete on public.options_margin_snapshots;
+create policy options_margin_snapshots_delete on public.options_margin_snapshots
+  for delete to authenticated using (household_id is not null and public.is_household_writer(household_id));
+
+do $$
+begin
+  alter publication supabase_realtime add table public.options_margin_snapshots;
+exception when duplicate_object then null; when undefined_object then null; end $$;
+
+do $$
+begin
+  alter publication supabase_realtime add table public.options_strategy_capital_history;
+exception when duplicate_object then null; when undefined_object then null; end $$;


### PR DESCRIPTION
## Summary
- Implements Phase 4 capital-at-risk, capital history, time-weighted RoCaR, and margin snapshot schema.
- Adds strategy grouper CaR calculations, monthly RoCaR/margin aggregation, IB Gateway margin sync with synthetic fallback, and Flex AccountInformation margin support.
- Wires /options EfficiencyGauges live with RoCaR, margin utilization, stale/source states, tests, and E2E seed coverage.

Working as McManus (Data/Finance lead), with Hockney (Backend) and Fenster (Frontend) scopes.

Closes #249

## Validation
- ✅ `cd apps/backend && uv run pytest -x -q tests/` (314 passed)
- ✅ `uv run --project apps/backend ruff check apps/backend/`
- ✅ `cd apps/frontend && npm test -- --reporter=dot` (232 passed)
- ✅ changed frontend files: `npx eslint src/components/Options/efficiency-gauges.tsx src/app/options/actions.ts src/app/options/page.tsx e2e/options-dashboard.spec.ts e2e/fixtures/seed-data.ts`
- ✅ Supabase migration applied with MCP `apply_migration`; new tables verified RLS enabled with 4 policies each.
- ⚠️ `pnpm` unavailable in this environment; npm was used (repo has package-lock).
- ⚠️ Full `npm run lint` and `npx tsc --noEmit` still report pre-existing unrelated repo issues; changed files lint clean and `src/app/options/actions.ts` has no typecheck errors.
- ⚠️ Synthetic backfill command reaches DB but fails with existing Supabase password auth error, before worker logic runs.

## Jony worked example fields
- CaR example in tests: 50/45 put credit spread collecting $150 => $350 max loss.
- RoCaR example in tests: $10,000 CaR active Jan 16-31 with $1,000 P&L => avg CaR $5,161.290323; RoCaR 19.3750%.
- E2E gauge seed: margin used $5,000; available $15,000; utilization 33.33%; source synthetic.

## Switching synthetic → live
1. Start IB Gateway.
2. Confirm `IB_HOST`, `IB_PORT`, and `IB_CLIENT_ID` are set.
3. Set `OPTIONS_FLEX_SOURCE=live` plus Flex credentials when ready.
4. Run/schedule `options_margin_sync`; source pill should change from synthetic to live (IB Gateway).
