### PR TITLE
feat(options): multi-year backfill for 2021-2024 (closes #250)

### DIFF
--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -117,7 +117,7 @@ def run_flex_options_sync(
 
     accounts = _load_accounts(session, account_id=account_id)
     if not accounts:
-        return {"accounts": [], "trade_count": 0, "cash_event_count": 0, "position_count": 0}
+        return {"accounts": [], "trade_count": 0, "cash_event_count": 0, "position_count": 0, "leg_count": 0}
 
     paths = _select_flex_source(from_date=from_date, to_date=to_date, synthetic=synthetic)
     total_trades = 0
@@ -137,11 +137,13 @@ def run_flex_options_sync(
             total_cash += counts["cash_event_count"]
             total_positions += counts["position_count"]
             summaries.append({"account_id": parsed_account_id, **counts})
+    total_legs = sum(int(summary.get("leg_count", 0)) for summary in summaries)
     return {
         "accounts": summaries,
         "trade_count": total_trades,
         "cash_event_count": total_cash,
         "position_count": total_positions,
+        "leg_count": total_legs,
         "source_files": [str(path) for path in paths],
     }
 
@@ -190,8 +192,12 @@ def _select_flex_source(*, from_date: date | None, to_date: date | None, synthet
 
 
 def _synthetic_files() -> list[Path]:
+    expected_years = {"2021", "2022", "2023", "2024"}
     paths = sorted(SYNTHETIC_DIR.glob("synthetic_*.xml"))
-    if paths:
+    present_years = {
+        path.stem.removeprefix("synthetic_") for path in paths if path.stem.removeprefix("synthetic_").isdigit()
+    }
+    if paths and expected_years.issubset(present_years):
         return paths
     from scripts.flex_synthetic import write_synthetic_files
 
@@ -226,6 +232,7 @@ def _ingest_account(
     from_date: date | None,
     to_date: date | None,
 ) -> dict[str, int]:
+    parsed = _filter_result_by_dates(parsed, from_date, to_date)
     leg_ids: dict[OptionLegKey, str] = {}
     trades_to_insert = parsed.trades
     for trade in trades_to_insert:
@@ -255,7 +262,35 @@ def _ingest_account(
         "trade_count": len(trades_to_insert),
         "cash_event_count": len(parsed.cash_transactions),
         "position_count": len(parsed.open_positions),
+        "leg_count": len(leg_ids),
     }
+
+
+def _filter_result_by_dates(parsed: FlexParseResult, from_date: date | None, to_date: date | None) -> FlexParseResult:
+    """Keep parsed Flex rows whose business date falls inside the requested window."""
+
+    if from_date is None and to_date is None:
+        return parsed
+
+    def in_window(value: date | None) -> bool:
+        if value is None:
+            return True
+        if from_date and value < from_date:
+            return False
+        if to_date and value > to_date:
+            return False
+        return True
+
+    return FlexParseResult(
+        trades=[row for row in parsed.trades if in_window(row.trade_date)],
+        cash_transactions=[row for row in parsed.cash_transactions if in_window(row.event_date)],
+        open_positions=[row for row in parsed.open_positions if in_window(row.as_of_date)],
+        option_eae=[row for row in parsed.option_eae if in_window(row.trade_date)],
+        account_information=[
+            row for row in parsed.account_information if in_window(row.as_of.date() if row.as_of else None)
+        ],
+        section_counts=parsed.section_counts,
+    )
 
 
 def _upsert_leg(session: Session, household_id: str, leg: OptionLegKey) -> str:

--- a/apps/backend/scripts/backfill_options.py
+++ b/apps/backend/scripts/backfill_options.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import argparse
+from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import date
 from decimal import Decimal
 import os
 import sys
-from typing import Iterable
 
 from sqlmodel import Session
 
@@ -20,55 +21,161 @@ from app.worker.handlers.options_sync import run_flex_options_sync
 DEFAULT_FROM = date(2025, 1, 1)
 
 
+@dataclass(frozen=True)
+class BackfillWindow:
+    """Inclusive date window that stays within one calendar year."""
+
+    start: date
+    end: date
+
+    @property
+    def label(self) -> str:
+        """Return the progress label used in CLI logs."""
+
+        return str(self.start.year) if self.start.year == self.end.year else f"{self.start}:{self.end}"
+
+
 def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     """Parse backfill CLI flags."""
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--from", dest="from_date", type=date.fromisoformat, default=DEFAULT_FROM)
-    parser.add_argument("--to", dest="to_date", type=date.fromisoformat, default=date.today())
+    parser.add_argument("--start", dest="start_date", type=date.fromisoformat, help="Inclusive backfill start date")
+    parser.add_argument("--end", dest="end_date", type=date.fromisoformat, help="Inclusive backfill end date")
+    parser.add_argument(
+        "--from",
+        dest="from_date",
+        type=date.fromisoformat,
+        help="Backward-compatible alias for --start",
+    )
+    parser.add_argument(
+        "--to",
+        dest="to_date",
+        type=date.fromisoformat,
+        help="Backward-compatible alias for --end",
+    )
+    parser.add_argument("--year", type=int, help="Backfill one calendar year, e.g. --year 2021")
     parser.add_argument("--account", dest="account_id", help="Broker accountId; defaults to all enabled accounts")
     parser.add_argument("--synthetic", action="store_true", help="Read tmp/flex/synthetic_*.xml instead of live Flex")
+    parser.add_argument("--dry-run", action="store_true", help="Run parsing/workers and roll back database writes")
     return parser.parse_args(argv)
+
+
+def yearly_windows(start: date, end: date) -> list[BackfillWindow]:
+    """Split an inclusive date range into calendar-year windows."""
+
+    if start > end:
+        raise ValueError("start date must be on or before end date")
+    windows: list[BackfillWindow] = []
+    year = start.year
+    while year <= end.year:
+        window_start = max(start, date(year, 1, 1))
+        window_end = min(end, date(year, 12, 31))
+        windows.append(BackfillWindow(window_start, window_end))
+        year += 1
+    return windows
+
+
+def requested_range(args: argparse.Namespace) -> tuple[date, date]:
+    """Resolve CLI date flags into one inclusive range."""
+
+    if args.year is not None:
+        if args.start_date or args.end_date or args.from_date or args.to_date:
+            raise ValueError("--year cannot be combined with --start/--end/--from/--to")
+        return date(args.year, 1, 1), date(args.year, 12, 31)
+    start = args.start_date or args.from_date or DEFAULT_FROM
+    end = args.end_date or args.to_date or date.today()
+    if start > end:
+        raise ValueError("--start/--from must be on or before --end/--to")
+    return start, end
 
 
 def main(argv: Iterable[str] | None = None) -> int:
     """Run a synchronous Flex options backfill and print reconciliation totals."""
 
     args = parse_args(argv)
+    try:
+        start, end = requested_range(args)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
     if args.synthetic:
         os.environ["OPTIONS_FLEX_SOURCE"] = "synthetic"
-    print(f"Backfilling options income from {args.from_date} to {args.to_date}")
-    with Session(engine) as session:
-        sync_result = run_flex_options_sync(
-            session,
-            from_date=args.from_date,
-            to_date=args.to_date,
-            account_id=args.account_id,
-            synthetic=args.synthetic,
+
+    windows = yearly_windows(start, end)
+    print(
+        f"Backfilling options income from {start} to {end} "
+        f"in {len(windows)} yearly chunk(s){' (dry run)' if args.dry_run else ''}"
+    )
+    combined_sync: dict[str, int] = {"trade_count": 0, "cash_event_count": 0, "position_count": 0, "leg_count": 0}
+    last_metrics: dict[str, object] = {"accounts": [], "row_count": 0}
+    for window in windows:
+        with Session(engine) as session:
+            sync_result = run_flex_options_sync(
+                session,
+                from_date=window.start,
+                to_date=window.end,
+                account_id=args.account_id,
+                synthetic=args.synthetic,
+            )
+            grouping_result = compute_options_strategy_groups(
+                session,
+                account_id=args.account_id,
+                from_date=window.start,
+                to_date=window.end,
+            )
+            margin_result = run_options_margin_sync(session, account_id=args.account_id)
+            metrics_result = compute_options_monthly_metrics(
+                session,
+                account_id=args.account_id,
+                from_date=window.start,
+                to_date=window.end,
+            )
+            if args.dry_run:
+                session.rollback()
+            else:
+                session.commit()
+        for key in combined_sync:
+            combined_sync[key] += int(sync_result.get(key, 0))
+        last_metrics = metrics_result
+        parsed = (
+            int(sync_result.get("trade_count", 0))
+            + int(sync_result.get("cash_event_count", 0))
+            + int(sync_result.get("position_count", 0))
         )
-        grouping_result = compute_options_strategy_groups(
-            session,
-            account_id=args.account_id,
-            from_date=args.from_date,
-            to_date=args.to_date,
+        print(
+            f"[backfill {window.label}] parsed={parsed}, "
+            f"upserted_legs={int(sync_result.get('leg_count', 0))}, "
+            f"groups={int(grouping_result.get('group_count', 0))}, "
+            f"monthly_rows={int(metrics_result.get('row_count', 0))}"
         )
-        margin_result = run_options_margin_sync(session, account_id=args.account_id)
-        metrics_result = compute_options_monthly_metrics(
-            session,
-            account_id=args.account_id,
-            from_date=args.from_date,
-            to_date=args.to_date,
+        if margin_result.get("status") != "succeeded":
+            print(f"[backfill {window.label}] margin={margin_result}")
+
+    if len(windows) > 1 and not args.dry_run:
+        with Session(engine) as session:
+            final_grouping = compute_options_strategy_groups(
+                session,
+                account_id=args.account_id,
+                from_date=start,
+                to_date=end,
+            )
+            last_metrics = compute_options_monthly_metrics(
+                session,
+                account_id=args.account_id,
+                from_date=start,
+                to_date=end,
+            )
+            session.commit()
+        print(
+            f"[backfill final] groups={int(final_grouping.get('group_count', 0))}, "
+            f"monthly_rows={int(last_metrics.get('row_count', 0))}"
         )
-        session.commit()
-    print("Flex sync:", sync_result)
-    print("Strategy grouping:", grouping_result)
-    print("Margin sync:", margin_result)
-    print("Monthly metrics:", metrics_result)
-    totals = _totals(metrics_result)
+
+    totals = _totals(last_metrics)
     print(
         "Reconciliation summary: "
-        f"accounts={totals['account_count']} trades={sync_result.get('trade_count', 0)} "
-        f"cash_events={sync_result.get('cash_event_count', 0)} "
+        f"accounts={totals['account_count']} trades={combined_sync['trade_count']} "
+        f"cash_events={combined_sync['cash_event_count']} "
         f"cash_flow={totals['cash_flow']} realized_pnl={totals['realized_pnl']} "
         f"variance_gap={totals['variance_gap']}"
     )

--- a/apps/backend/scripts/flex_synthetic.py
+++ b/apps/backend/scripts/flex_synthetic.py
@@ -29,7 +29,7 @@ def base_attrs(trade_id: str, transaction_id: str) -> dict[str, str]:
     }
 
 
-def flex_root(statement_name: str) -> Element:
+def flex_root(statement_name: str, *, from_date: str = "2025-01-01", to_date: str = "2025-12-31") -> Element:
     """Create the shared Flex response/statement envelope."""
     root = Element("FlexQueryResponse", {"queryName": statement_name})
     statements = SubElement(root, "FlexStatements", {"count": "1"})
@@ -38,8 +38,8 @@ def flex_root(statement_name: str) -> Element:
         "FlexStatement",
         {
             "accountId": ACCOUNT_ID,
-            "fromDate": "2025-01-01",
-            "toDate": "2025-12-31",
+            "fromDate": from_date,
+            "toDate": to_date,
             "period": "YearToDate",
         },
     )
@@ -587,6 +587,42 @@ def write_option_eae(path: Path) -> None:
     write_xml(path, root)
 
 
+def write_multiyear_smoke(path: Path, *, year: int, underlying_symbol: str) -> None:
+    """Write one distinct option trade for a historical smoke-test year."""
+
+    root = flex_root(
+        f"synthetic_{year}_smoke",
+        from_date=f"{year}-01-01",
+        to_date=f"{year}-12-31",
+    )
+    section = SubElement(statement(root), "TradeConfirms")
+    SubElement(
+        section,
+        "TradeConfirm",
+        option_trade(
+            trade_id=f"T-SMOKE-{year}-001",
+            transaction_id=f"X-SMOKE-{year}-001",
+            scenario=f"multiyear_smoke_{year}",
+            date_time=f"{year}-06-15;100000",
+            symbol=f"{underlying_symbol:<6}{str(year + 1)[2:]}0117P00100000",
+            underlying_symbol=underlying_symbol,
+            put_call="P",
+            strike="100",
+            expiry=f"{year + 1}0117",
+            quantity="-1",
+            trade_price="1.00",
+            proceeds="100",
+            commission="0",
+            net_cash="100",
+            fifo_pnl_realized="0",
+            buy_sell="SELL",
+            open_close_indicator="O",
+            notes="Minimal historical smoke-test trade for chunked backfills",
+        ),
+    )
+    write_xml(path, root)
+
+
 def write_account_info(path: Path) -> None:
     """Write synthetic AccountInformation rows."""
     root = flex_root("synthetic_account_info")
@@ -613,12 +649,26 @@ def write_account_info(path: Path) -> None:
 def write_synthetic_files(output_dir: Path = DEFAULT_OUTPUT_DIR) -> list[Path]:
     """Write all synthetic Flex fixtures and return their paths."""
     output_dir.mkdir(parents=True, exist_ok=True)
+    yearly_underlyings = {
+        2021: "IBM",
+        2022: "INTC",
+        2023: "AMD",
+        2024: "QQQ",
+    }
     writers = {
         "synthetic_trades.xml": write_trades,
         "synthetic_cash.xml": write_cash,
         "synthetic_positions.xml": write_positions,
         "synthetic_option_eae.xml": write_option_eae,
         "synthetic_account_info.xml": write_account_info,
+        **{
+            f"synthetic_{year}.xml": (
+                lambda path, year=year, underlying=underlying: write_multiyear_smoke(
+                    path, year=year, underlying_symbol=underlying
+                )
+            )
+            for year, underlying in yearly_underlyings.items()
+        },
     }
     paths: list[Path] = []
     for filename, writer in writers.items():

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -19,7 +19,7 @@ def test_parse_synthetic_flex_rows_into_typed_models() -> None:
     try:
         paths = write_synthetic_files(output_dir)
         parsed = parse_flex_files(paths)
-        assert len(parsed.trades) == 14
+        assert len(parsed.trades) == 18
         first = parsed.trades[0]
         assert first.account_id == "U1234567"
         assert first.leg.underlying_symbol == "SPY"

--- a/apps/backend/tests/test_backfill_options.py
+++ b/apps/backend/tests/test_backfill_options.py
@@ -1,0 +1,221 @@
+"""Tests for chunked options backfill CLI behavior."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from scripts import backfill_options
+from app.worker.handlers.options_sync import run_flex_options_sync
+
+HOUSEHOLD_ID = "10000000-0000-0000-0000-000000000001"
+ACCOUNT_ID = "U1234567"
+
+
+class FakeScalar:
+    """Scalar wrapper for generated IDs."""
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def scalar_one(self) -> str:
+        """Return the fake scalar value."""
+
+        return self.value
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return no mappings for scalar statements."""
+
+        return []
+
+
+class FakeMappings:
+    """Mappings wrapper for fake SELECT statements."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class InMemoryOptionsSession:
+    """Small in-memory session that models the worker's upsert semantics."""
+
+    def __init__(self) -> None:
+        self.legs: dict[tuple[Any, ...], str] = {}
+        self.trades: dict[tuple[Any, ...], dict[str, Any]] = {}
+        self.cash_events: dict[tuple[Any, ...], dict[str, Any]] = {}
+        self.positions: list[dict[str, Any]] = []
+        self.sync_states = 0
+        self.commits = 0
+        self.rollbacks = 0
+
+    def __enter__(self) -> InMemoryOptionsSession:
+        """Return this fake session as a context manager."""
+
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        """No-op context manager exit."""
+
+    def commit(self) -> None:
+        """Record a commit."""
+
+        self.commits += 1
+
+    def rollback(self) -> None:
+        """Record a rollback."""
+
+        self.rollbacks += 1
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeScalar | FakeMappings:
+        """Record writes and return deterministic rows for worker SELECTs."""
+
+        sql = str(statement)
+        params = params or {}
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "id": 1,
+                        "household_id": HOUSEHOLD_ID,
+                        "account_id": ACCOUNT_ID,
+                        "name": "IBKR Synthetic",
+                    }
+                ]
+            )
+        if "insert into public.options_legs" in sql:
+            key = (
+                params["household_id"],
+                params["account_id"],
+                params["underlying_symbol"],
+                params["expiry"],
+                params["strike"],
+                params["right"],
+                params["multiplier"],
+                params["currency"],
+            )
+            self.legs.setdefault(key, f"leg-{len(self.legs) + 1}")
+            return FakeScalar(self.legs[key])
+        if "insert into public.options_trades" in sql:
+            key = (
+                params["household_id"],
+                "ibkr_flex",
+                params["source_trade_id"],
+                params["source_transaction_id"],
+                params.get("source_exec_id"),
+            )
+            self.trades[key] = dict(params)
+        elif "insert into public.options_cash_events" in sql:
+            key = (params["household_id"], "ibkr_flex", params["source_transaction_id"])
+            self.cash_events[key] = dict(params)
+        elif "delete from public.options_positions" in sql:
+            self.positions = [
+                row
+                for row in self.positions
+                if not (
+                    row["household_id"] == params["household_id"]
+                    and row["account_id"] == params["account_id"]
+                    and row["as_of_date"] == params["as_of_date"]
+                )
+            ]
+        elif "insert into public.options_positions" in sql:
+            self.positions.append(dict(params))
+        elif "insert into public.options_flex_sync_state" in sql:
+            self.sync_states += 1
+        return FakeMappings([])
+
+
+def test_yearly_windows_split_2021_to_2024() -> None:
+    """The 2021-2024 backfill range is split into four IBKR-safe yearly chunks."""
+
+    windows = backfill_options.yearly_windows(date(2021, 1, 1), date(2024, 12, 31))
+    assert [(window.start, window.end) for window in windows] == [
+        (date(2021, 1, 1), date(2021, 12, 31)),
+        (date(2022, 1, 1), date(2022, 12, 31)),
+        (date(2023, 1, 1), date(2023, 12, 31)),
+        (date(2024, 1, 1), date(2024, 12, 31)),
+    ]
+
+
+def test_multiyear_backfill_ingests_one_synthetic_trade_per_year(monkeypatch, capsys) -> None:  # type: ignore[no-untyped-def]
+    """Chunked backfill processes each synthetic historical year once and commits each chunk."""
+
+    session = InMemoryOptionsSession()
+    monkeypatch.setattr(backfill_options, "Session", lambda _engine: session)
+    monkeypatch.setattr(backfill_options, "compute_options_strategy_groups", lambda *args, **kwargs: {"group_count": 0})
+    monkeypatch.setattr(backfill_options, "run_options_margin_sync", lambda *args, **kwargs: {"status": "succeeded"})
+    monkeypatch.setattr(
+        backfill_options,
+        "compute_options_monthly_metrics",
+        lambda *args, **kwargs: {
+            "row_count": 1,
+            "accounts": [
+                {
+                    "cash_flow_total": "100",
+                    "realized_pnl_total": "0",
+                    "variance_gap_cumulative": "100",
+                }
+            ],
+        },
+    )
+
+    exit_code = backfill_options.main(
+        ["--synthetic", "--start", "2021-01-01", "--end", "2024-12-31", "--account", ACCOUNT_ID]
+    )
+
+    assert exit_code == 0
+    assert session.commits == 5
+    trades_by_year: dict[int, int] = {}
+    for trade in session.trades.values():
+        trade_year = trade["trade_date"].year
+        trades_by_year[trade_year] = trades_by_year.get(trade_year, 0) + 1
+    assert trades_by_year == {2021: 1, 2022: 1, 2023: 1, 2024: 1}
+    assert sum(Decimal(str(row["net_cash_flow"])) for row in session.trades.values()) == Decimal("400.000000")
+    output = capsys.readouterr().out
+    assert "[backfill 2021] parsed=1" in output
+    assert "[backfill 2024] parsed=1" in output
+
+
+def test_dry_run_rolls_back_each_chunk(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Dry-run mode executes the pipeline but rolls back instead of committing."""
+
+    session = InMemoryOptionsSession()
+    monkeypatch.setattr(backfill_options, "Session", lambda _engine: session)
+    monkeypatch.setattr(backfill_options, "compute_options_strategy_groups", lambda *args, **kwargs: {"group_count": 0})
+    monkeypatch.setattr(backfill_options, "run_options_margin_sync", lambda *args, **kwargs: {"status": "succeeded"})
+    monkeypatch.setattr(backfill_options, "compute_options_monthly_metrics", lambda *args, **kwargs: {"row_count": 0})
+
+    assert backfill_options.main(["--synthetic", "--year", "2021", "--dry-run", "--account", ACCOUNT_ID]) == 0
+    assert session.commits == 0
+    assert session.rollbacks == 1
+
+
+def test_same_window_backfill_is_idempotent(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Re-running the same synthetic window does not duplicate trades or legs."""
+
+    monkeypatch.setenv("OPTIONS_FLEX_SOURCE", "synthetic")
+    session = InMemoryOptionsSession()
+    first = run_flex_options_sync(
+        session,  # type: ignore[arg-type]
+        from_date=date(2021, 1, 1),
+        to_date=date(2021, 12, 31),
+        account_id=ACCOUNT_ID,
+        synthetic=True,
+    )
+    second = run_flex_options_sync(
+        session,  # type: ignore[arg-type]
+        from_date=date(2021, 1, 1),
+        to_date=date(2021, 12, 31),
+        account_id=ACCOUNT_ID,
+        synthetic=True,
+    )
+
+    assert first["trade_count"] == 1
+    assert second["trade_count"] == 1
+    assert len(session.trades) == 1
+    assert len(session.legs) == 1

--- a/apps/backend/tests/test_flex_synthetic.py
+++ b/apps/backend/tests/test_flex_synthetic.py
@@ -21,6 +21,7 @@ def test_jony_worked_example_totals() -> None:
         jony = summary["scenario_summaries"]["jony_worked_example"]
         assert Decimal(jony["cash_flow"]) == Decimal("2700.00")
         assert Decimal(jony["fifoPnlRealized"]) == Decimal("1000.00")
+        assert {f"multiyear_smoke_{year}" for year in range(2021, 2025)}.issubset(summary["scenario_summaries"])
     finally:
         if output_dir.exists():
             shutil.rmtree(output_dir)

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -88,12 +88,11 @@ def test_run_flex_options_sync_ingests_synthetic_source(monkeypatch) -> None:  #
     monkeypatch.setenv("OPTIONS_FLEX_SOURCE", "synthetic")
     session = FakeSession()
     result = run_flex_options_sync(session)  # type: ignore[arg-type]
-    assert result["trade_count"] == 14
+    assert result["trade_count"] == 18
     assert result["cash_event_count"] == 2
     assert result["position_count"] == 1
-    assert len(session.trades) == 14
-    assert (
-        session.trades[2]["realized_pnl"] == "-1000.000000" or str(session.trades[2]["realized_pnl"]) == "-1000.000000"
-    )
+    assert len(session.trades) == 18
+    losing_roll = next(row for row in session.trades if row["source_trade_id"] == "T-JONY-003")
+    assert losing_roll["realized_pnl"] == "-1000.000000" or str(losing_roll["realized_pnl"]) == "-1000.000000"
     assert len(session.legs) >= 1
     assert session.sync_states == 1

--- a/docs/options-flex-query-setup.md
+++ b/docs/options-flex-query-setup.md
@@ -164,12 +164,30 @@ uv run python scripts/flex_probe.py --account U1234567 --from 2025-01-01 --to 20
 
 The probe writes raw XML to `apps/backend/tmp/flex/` and prints one Python dict summary. Confirm that `row_counts` includes `TradeConfirms`, `CashTransactions`, `OpenPositions`, `OptionEAE`, and `AccountInformation`, then compare one known rolled spread against the broker statement to the cent.
 
-## 6. Troubleshooting
+## 6. Multi-year Backfill
+
+After issue #245 is complete and the Flex Web Service token/query IDs are configured, backfill historical dashboard facts one account at a time. The backfill command chunks the requested range into calendar-year windows because IBKR Flex requests are typically capped at roughly 365 days.
+
+```bash
+cd apps/backend
+set -a && source .env && set +a
+uv run python scripts/backfill_options.py --start 2021-01-01 --end 2024-12-31 --account U1234567
+```
+
+Use `--year 2021` for a single calendar-year retry, and `--dry-run` to parse/run the worker chain while rolling back database writes:
+
+```bash
+uv run python scripts/backfill_options.py --year 2021 --account U1234567 --dry-run
+```
+
+Synthetic fixtures cover 2021-2025 for smoke testing only: 2021-2024 include one distinct trade per year to exercise chunking, and the existing 2025 worked example remains the richer reconciliation fixture. Real historical data still requires Jony to complete the IBKR.com Flex Query setup in issue #245.
+
+## 7. Troubleshooting
 
 - **No token configured:** `flex_probe.py` intentionally falls back to synthetic fixtures so Phase 1 can continue in parallel.
 - **Token expired or revoked:** generate a new token in Flex Web Service Configuration and update `apps/backend/.env` or GitHub secrets.
 - **IP not whitelisted:** add the worker's current public IP in IBKR's Flex Web Service Configuration, or temporarily disable IP restriction if acceptable.
 - **Query ID typo:** re-copy the Query ID from the Flex Queries page and verify it is in the matching `IBKR_FLEX_QUERY_ID_*` variable.
 - **1019 Statement generation in progress:** the probe polls `GetStatement`; if it times out, retry with a smaller date range or increase `--max-polls`.
-- **365-day range failure:** split the date range into multiple runs.
+- **365-day range failure:** rerun the command with `--year YYYY`, or use a narrower `--start/--end` range for the affected year.
 - **Missing fields:** edit the Flex Query and tick every field in Appendix A; rerun the probe and inspect `tmp/flex/*.xml`.

--- a/docs/options-income-dashboard-design.md
+++ b/docs/options-income-dashboard-design.md
@@ -850,6 +850,13 @@ Acceptance criteria:
 - RLS verified for household reads.
 - Worker can retry and produce useful errors.
 
+Backfill flow:
+
+- `scripts/backfill_options.py` accepts `--start YYYY-MM-DD --end YYYY-MM-DD` and `--year YYYY`, then splits the range into inclusive calendar-year chunks to stay within IBKR's typical 365-day Flex limit.
+- Each chunk runs Flex ingestion, strategy grouping/roll detection, margin snapshot sync, and monthly metrics aggregation in order; after a multi-year write run, the CLI refreshes strategy grouping and monthly metrics once more for the full requested range so roll links and cumulative series can span year boundaries. Reruns are idempotent because source IDs and natural option-leg keys use existing upsert constraints.
+- `--dry-run` executes the same chain and rolls back the chunk transaction so operators can inspect counts before writing.
+- Synthetic fixtures cover 2021-2025 for smoke testing: 2021-2024 have one distinct trade per year for chunk verification, while the existing 2025 worked example remains unchanged for reconciliation. Real historical data requires IBKR Flex tokens/query IDs from issue #245.
+
 ### Phase 2 — Roll detection + StrategyGroup linkage + base metrics
 
 Goal: turn trades into income-quality analytics.


### PR DESCRIPTION
## Summary
- Adds calendar-year chunking to `scripts/backfill_options.py` with `--start/--end`, `--year`, and `--dry-run` support.
- Filters parsed Flex rows to each requested window, reports structured per-chunk progress, and does a final full-range strategy/metrics refresh so roll links and cumulative monthly metrics can span year boundaries.
- Extends synthetic Flex fixtures with one distinct smoke-test trade for each year 2021-2024 while leaving the 2025 worked example intact.

Working as Hockney (Backend Dev).

Closes #250

## Chunking strategy
IBKR Flex requests are treated as calendar-year windows. A request such as `--start 2021-01-01 --end 2024-12-31` runs four chunks sequentially: 2021, 2022, 2023, and 2024. Each chunk runs Flex sync, strategy grouping/roll detection, margin sync, and monthly metrics. Write runs then do one final full-range grouping + monthly metrics refresh for cross-year rolls/cumulative series. `--dry-run` executes the same chunk pipeline and rolls back each chunk transaction.

## Synthetic test coverage
Synthetic fixtures now cover 2021-2025:
- 2021: IBM smoke trade
- 2022: INTC smoke trade
- 2023: AMD smoke trade
- 2024: QQQ smoke trade
- 2025: existing Jony worked-example fixture unchanged

Added tests for chunk generation, multi-year synthetic backfill row counts/totals, dry-run rollback, and idempotent same-window reruns.

## Live data dependency on #245
Live execution remains gated on Jony completing issue #245 (IBKR.com Flex Query setup). Once token/query IDs are configured in `apps/backend/.env`, run per account:

```bash
cd apps/backend
set -a && source .env && set +a
uv run python scripts/backfill_options.py --start 2021-01-01 --end 2024-12-31 --account U1234567
```

For a single-year retry:

```bash
uv run python scripts/backfill_options.py --year 2021 --account U1234567
```

For a safety pass before writing:

```bash
uv run python scripts/backfill_options.py --year 2021 --account U1234567 --dry-run
```

Expected synthetic smoke progress shape:

```text
Backfilling options income from 2021-01-01 to 2024-12-31 in 4 yearly chunk(s)
[backfill 2021] parsed=1, upserted_legs=1, groups=0, monthly_rows=1
[backfill 2022] parsed=1, upserted_legs=1, groups=0, monthly_rows=1
[backfill 2023] parsed=1, upserted_legs=1, groups=0, monthly_rows=1
[backfill 2024] parsed=1, upserted_legs=1, groups=0, monthly_rows=1
[backfill final] groups=0, monthly_rows=4
```

## Validation
- `uv run --project apps/backend ruff check apps/backend/`
- `uv run --project apps/backend pytest -q apps/backend/tests` (318 passed, 26 warnings)
- Targeted synthetic tests: `uv run --project apps/backend pytest -q apps/backend/tests/test_backfill_options.py apps/backend/tests/test_flex_synthetic.py apps/backend/tests/services/options/test_flex_parser.py apps/backend/tests/worker/test_options_sync.py`

Note: a direct local CLI dry-run against the configured database still depends on valid local database credentials; the code path is covered by the synthetic integration tests above.