### PR TITLE
fix(options): drop trading_account_config.name from worker SQL + schema drift audit

### DIFF
--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -42,7 +42,6 @@ class OptionsAccount:
     household_id: str
     account_id: str | None
     config_id: int | None = None
-    name: str | None = None
 
 
 def _default_session_factory() -> AbstractContextManager[Session]:
@@ -157,7 +156,7 @@ def _load_accounts(session: Session, *, account_id: str | None) -> list[OptionsA
     rows = session.execute(
         text(
             f"""
-            select id, household_id::text as household_id, account_id, name
+            select id, household_id::text as household_id, account_id
               from public.trading_account_config
              where {" and ".join(filters)}
              order by id
@@ -170,7 +169,6 @@ def _load_accounts(session: Session, *, account_id: str | None) -> list[OptionsA
             household_id=str(row["household_id"]),
             account_id=str(row["account_id"]) if row["account_id"] else None,
             config_id=int(row["id"]),
-            name=str(row["name"]),
         )
         for row in rows
         if row["household_id"]

--- a/apps/backend/tests/worker/test_options_margin_sync.py
+++ b/apps/backend/tests/worker/test_options_margin_sync.py
@@ -49,13 +49,13 @@ class FakeSession:
         sql = str(statement)
         params = params or {}
         if "from public.trading_account_config" in sql:
+            assert "name" not in sql
             return FakeMappings(
                 [
                     {
                         "id": 1,
                         "household_id": "10000000-0000-0000-0000-000000000001",
                         "account_id": "U123",
-                        "name": "IBKR",
                     }
                 ]
             )

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from app.worker.handlers.options_sync import run_flex_options_sync
+from app.worker.handlers.options_sync import _load_accounts, run_flex_options_sync
 
 
 class FakeScalar:
@@ -51,13 +51,13 @@ class FakeSession:
         sql = str(statement)
         params = params or {}
         if "from public.trading_account_config" in sql:
+            assert "name" not in sql
             return FakeMappings(
                 [
                     {
                         "id": 1,
                         "household_id": "10000000-0000-0000-0000-000000000001",
                         "account_id": "U1234567",
-                        "name": "IBKR Synthetic",
                     }
                 ]
             )
@@ -80,6 +80,16 @@ class FakeSession:
         elif "insert into public.options_flex_sync_state" in sql:
             self.sync_states += 1
         return FakeMappings([])
+
+
+def test_load_accounts_matches_trading_account_config_schema() -> None:
+    """Account loading must not select fields absent from trading_account_config."""
+
+    accounts = _load_accounts(FakeSession(), account_id="U1234567")  # type: ignore[arg-type]
+
+    assert len(accounts) == 1
+    assert accounts[0].account_id == "U1234567"
+    assert accounts[0].config_id == 1
 
 
 def test_run_flex_options_sync_ingests_synthetic_source(monkeypatch) -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- drop the nonexistent trading_account_config.name column from options account loading
- simplify OptionsAccount because the name field was unused downstream
- audited worker SQL against live Supabase information_schema for trading_account_config and options_* tables; no additional schema drift found
- add regression coverage so account loading fails if it reintroduces the missing name column

Unblocks live backfill for Jony's account `U2515365`.

## Validation
- `cd apps/backend && uv run pytest -q tests` (319 passed)
- `cd apps/backend && uv run ruff check app tests`

Working as Hockney (Backend Dev).