### PR TITLE
fix(options): import Flex probe from backfill runner

### DIFF
--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -179,7 +179,12 @@ def _select_flex_source(*, from_date: date | None, to_date: date | None, synthet
     source = os.getenv("OPTIONS_FLEX_SOURCE", "synthetic").lower()
     if synthetic is True or source == "synthetic" or not os.getenv("IBKR_FLEX_TOKEN"):
         return _synthetic_files()
-    from scripts.flex_probe import fetch_live_xml, parse_args, query_configs_from_env
+    try:
+        from scripts.flex_probe import fetch_live_xml, parse_args, query_configs_from_env
+    except ModuleNotFoundError as exc:
+        if exc.name != "scripts":
+            raise
+        from flex_probe import fetch_live_xml, parse_args, query_configs_from_env
 
     args = parse_args([])
     args.from_date = from_date

--- a/apps/backend/tests/test_backfill_options.py
+++ b/apps/backend/tests/test_backfill_options.py
@@ -84,7 +84,6 @@ class InMemoryOptionsSession:
                         "id": 1,
                         "household_id": HOUSEHOLD_ID,
                         "account_id": ACCOUNT_ID,
-                        "name": "IBKR Synthetic",
                     }
                 ]
             )


### PR DESCRIPTION
## Summary
- make live Flex source loading work when backfill_options.py is executed as a script
- keep the existing worker import path for scheduled/container execution and fall back to the script-local module path
- remove stale account name fixture data from the backfill tests after the schema-drift fix

## Validation
- `cd apps/backend && uv run pytest -q tests` (319 passed)
- `cd apps/backend && uv run ruff check app tests`

Working as Hockney (Backend Dev).