### PR TITLE
fix(options): parse live Flex trade rows

### DIFF
--- a/apps/backend/app/services/options/flex_parser.py
+++ b/apps/backend/app/services/options/flex_parser.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 SECTION_ROW_NAMES = {
     "TradeConfirms": "TradeConfirm",
+    "Trades": "Trade",
     "CashTransactions": "CashTransaction",
     "OpenPositions": "OpenPosition",
     "OptionEAE": "OptionEAE",
@@ -140,14 +141,17 @@ def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> Fl
             if account_id and attrs.get("accountId") != account_id:
                 continue
             counts[section_name] = counts.get(section_name, 0) + 1
-            if section_name == "TradeConfirms":
-                trades.append(parse_trade_confirm(attrs, statement_dates[1]))
+            if section_name in {"TradeConfirms", "Trades"}:
+                if _is_option_contract_row(attrs):
+                    trades.append(parse_trade_confirm(attrs, statement_dates[1]))
             elif section_name == "CashTransactions":
                 cash.append(parse_cash_transaction(attrs))
             elif section_name == "OpenPositions":
-                positions.append(parse_open_position(attrs, statement_dates[1]))
+                if _is_option_contract_row(attrs):
+                    positions.append(parse_open_position(attrs, statement_dates[1]))
             elif section_name == "OptionEAE":
-                eae_rows.append(parse_option_eae(attrs, statement_dates[1]))
+                if _is_option_contract_row(attrs):
+                    eae_rows.append(parse_option_eae(attrs, statement_dates[1]))
             elif section_name == "AccountInformation":
                 account_info.append(parse_account_information(attrs))
     return FlexParseResult(
@@ -245,8 +249,8 @@ def parse_open_position(attrs: dict[str, str], fallback_date: date | None = None
         as_of_date=sync_time.date(),
         opened_at=sync_time,
         quantity_open=_first_decimal(attrs, ("position", "quantity")),
-        average_open_price=_first_decimal(attrs, ("costPrice", "avgCost")),
-        open_cash_flow=_first_decimal(attrs, ("costBasis", "openCashFlow")),
+        average_open_price=_first_decimal(attrs, ("costPrice", "avgCost", "costBasisPrice")),
+        open_cash_flow=_first_decimal(attrs, ("costBasis", "openCashFlow", "costBasisMoney")),
         ib_margin_requirement=_optional_decimal(attrs, "marginRequirement"),
         last_broker_sync_at=sync_time,
         raw_payload=attrs,
@@ -284,6 +288,12 @@ def _statement_dates(root: Element) -> tuple[date | None, date | None]:
     if statement is None:
         return None, None
     return _parse_date_value(statement.attrib.get("fromDate")), _parse_date_value(statement.attrib.get("toDate"))
+
+
+def _is_option_contract_row(attrs: dict[str, str]) -> bool:
+    if attrs.get("assetCategory") == "OPT":
+        return True
+    return all(_optional_text(attrs.get(name)) for name in ("expiry", "strike", "putCall"))
 
 
 def _leg_from_attrs(attrs: dict[str, str]) -> OptionLegKey:

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -6,7 +6,7 @@ import shutil
 from decimal import Decimal
 from pathlib import Path
 
-from app.services.options.flex_parser import parse_flex_files
+from app.services.options.flex_parser import parse_flex_files, parse_open_position, parse_trade_confirm
 from scripts.flex_synthetic import write_synthetic_files
 
 
@@ -33,3 +33,55 @@ def test_parse_synthetic_flex_rows_into_typed_models() -> None:
     finally:
         if output_dir.exists():
             shutil.rmtree(output_dir)
+
+
+def test_parse_live_flex_trade_and_open_position_aliases() -> None:
+    """Live Activity Flex rows use Trade tags and cost-basis aliases."""
+
+    trade = parse_trade_confirm(
+        {
+            "accountId": "U1234567",
+            "assetCategory": "OPT",
+            "conid": "123456789",
+            "currency": "USD",
+            "dateTime": "20260504;153000",
+            "expiry": "20260619",
+            "fifoPnlRealized": "12.34",
+            "ibCommission": "-1.05",
+            "ibExecID": "exec-1",
+            "multiplier": "100",
+            "netCash": "198.95",
+            "proceeds": "200.00",
+            "putCall": "P",
+            "quantity": "-1",
+            "strike": "450",
+            "symbol": "SPY",
+            "tradeID": "trade-1",
+            "tradePrice": "2.00",
+            "underlyingSymbol": "SPY",
+        }
+    )
+    position = parse_open_position(
+        {
+            "accountId": "U1234567",
+            "assetCategory": "OPT",
+            "conid": "123456789",
+            "costBasisMoney": "-198.95",
+            "costBasisPrice": "1.9895",
+            "currency": "USD",
+            "expiry": "20260619",
+            "multiplier": "100",
+            "openDateTime": "20260504;153000",
+            "position": "-1",
+            "putCall": "P",
+            "strike": "450",
+            "symbol": "SPY",
+            "underlyingSymbol": "SPY",
+        }
+    )
+
+    assert trade.source_trade_id == "trade-1"
+    assert trade.side == "sell"
+    assert trade.leg.expiry.isoformat() == "2026-06-19"
+    assert position.average_open_price == Decimal("1.9895")
+    assert position.open_cash_flow == Decimal("-198.95")


### PR DESCRIPTION
## Summary
- support live Activity Flex `Trades/Trade` rows in addition to synthetic `TradeConfirms/TradeConfirm` rows
- skip non-option trade/position rows before normalizing option legs
- accept live OpenPosition cost-basis aliases
- add regression coverage for live-style option trade and open-position rows

This unblocks the cached live Flex file for Jony's account after IBKR returned persistent 1001 throttling for a fresh request.

## Validation
- `cd apps/backend && uv run python - <<'PY' ... parse_flex_files([tmp/flex/trades_20260504T160341Z.xml], 'U2515365') ... PY` => 994 trades, 1308 cash, 34 option positions, 27 raw OptionEAE rows
- `cd apps/backend && uv run pytest -q tests` (320 passed)
- `cd apps/backend && uv run ruff check app tests`

Working as Hockney (Backend Dev).