### PR TITLE
fix(options): tolerate duplicate Flex conids

### DIFF
--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -297,6 +297,7 @@ def _filter_result_by_dates(parsed: FlexParseResult, from_date: date | None, to_
 
 
 def _upsert_leg(session: Session, household_id: str, leg: OptionLegKey) -> str:
+    source_conid = _source_conid_for_insert(session, household_id, leg)
     row = session.execute(
         text(
             """
@@ -318,7 +319,7 @@ def _upsert_leg(session: Session, household_id: str, leg: OptionLegKey) -> str:
         {
             "household_id": household_id,
             "account_id": leg.account_id,
-            "source_conid": leg.source_conid,
+            "source_conid": source_conid,
             "underlying_symbol": leg.underlying_symbol,
             "option_symbol": leg.option_symbol,
             "expiry": leg.expiry,
@@ -330,6 +331,43 @@ def _upsert_leg(session: Session, household_id: str, leg: OptionLegKey) -> str:
         },
     ).scalar_one()
     return str(row)
+
+
+def _source_conid_for_insert(session: Session, household_id: str, leg: OptionLegKey) -> int | None:
+    if leg.source_conid is None:
+        return None
+    conflicting_leg_id = session.execute(
+        text(
+            """
+            select id::text
+              from public.options_legs
+             where household_id = :household_id
+               and account_id = :account_id
+               and source_conid = :source_conid
+               and not (
+                 underlying_symbol = :underlying_symbol
+                 and expiry = :expiry
+                 and strike = :strike
+                 and "right" = :right
+                 and multiplier = :multiplier
+                 and currency = :currency
+               )
+             limit 1
+            """
+        ),
+        {
+            "household_id": household_id,
+            "account_id": leg.account_id,
+            "source_conid": leg.source_conid,
+            "underlying_symbol": leg.underlying_symbol,
+            "expiry": leg.expiry,
+            "strike": leg.strike,
+            "right": leg.right,
+            "multiplier": leg.multiplier,
+            "currency": leg.currency,
+        },
+    ).scalar_one_or_none()
+    return None if conflicting_leg_id else leg.source_conid
 
 
 def _upsert_trade(session: Session, household_id: str, trade: FlexTradeConfirm, leg_id: str) -> None:

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import date
+from decimal import Decimal
 from typing import Any
 
-from app.worker.handlers.options_sync import _load_accounts, run_flex_options_sync
+from app.services.options.flex_parser import OptionLegKey
+from app.worker.handlers.options_sync import _load_accounts, _source_conid_for_insert, run_flex_options_sync
 
 
 class FakeScalar:
@@ -18,6 +21,11 @@ class FakeScalar:
         """Return the fake scalar value."""
 
         return self.value
+
+    def scalar_one_or_none(self) -> str | None:
+        """Return the fake scalar value when present."""
+
+        return self.value or None
 
     def mappings(self) -> list[dict[str, Any]]:
         """Return no mappings for scalar statements."""
@@ -80,6 +88,39 @@ class FakeSession:
         elif "insert into public.options_flex_sync_state" in sql:
             self.sync_states += 1
         return FakeMappings([])
+
+
+class ConidConflictSession:
+    """Fake session for duplicate source_conid checks."""
+
+    def __init__(self, conflicting: bool) -> None:
+        self.conflicting = conflicting
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeScalar:
+        """Return a conflicting leg id only for the conid preflight query."""
+
+        assert "from public.options_legs" in str(statement)
+        assert params and params["source_conid"] == 701529335
+        return FakeScalar("existing-leg" if self.conflicting else "")
+
+
+def test_duplicate_conid_is_dropped_for_different_natural_leg() -> None:
+    """Live Flex can reuse conids across adjusted option symbols."""
+
+    leg = OptionLegKey(
+        account_id="U1234567",
+        underlying_symbol="IBKR",
+        option_symbol="IBKR  260116P00180000",
+        expiry=date(2026, 1, 16),
+        strike=Decimal("180"),
+        right="put",
+        source_conid=701529335,
+    )
+
+    household_id = "10000000-0000-0000-0000-000000000001"
+
+    assert _source_conid_for_insert(ConidConflictSession(conflicting=False), household_id, leg) == 701529335  # type: ignore[arg-type]
+    assert _source_conid_for_insert(ConidConflictSession(conflicting=True), household_id, leg) is None  # type: ignore[arg-type]
 
 
 def test_load_accounts_matches_trading_account_config_schema() -> None:


### PR DESCRIPTION
## Summary
- preflight source_conid before leg upserts so live Flex rows with reused/adjusted conids do not violate the partial conid unique index
- preserve source_conid when it matches the natural leg; drop it only for a conflicting natural option leg
- add regression coverage for the duplicate-conid decision

## Validation
- cached live 2025 dry-run ingest: 681 trades, 559 cash events, 287 legs, transaction rolled back
- `cd apps/backend && uv run pytest -q tests` (321 passed)
- `cd apps/backend && uv run ruff check app tests`

Working as Hockney (Backend Dev).