### PR TITLE
fix(options): align account filter with live schema

### DIFF
--- a/apps/frontend/src/app/options/actions.test.ts
+++ b/apps/frontend/src/app/options/actions.test.ts
@@ -78,7 +78,7 @@ describe('options dashboard actions', () => {
 
   it('lists options-enabled trading accounts for the filter', async () => {
     const order = vi.fn().mockResolvedValue({
-      data: [{ id: 7, name: 'IBKR Main', account_type: 'IBKR', account_id: 'DU777', linked_account_id: null }],
+      data: [{ id: 7, account_id: 'DU777', linked_account_id: null }],
       error: null,
     });
     const accountsQuery = {
@@ -94,7 +94,7 @@ describe('options dashboard actions', () => {
     });
     (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from });
 
-    await expect(getUserAccountsWithOptionsEnabled()).resolves.toEqual([{ id: '7', label: 'IBKR Main (DU777)', accountId: 'DU777', accountType: 'IBKR' }]);
+    await expect(getUserAccountsWithOptionsEnabled()).resolves.toEqual([{ id: '7', label: 'DU777', accountId: 'DU777', accountType: 'IBKR' }]);
     expect(accountsQuery.eq).toHaveBeenCalledWith('compute_options_income', true);
   });
 });

--- a/apps/frontend/src/app/options/actions.ts
+++ b/apps/frontend/src/app/options/actions.ts
@@ -326,11 +326,11 @@ export async function getUserAccountsWithOptionsEnabled(): Promise<OptionsEnable
   const supabase = await createClient();
   const { data, error } = await supabase
     .from('trading_account_config')
-    .select('id, name, account_type, account_id, linked_account_id')
+    .select('id, account_id, linked_account_id')
     .eq('household_id', householdId)
     .eq('compute_options_income', true)
     .is('deleted_at', null)
-    .order('name', { ascending: true });
+    .order('id', { ascending: true });
 
   if (error) {
     console.error('[getUserAccountsWithOptionsEnabled] query error:', error.message);
@@ -340,13 +340,11 @@ export async function getUserAccountsWithOptionsEnabled(): Promise<OptionsEnable
   return ((data ?? []) as Record<string, unknown>[]).map((row) => {
     const fallbackId = String(row.id ?? '');
     const account = text(row.account_id) || text(row.linked_account_id) || fallbackId;
-    const name = text(row.name, account);
-    const type = text(row.account_type, 'IBKR');
     return {
       id: fallbackId,
-      label: `${name}${account && account !== name ? ` (${account})` : ''}`,
+      label: account,
       accountId: account,
-      accountType: type,
+      accountType: 'IBKR',
     };
   }).filter((account) => account.accountId.length > 0);
 }


### PR DESCRIPTION
## Summary
- remove nonexistent trading_account_config.name/account_type selects from the options dashboard account filter
- order options-enabled accounts by id and label them by account_id/link fallback from the live schema
- update the server-action regression test

This fixes the deployed /options page empty-account state after the backend backfill populated Jony's live account.

## Validation
- `cd apps/frontend && npm test -- src/app/options/actions.test.ts`
- `cd apps/frontend && npm run build`

Working as Hockney (Backend Dev).