### PR TITLE
fix(trading): align trading_account_config UI with live schema

### DIFF
--- a/apps/frontend/e2e/fixtures/seed-data.ts
+++ b/apps/frontend/e2e/fixtures/seed-data.ts
@@ -238,6 +238,40 @@ export async function seedTrade(householdId: string, data: TradeSeedData): Promi
   }
 }
 
+export interface TradingAccountSeedData {
+  name?: string;
+  accountId?: string;
+  host?: string;
+  port?: number;
+  clientId?: number;
+  computeOptionsIncome?: boolean;
+}
+
+/** Seeds a trading account config row for account-management E2E flows. */
+export async function seedTradingAccount(
+  householdId: string,
+  data: TradingAccountSeedData = {},
+): Promise<{ accountId: string }> {
+  const admin = getAdminClient();
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`;
+  const accountId = data.accountId ?? `E2E_TRADING_${suffix}`;
+
+  const { error } = await admin.from('trading_account_config').insert({
+    household_id: householdId,
+    name: data.name ?? 'E2E IBKR Account',
+    account_type: 'IBKR',
+    host: data.host ?? '127.0.0.1',
+    port: data.port ?? 4001,
+    client_id: data.clientId ?? 1,
+    account_id: accountId,
+    compute_options_income: data.computeOptionsIncome ?? true,
+  });
+
+  if (error) throw new Error(`[seed-data] insert trading_account_config failed: ${error.message}`);
+
+  return { accountId };
+}
+
 export interface OptionsDashboardSeedResult {
   accountId: string;
   groupId: string;

--- a/apps/frontend/e2e/flows/trading-accounts.spec.ts
+++ b/apps/frontend/e2e/flows/trading-accounts.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '../fixtures/test-user';
+import { cleanupHouseholdData, seedTradingAccount } from '../fixtures/seed-data';
+
+const UPDATED_ACCOUNT_NAME = 'E2E Edited IBKR Account';
+
+test.describe('trading accounts settings @auth', () => {
+  test('user sees an existing IBKR account and can edit it', async ({ testUser: { page, householdId } }) => {
+    await seedTradingAccount(householdId, {
+      name: 'E2E IBKR Account',
+      accountId: 'E2E_IBKR_001',
+      computeOptionsIncome: true,
+    });
+
+    try {
+      await page.goto('/trading/accounts', { waitUntil: 'networkidle', timeout: 20_000 });
+
+      await expect(page.getByRole('heading', { name: /Trading Accounts/i })).toBeVisible();
+      await expect(page.getByRole('button', { name: 'E2E IBKR Account' })).toBeVisible();
+      await expect(page.getByText(/IBKR Account:/)).toBeVisible();
+
+      await page.getByRole('button', { name: 'Settings' }).click();
+      await expect(page.getByRole('button', { name: /E2E IBKR Account \(IBKR\)/ })).toBeVisible();
+
+      await page.getByTitle('Account Name').fill(UPDATED_ACCOUNT_NAME);
+      await page.getByRole('button', { name: 'Save Settings' }).click();
+
+      await expect(page.getByText('Settings saved successfully!')).toBeVisible({ timeout: 10_000 });
+      await expect(page.getByRole('button', { name: new RegExp(`${UPDATED_ACCOUNT_NAME} \\(IBKR\\)`) })).toBeVisible();
+      await expect(page.getByText(/Failed to create trading account settings\./)).toHaveCount(0);
+    } finally {
+      await cleanupHouseholdData(householdId);
+    }
+  });
+});

--- a/apps/frontend/src/app/trading/actions.test.ts
+++ b/apps/frontend/src/app/trading/actions.test.ts
@@ -75,8 +75,9 @@ describe('getTradingConfigs', () => {
         port: 4001,
         client_id: 1,
         linked_account_id: null,
-        account_id: null,
+        account_id: 'U2515365',
         last_synced: null,
+        compute_options_income: true,
       },
     ];
     const order = vi.fn().mockResolvedValue({ data: rows, error: null });
@@ -92,6 +93,11 @@ describe('getTradingConfigs', () => {
     const result = await getTradingConfigs();
 
     expect(from).toHaveBeenCalledWith('trading_account_config');
+    const selectColumns = select.mock.calls[0]?.[0] as string;
+    expect(selectColumns).toContain('name');
+    expect(selectColumns).toContain('account_type');
+    expect(selectColumns).toContain('last_synced');
+    expect(selectColumns).not.toContain('last_synced_at');
     expect(is).toHaveBeenCalledWith('deleted_at', null);
     expect(result).toEqual(rows);
   });
@@ -114,6 +120,8 @@ describe('getTradingConfig', () => {
 
     const result = await getTradingConfig(7);
 
+    const selectColumns = select.mock.calls[0]?.[0] as string;
+    expect(selectColumns).not.toContain('last_synced_at');
     expect(eq).toHaveBeenCalledWith('id', 7);
     expect(result).toEqual(row);
   });

--- a/apps/frontend/src/app/trading/actions.ts
+++ b/apps/frontend/src/app/trading/actions.ts
@@ -8,7 +8,7 @@ export type TradingAccountType = 'IBKR' | 'SCHWAB';
 
 export interface TradingAccountConfig {
   id: number;
-  name: string;
+  name: string | null;
   account_type: TradingAccountType;
   host: string;
   port: number;
@@ -16,7 +16,6 @@ export interface TradingAccountConfig {
   linked_account_id: string | null;
   account_id: string | null;
   last_synced: string | null;
-  last_synced_at: string | null;
   compute_options_income: boolean;
 }
 
@@ -72,7 +71,6 @@ const CONFIG_SELECT = [
   'linked_account_id',
   'account_id',
   'last_synced',
-  'last_synced_at',
   'compute_options_income',
 ].join(', ');
 

--- a/apps/frontend/src/components/trading/TradingAccountDashboard.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountDashboard.tsx
@@ -85,7 +85,8 @@ export default function TradingAccountDashboard() {
     }
 
     const activeConfig = configs.find(c => c.id === activeAccountId);
-    const freshnessTimestamp = activeConfig?.last_synced_at || activeConfig?.last_synced || stats?.timestamp;
+    const activeAccountLabel = activeConfig?.name ?? activeConfig?.account_id ?? "My Trading Account";
+    const freshnessTimestamp = activeConfig?.last_synced || stats?.timestamp;
     const lastSynced = freshnessTimestamp ? new Date(freshnessTimestamp).toLocaleString() : "Never";
 
     return (
@@ -101,14 +102,14 @@ export default function TradingAccountDashboard() {
                             : "bg-slate-900 border-slate-800 text-slate-400 hover:border-slate-700"
                             }`}
                     >
-                        {c.name}
+                        {c.name ?? c.account_id ?? "My Trading Account"}
                     </button>
                 ))}
             </div>
 
             <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
                 <div className="text-slate-400 text-sm">
-                    {activeConfig?.account_type} Account: <span className="text-slate-200 font-medium">{activeConfig?.name}</span>
+                    {activeConfig?.account_type} Account: <span className="text-slate-200 font-medium">{activeAccountLabel}</span>
                     <span className="mx-2 opacity-30">|</span>
                     Last Synced: <span className="text-slate-200 font-medium">{lastSynced}</span>
                 </div>

--- a/apps/frontend/src/components/trading/TradingAccountSettings.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountSettings.tsx
@@ -14,6 +14,13 @@ type TradingAccountFormState = Partial<TradingAccountConfig> & {
     account_hash?: string;
 };
 
+type FinanceAccountOption = {
+    id: string;
+    name: string;
+    owner?: string;
+    category?: string;
+};
+
 export default function TradingAccountSettings() {
     const [configs, setConfigs] = useState<TradingAccountConfig[]>([]);
     const [editingConfig, setEditingConfig] = useState<TradingAccountFormState>({
@@ -25,7 +32,7 @@ export default function TradingAccountSettings() {
         linked_account_id: "",
         compute_options_income: true,
     });
-    const [financeAccounts, setFinanceAccounts] = useState<any[]>([]);
+    const [financeAccounts, setFinanceAccounts] = useState<FinanceAccountOption[]>([]);
     const [loading, setLoading] = useState(true);
     const [saving, setSaving] = useState(false);
     const [message, setMessage] = useState("");
@@ -51,7 +58,10 @@ export default function TradingAccountSettings() {
         try {
             const snapshot = await getLatestFinanceSnapshot();
             if (snapshot?.data?.items) {
-                setFinanceAccounts(snapshot.data.items.filter((i) => i.category === "Investments"));
+                const investmentAccounts = snapshot.data.items
+                    .filter((item) => item.category === "Investments")
+                    .map((item) => ({ id: item.id, name: item.name, owner: item.owner, category: item.category }));
+                setFinanceAccounts(investmentAccounts);
             }
         } catch (err) {
             console.error("Error fetching finance accounts:", err);
@@ -82,7 +92,7 @@ export default function TradingAccountSettings() {
             } else {
                 setMessage(result.error || "Error saving settings.");
             }
-        } catch (err) {
+        } catch {
             setMessage("Error saving settings.");
         } finally {
             setSaving(false);
@@ -118,7 +128,7 @@ export default function TradingAccountSettings() {
                             : "bg-slate-900 border-slate-800 text-slate-400 hover:border-slate-700"
                             }`}
                     >
-                        {c.name} ({c.account_type})
+                        {c.name ?? c.account_id ?? "My Trading Account"} ({c.account_type})
                     </button>
                 ))}
                 <button

--- a/supabase/migrations/20260504181442_add_trading_config_label.sql
+++ b/supabase/migrations/20260504181442_add_trading_config_label.sql
@@ -1,0 +1,43 @@
+-- Add frontend-facing labels for trading account configuration.
+-- The live schema drifted from the UI contract and was missing these columns.
+
+alter table public.trading_account_config
+  add column if not exists name text;
+
+alter table public.trading_account_config
+  add column if not exists account_type text;
+
+alter table public.trading_account_config
+  alter column account_type drop default;
+
+alter table public.trading_account_config
+  alter column account_type type text using account_type::text;
+
+update public.trading_account_config
+set name = coalesce(nullif(account_id, ''), 'My Trading Account')
+where name is null or btrim(name) = '';
+
+update public.trading_account_config
+set account_type = 'IBKR'
+where account_type is null or btrim(account_type) = '';
+
+alter table public.trading_account_config
+  alter column account_type set default 'IBKR',
+  alter column account_type set not null;
+
+alter table public.trading_account_config
+  alter column name drop not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'trading_account_config_account_type_check'
+      and conrelid = 'public.trading_account_config'::regclass
+  ) then
+    alter table public.trading_account_config
+      add constraint trading_account_config_account_type_check
+      check (account_type in ('IBKR', 'SCHWAB'));
+  end if;
+end $$;


### PR DESCRIPTION
## Summary

Fixes the frontend schema drift in the trading account configuration flow so existing IBKR rows are listed and editable again.

- Adds `name` and `account_type` to `public.trading_account_config` via Supabase migration and backfills existing rows (`name = account_id` fallback, `account_type = 'IBKR'`).
- Removes stale `last_synced_at` from the frontend config SELECT/type and uses `last_synced` for freshness display.
- Keeps the `/options` account query unchanged after audit: it selects only live columns (`id`, `account_id`, `linked_account_id`) and filters by live `compute_options_income`.
- Adds a Playwright regression for `/trading/accounts` showing an existing IBKR account and editing it.

Prior backend fix in the same schema-drift family: #258.

## Validation

- Supabase MCP `apply_migration`: succeeded
- Supabase live schema check: `name text null`, `account_type text not null default 'IBKR'`, check constraint for `IBKR`/`SCHWAB`
- `npm test` — 34 files / 232 tests passed
- `npm test -- --run src/app/trading/actions.test.ts` — 8 passed
- `npm run build` — passed
- `SUPABASE_E2E_ALLOW_PROD=true npx playwright test e2e/flows/trading-accounts.spec.ts --project=chromium` — 1 passed
- Changed-file ESLint — no errors (existing `TradingAccountDashboard` hook warning remains)
- Full `npm run lint` and raw `npx tsc --noEmit` still report pre-existing unrelated repo-wide issues; changed files have no typecheck errors.

## Notes

Working as Fenster (Frontend Dev).
