### PR TITLE
feat(options): synthetic assignment cash flow adjustment

### DIFF
--- a/apps/backend/app/services/options/flex_parser.py
+++ b/apps/backend/app/services/options/flex_parser.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation
+import logging
 from pathlib import Path
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, ParseError
@@ -20,6 +22,8 @@ SECTION_ROW_NAMES = {
     "AccountInformation": "AccountInformation",
 }
 MONEY_ZERO = Decimal("0")
+ASSIGNMENT_TRANSACTION_TYPES = {"assignment", "exercise"}
+logger = logging.getLogger(__name__)
 
 
 class FlexParserError(RuntimeError):
@@ -124,6 +128,20 @@ class FlexParseResult(BaseModel):
     section_counts: dict[str, int] = Field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class _AssignmentOptionLeg:
+    account_id: str
+    underlying_symbol: str
+    trade_date: date
+    trade_time: datetime
+    strike: Decimal
+    share_quantity_abs: Decimal
+    eae_trade_id: str
+    option_trade_id: str
+    transaction_type: str
+    currency: str
+
+
 def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> FlexParseResult:
     """Parse Flex XML files into typed rows, optionally filtering to one account."""
 
@@ -132,7 +150,14 @@ def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> Fl
     positions: list[FlexOpenPosition] = []
     eae_rows: list[FlexTradeConfirm] = []
     account_info: list[FlexAccountInformation] = []
-    counts: dict[str, int] = {}
+    assignment_eae_attrs: list[dict[str, str]] = []
+    option_trade_attrs: list[dict[str, str]] = []
+    stock_trade_attrs: list[dict[str, str]] = []
+    counts: dict[str, int] = {
+        "assignment_synthetic_emitted": 0,
+        "assignment_synthetic_skipped_no_market": 0,
+        "assignment_synthetic_skipped_ambiguous": 0,
+    }
     for path in paths:
         root = _parse_xml_file(path)
         statement_dates = _statement_dates(root)
@@ -143,17 +168,23 @@ def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> Fl
             counts[section_name] = counts.get(section_name, 0) + 1
             if section_name in {"TradeConfirms", "Trades"}:
                 if _is_option_contract_row(attrs):
+                    option_trade_attrs.append(attrs)
                     trades.append(parse_trade_confirm(attrs, statement_dates[1]))
+                elif attrs.get("assetCategory") == "STK":
+                    stock_trade_attrs.append(attrs)
             elif section_name == "CashTransactions":
                 cash.append(parse_cash_transaction(attrs))
             elif section_name == "OpenPositions":
                 if _is_option_contract_row(attrs):
                     positions.append(parse_open_position(attrs, statement_dates[1]))
             elif section_name == "OptionEAE":
+                if _is_assignment_lifecycle_row(attrs):
+                    assignment_eae_attrs.append(attrs)
                 if _is_option_contract_row(attrs):
                     eae_rows.append(parse_option_eae(attrs, statement_dates[1]))
             elif section_name == "AccountInformation":
                 account_info.append(parse_account_information(attrs))
+    cash.extend(_assignment_synthetic_cash_events(assignment_eae_attrs, option_trade_attrs, stock_trade_attrs, counts))
     return FlexParseResult(
         trades=trades,
         cash_transactions=cash,
@@ -266,6 +297,163 @@ def parse_account_information(attrs: dict[str, str]) -> FlexAccountInformation:
         currency=attrs.get("baseCurrency") or _currency(attrs),
         raw_payload=attrs,
     )
+
+
+def _assignment_synthetic_cash_events(
+    eae_rows: list[dict[str, str]],
+    option_trade_rows: list[dict[str, str]],
+    stock_trade_rows: list[dict[str, str]],
+    counts: dict[str, int],
+) -> list[FlexCashTransaction]:
+    """Create cash-flow adjustments from assigned/exercised stock legs."""
+
+    option_rows_by_trade_id: dict[str, list[dict[str, str]]] = {}
+    for row in option_trade_rows:
+        trade_id = _optional_text(row.get("tradeID") or row.get("transactionID"))
+        if trade_id:
+            option_rows_by_trade_id.setdefault(trade_id, []).append(row)
+
+    emitted: list[FlexCashTransaction] = []
+    seen_source_ids: set[str] = set()
+    for eae in eae_rows:
+        option_leg = _assignment_option_leg(eae, option_rows_by_trade_id)
+        if option_leg is None:
+            continue
+        matches = [row for row in stock_trade_rows if _stock_row_matches_assignment(row, option_leg)]
+        if len(matches) > 1:
+            counts["assignment_synthetic_skipped_ambiguous"] += 1
+            logger.warning(
+                "Skipping ambiguous assignment synthetic cash event",
+                extra={
+                    "account_id": option_leg.account_id,
+                    "underlying": option_leg.underlying_symbol,
+                    "trade_date": option_leg.trade_date.isoformat(),
+                    "eae_trade_id": option_leg.eae_trade_id,
+                    "stock_trade_ids": [_optional_text(row.get("tradeID")) for row in matches],
+                },
+            )
+            continue
+        if not matches:
+            continue
+        event = _synthetic_cash_from_stock_row(option_leg, matches[0], counts)
+        if event is None or event.source_transaction_id in seen_source_ids:
+            continue
+        seen_source_ids.add(event.source_transaction_id)
+        counts["assignment_synthetic_emitted"] += 1
+        emitted.append(event)
+    return emitted
+
+
+def _assignment_option_leg(
+    eae: dict[str, str], option_rows_by_trade_id: dict[str, list[dict[str, str]]]
+) -> _AssignmentOptionLeg | None:
+    transaction_type = _optional_text(eae.get("transactionType") or eae.get("type") or eae.get("action"))
+    if (transaction_type or "").lower() not in ASSIGNMENT_TRANSACTION_TYPES:
+        return None
+    eae_trade_id = _optional_text(eae.get("tradeID") or eae.get("transactionID"))
+    if not eae_trade_id:
+        return None
+    option_matches = option_rows_by_trade_id.get(eae_trade_id, [])
+    if len(option_matches) != 1:
+        if len(option_matches) > 1:
+            logger.warning(
+                "Skipping assignment synthetic cash event with ambiguous option leg",
+                extra={"eae_trade_id": eae_trade_id, "option_match_count": len(option_matches)},
+            )
+        return None
+    option_row = option_matches[0]
+    trade_time = _datetime_attr(option_row, ("dateTime",), fallback_date=None)
+    return _AssignmentOptionLeg(
+        account_id=_required_any(option_row, ("accountId",)),
+        underlying_symbol=_required_any(option_row, ("underlyingSymbol", "symbol")),
+        trade_date=_date_attr(option_row, ("tradeDate", "dateTime"), fallback=trade_time.date()),
+        trade_time=trade_time,
+        strike=_decimal_attr(option_row, "strike"),
+        share_quantity_abs=abs(
+            _decimal_attr(option_row, "quantity") * (_decimal_attr(option_row, "multiplier") or Decimal("100"))
+        ),
+        eae_trade_id=eae_trade_id,
+        option_trade_id=_required_any(option_row, ("tradeID", "transactionID")),
+        transaction_type=transaction_type or "Assignment",
+        currency=_currency(option_row),
+    )
+
+
+def _stock_row_matches_assignment(row: dict[str, str], option_leg: _AssignmentOptionLeg) -> bool:
+    if _optional_text(row.get("assetCategory")) != "STK":
+        return False
+    account_id = _optional_text(row.get("accountId"))
+    underlying = _optional_text(row.get("underlyingSymbol") or row.get("symbol"))
+    event_time = _optional_datetime_attr(row, ("dateTime",))
+    trade_date = _date_attr(row, ("tradeDate", "dateTime"), fallback=(event_time or option_leg.trade_time).date())
+    return (
+        account_id == option_leg.account_id
+        and underlying == option_leg.underlying_symbol
+        and trade_date == option_leg.trade_date
+        and _first_decimal(row, ("tradePrice", "price")) == option_leg.strike
+        and abs(_decimal_attr(row, "quantity")) == option_leg.share_quantity_abs
+    )
+
+
+def _synthetic_cash_from_stock_row(
+    option_leg: _AssignmentOptionLeg, stock_row: dict[str, str], counts: dict[str, int]
+) -> FlexCashTransaction | None:
+    mtm_pnl = _optional_decimal(stock_row, "mtmPnl")
+    close_price = _optional_decimal(stock_row, "closePrice")
+    trade_price = _first_decimal(stock_row, ("tradePrice", "price"))
+    quantity = _decimal_attr(stock_row, "quantity")
+    formula = "mtmPnl"
+    if mtm_pnl is not None:
+        amount = mtm_pnl
+    elif close_price is not None:
+        amount = quantity * (close_price - trade_price)
+        formula = "computed"
+    else:
+        counts["assignment_synthetic_skipped_no_market"] += 1
+        logger.warning(
+            "Skipping assignment synthetic cash event without market price",
+            extra={
+                "account_id": option_leg.account_id,
+                "underlying": option_leg.underlying_symbol,
+                "eae_trade_id": option_leg.eae_trade_id,
+                "stock_trade_id": _optional_text(stock_row.get("tradeID")),
+            },
+        )
+        return None
+
+    stock_trade_id = _required_any(stock_row, ("tradeID", "transactionID"))
+    market_text = str(close_price) if close_price is not None else "unknown"
+    raw_payload = {
+        "underlying": option_leg.underlying_symbol,
+        "eae_trade_id": option_leg.eae_trade_id,
+        "option_trade_id": option_leg.option_trade_id,
+        "stk_trade_id": stock_trade_id,
+        "strike": str(option_leg.strike),
+        "close_price": str(close_price) if close_price is not None else "",
+        "trade_price": str(trade_price),
+        "quantity": str(quantity),
+        "formula": formula,
+        "transaction_type": option_leg.transaction_type,
+    }
+    return FlexCashTransaction(
+        account_id=option_leg.account_id,
+        source_transaction_id=f"assign_synth:{stock_trade_id}",
+        event_date=option_leg.trade_date,
+        event_time=_optional_datetime_attr(stock_row, ("dateTime",)) or option_leg.trade_time,
+        event_category="assignment_synthetic",
+        description=(
+            f"{option_leg.underlying_symbol} assignment synthetic "
+            f"(strike {option_leg.strike} vs market {market_text}, {abs(quantity)} shares)"
+        ),
+        amount=amount,
+        currency=_currency(stock_row) or option_leg.currency,
+        raw_payload=raw_payload,
+    )
+
+
+def _is_assignment_lifecycle_row(attrs: dict[str, str]) -> bool:
+    transaction_type = _optional_text(attrs.get("transactionType") or attrs.get("type") or attrs.get("action"))
+    return (transaction_type or "").lower() in ASSIGNMENT_TRANSACTION_TYPES
 
 
 def _parse_xml_file(path: Path) -> Element:

--- a/apps/backend/app/services/options/strategy_grouper.py
+++ b/apps/backend/app/services/options/strategy_grouper.py
@@ -26,6 +26,7 @@ class StrategyTrade(RollCandidateTrade):
     household_id: str = ""
     trade_time: datetime | None = None
     multiplier: Decimal = DEFAULT_MULTIPLIER
+    assignment_cash_flow: Decimal = ZERO
 
 
 @dataclass(frozen=True, slots=True)
@@ -277,7 +278,7 @@ def _build_group(builder: _GroupBuilder, by_id: dict[str, StrategyTrade]) -> Str
         closed_at=max(close_times)
         if close_times and all(_is_close(trade) or _has_close(trade, group_trades) for trade in group_trades)
         else None,
-        net_cash_flow=sum((trade.net_cash_flow for trade in group_trades), ZERO),
+        net_cash_flow=sum((trade.net_cash_flow + trade.assignment_cash_flow for trade in group_trades), ZERO),
         realized_pnl=sum((trade.realized_pnl for trade in group_trades), ZERO),
         capital_at_risk_open=capital_at_risk,
         risk_calculation_method=method,

--- a/apps/backend/app/worker/handlers/options_grouping.py
+++ b/apps/backend/app/worker/handlers/options_grouping.py
@@ -120,9 +120,19 @@ def _load_strategy_trades(
                    l."right"::text as right,
                    l.strike,
                    l.expiry,
-                   l.multiplier
+                   l.multiplier,
+                   coalesce(s.assignment_cash_flow, 0) as assignment_cash_flow
               from public.options_trades t
               join public.options_legs l on l.id = t.leg_id
+              left join (
+                   select account_id,
+                          raw_payload ->> 'option_trade_id' as source_trade_id,
+                          sum(amount) as assignment_cash_flow
+                     from public.options_cash_events
+                    where event_category = 'assignment_synthetic'
+                      and source_transaction_id like 'assign_synth:%'
+                    group by account_id, raw_payload ->> 'option_trade_id'
+              ) s on s.account_id = t.account_id and s.source_trade_id = t.source_trade_id
              where {" and ".join(where)}
              order by t.trade_date, t.trade_time, t.id
             """
@@ -148,6 +158,7 @@ def _load_strategy_trades(
             strike=Decimal(str(row["strike"])),
             expiry=row["expiry"],
             multiplier=Decimal(str(row["multiplier"])),
+            assignment_cash_flow=Decimal(str(row["assignment_cash_flow"])),
         )
         for row in rows
     ]

--- a/apps/backend/app/worker/handlers/options_metrics.py
+++ b/apps/backend/app/worker/handlers/options_metrics.py
@@ -206,7 +206,7 @@ def _load_trade_facts(
             select event_date as trade_date, amount as net_cash_flow, 0::numeric as realized_pnl, 0 as trade_count
               from public.options_cash_events
              where {" and ".join(where).replace("trade_date", "event_date")}
-               and event_category = 'option_related'
+               and event_category in ('option_related', 'assignment_synthetic')
              order by trade_date
             """
         ),

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -85,3 +85,204 @@ def test_parse_live_flex_trade_and_open_position_aliases() -> None:
     assert trade.leg.expiry.isoformat() == "2026-06-19"
     assert position.average_open_price == Decimal("1.9895")
     assert position.open_cash_flow == Decimal("-198.95")
+
+
+def test_assignment_synthetic_cash_events_cover_all_sign_cases() -> None:
+    """Assigned/exercised stock legs create correctly signed synthetic cash flow."""
+
+    output_dir = Path("tmp/test-options-assignment-synthetic")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "assignments.xml"
+    path.write_text(
+        _flex_xml(
+            [
+                _assignment_rows(
+                    "short-put",
+                    transaction="Assignment",
+                    right="P",
+                    opt_qty="10",
+                    stk_qty="1000",
+                    strike="112",
+                    close="83",
+                    mtm="-29000",
+                ),
+                _assignment_rows(
+                    "short-call",
+                    transaction="Assignment",
+                    right="C",
+                    opt_qty="-10",
+                    stk_qty="-1000",
+                    strike="80",
+                    close="110",
+                    mtm="-30000",
+                ),
+                _assignment_rows(
+                    "long-call",
+                    transaction="Exercise",
+                    right="C",
+                    opt_qty="10",
+                    stk_qty="1000",
+                    strike="80",
+                    close="110",
+                    mtm="30000",
+                ),
+                _assignment_rows(
+                    "long-put",
+                    transaction="Exercise",
+                    right="P",
+                    opt_qty="-10",
+                    stk_qty="-1000",
+                    strike="112",
+                    close="83",
+                    mtm="29000",
+                ),
+            ]
+        )
+    )
+
+    parsed = parse_flex_files([path])
+    synthetics = [cash for cash in parsed.cash_transactions if cash.event_category == "assignment_synthetic"]
+
+    assert [cash.amount for cash in synthetics] == [
+        Decimal("-29000"),
+        Decimal("-30000"),
+        Decimal("30000"),
+        Decimal("29000"),
+    ]
+    assert parsed.section_counts["assignment_synthetic_emitted"] == 4
+    assert synthetics[0].source_transaction_id == "assign_synth:short-put-stk"
+    assert synthetics[0].raw_payload["option_trade_id"] == "short-put-opt"
+
+
+def test_assignment_synthetic_computes_amount_without_mtm_pnl() -> None:
+    """When mtmPnl is absent, use signed stock quantity × (market − strike)."""
+
+    output_dir = Path("tmp/test-options-assignment-computed")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "computed.xml"
+    path.write_text(
+        _flex_xml(
+            [
+                _assignment_rows(
+                    "computed",
+                    transaction="Assignment",
+                    right="P",
+                    opt_qty="1",
+                    stk_qty="100",
+                    strike="112",
+                    close="83",
+                )
+            ]
+        )
+    )
+
+    parsed = parse_flex_files([path])
+    synthetic = next(cash for cash in parsed.cash_transactions if cash.event_category == "assignment_synthetic")
+
+    assert synthetic.amount == Decimal("-2900")
+    assert synthetic.raw_payload["formula"] == "computed"
+
+
+def test_cash_settled_option_without_stock_leg_emits_no_assignment_synthetic() -> None:
+    """Cash-settled products without a stock leg keep existing cash flow only."""
+
+    output_dir = Path("tmp/test-options-cash-settled")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "cash-settled.xml"
+    rows = _assignment_rows(
+        "spx", transaction="Exercise", right="P", opt_qty="1", stk_qty="100", strike="5000", close="4990"
+    )
+    path.write_text(_flex_xml([rows[: rows.index('<Trade accountId="U1234567" assetCategory="STK"')]]))
+
+    parsed = parse_flex_files([path])
+
+    assert [cash for cash in parsed.cash_transactions if cash.event_category == "assignment_synthetic"] == []
+    assert parsed.section_counts["assignment_synthetic_emitted"] == 0
+
+
+def test_ambiguous_assignment_stock_match_skips_and_logs(caplog) -> None:  # type: ignore[no-untyped-def]
+    """If two stock rows match one EAE row, the parser skips rather than guessing."""
+
+    output_dir = Path("tmp/test-options-assignment-ambiguous")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "ambiguous.xml"
+    rows = _assignment_rows(
+        "ambiguous",
+        transaction="Assignment",
+        right="P",
+        opt_qty="1",
+        stk_qty="100",
+        strike="112",
+        close="83",
+        mtm="-2900",
+    )
+    duplicate = rows.replace('tradeID="ambiguous-stk"', 'tradeID="ambiguous-stk-2"')
+    duplicate = duplicate[duplicate.index('<Trade accountId="U1234567" assetCategory="STK"') :]
+    path.write_text(_flex_xml([rows + duplicate]))
+
+    with caplog.at_level("WARNING", logger="app.services.options.flex_parser"):
+        parsed = parse_flex_files([path])
+
+    assert [cash for cash in parsed.cash_transactions if cash.event_category == "assignment_synthetic"] == []
+    assert parsed.section_counts["assignment_synthetic_skipped_ambiguous"] == 1
+    assert "ambiguous assignment synthetic" in caplog.text
+
+
+def _flex_xml(row_groups: list[str]) -> str:
+    return (
+        '<FlexQueryResponse><FlexStatements><FlexStatement accountId="U1234567" '
+        'fromDate="20260101" toDate="20260131"><Trades>'
+        + "".join(row_groups)
+        + "</Trades><OptionEAE>"
+        + "".join(_eae_row(group) for group in row_groups)
+        + "</OptionEAE></FlexStatement></FlexStatements></FlexQueryResponse>"
+    )
+
+
+def _assignment_rows(
+    prefix: str,
+    *,
+    transaction: str,
+    right: str,
+    opt_qty: str,
+    stk_qty: str,
+    strike: str,
+    close: str,
+    mtm: str | None = None,
+) -> str:
+    mtm_attr = f' mtmPnl="{mtm}"' if mtm is not None else ""
+    return f'''
+<Trade accountId="U1234567" assetCategory="OPT" currency="USD" symbol="{prefix} OPT" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-opt" multiplier="100" strike="{strike}" expiry="2026-01-17" dateTime="2026-01-17;120000" putCall="{right}" quantity="{opt_qty}" tradePrice="0" proceeds="0" netCash="0" fifoPnlRealized="0" />
+<Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="{prefix.upper()}" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-stk" multiplier="1" dateTime="2026-01-17;120000" quantity="{stk_qty}" tradePrice="{strike}" closePrice="{close}" proceeds="0" netCash="0"{mtm_attr} />
+<!--EAE {prefix}-opt {transaction}-->
+'''
+
+
+def _eae_row(group: str) -> str:
+    marker = "<!--EAE "
+    if marker not in group:
+        return ""
+    start = group.index(marker) + len(marker)
+    end = group.index("-->", start)
+    trade_id, transaction = group[start:end].strip().split()
+    symbol = trade_id.removesuffix("-opt").upper()
+    return (
+        f'<OptionEAE accountId="U1234567" currency="USD" symbol="{symbol} OPT" '
+        f'underlyingSymbol="{symbol}" transactionType="{transaction}" tradeID="{trade_id}" />'
+    )
+
+
+def test_live_nflx_assignment_fixture_emits_expected_synthetic_amount() -> None:
+    """Cached live Flex XML emits the verified NFLX assignment adjustment."""
+
+    parsed = parse_flex_files([Path("tmp/flex/trades_20260504T160341Z.xml")], account_id="U2515365")
+    nflx = [
+        cash
+        for cash in parsed.cash_transactions
+        if cash.event_category == "assignment_synthetic" and cash.raw_payload.get("stk_trade_id") == "8869640568"
+    ]
+
+    assert len(nflx) == 1
+    assert nflx[0].amount == Decimal("-28460")
+    assert nflx[0].raw_payload["eae_trade_id"] == "8869640563"
+    assert nflx[0].raw_payload["option_trade_id"] == "8869640563"

--- a/apps/backend/tests/services/options/test_strategy_grouper.py
+++ b/apps/backend/tests/services/options/test_strategy_grouper.py
@@ -21,6 +21,7 @@ def trade(
     expiry: date = date(2025, 3, 21),
     cash: str = "0",
     pnl: str = "0",
+    assignment_cash: str = "0",
     quantity: str | None = None,
 ) -> StrategyTrade:
     """Build a minimal strategy trade."""
@@ -41,6 +42,7 @@ def trade(
         quantity=Decimal(quantity or ("1" if side == "buy" else "-1")),
         realized_pnl=Decimal(pnl),
         net_cash_flow=Decimal(cash),
+        assignment_cash_flow=Decimal(assignment_cash),
     )
 
 
@@ -99,3 +101,18 @@ def test_idempotent_rerun_produces_same_group_ids() -> None:
     first = group_option_strategies(trades)
     second = group_option_strategies(list(reversed(trades)))
     assert [group.group_id for group in first.groups] == [group.group_id for group in second.groups]
+
+
+def test_assignment_synthetic_cash_flow_rolls_into_group_net_cash_flow() -> None:
+    """Strategy net cash flow includes synthetic assignment adjustments."""
+
+    result = group_option_strategies(
+        [
+            trade("open-short-put", cash="200"),
+            trade(
+                "assignment-close", day=date(2025, 2, 21), indicator="C", side="buy", cash="0", assignment_cash="-2900"
+            ),
+        ]
+    )
+
+    assert result.groups[0].net_cash_flow == Decimal("-2700")

--- a/apps/backend/tests/test_backfill_options.py
+++ b/apps/backend/tests/test_backfill_options.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date
 from decimal import Decimal
+from pathlib import Path
 from typing import Any
 
 from scripts import backfill_options
@@ -218,3 +219,34 @@ def test_same_window_backfill_is_idempotent(monkeypatch) -> None:  # type: ignor
     assert second["trade_count"] == 1
     assert len(session.trades) == 1
     assert len(session.legs) == 1
+
+
+def test_assignment_synthetic_cash_events_are_idempotent(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Re-running the same assignment XML upserts one assign_synth cash event."""
+
+    fixture_dir = Path("tmp/test-options-sync-idempotent")
+    fixture_dir.mkdir(parents=True, exist_ok=True)
+    fixture = fixture_dir / "assignment.xml"
+    fixture.write_text(
+        """
+<FlexQueryResponse><FlexStatements><FlexStatement accountId="U1234567" fromDate="20260101" toDate="20260131">
+  <Trades>
+    <Trade accountId="U1234567" assetCategory="OPT" currency="USD" symbol="NFLX  260117P00112000" underlyingSymbol="NFLX" tradeID="opt-1" multiplier="100" strike="112" expiry="2026-01-17" dateTime="2026-01-17;120000" putCall="P" quantity="1" tradePrice="0" proceeds="0" netCash="0" fifoPnlRealized="0" />
+    <Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="NFLX" underlyingSymbol="NFLX" tradeID="stk-1" multiplier="1" dateTime="2026-01-17;120000" quantity="100" tradePrice="112" closePrice="83" proceeds="0" netCash="0" mtmPnl="-2900" />
+  </Trades>
+  <OptionEAE>
+    <OptionEAE accountId="U1234567" currency="USD" symbol="NFLX  260117P00112000" underlyingSymbol="NFLX" transactionType="Assignment" tradeID="opt-1" />
+  </OptionEAE>
+</FlexStatement></FlexStatements></FlexQueryResponse>
+"""
+    )
+    monkeypatch.setattr("app.worker.handlers.options_sync._select_flex_source", lambda **_kwargs: [fixture])
+    session = InMemoryOptionsSession()
+
+    first = run_flex_options_sync(session, account_id=ACCOUNT_ID)
+    second = run_flex_options_sync(session, account_id=ACCOUNT_ID)
+
+    assert first["cash_event_count"] == 1
+    assert second["cash_event_count"] == 1
+    assert len(session.cash_events) == 1
+    assert next(iter(session.cash_events.values()))["source_transaction_id"] == "assign_synth:stk-1"

--- a/apps/backend/tests/worker/test_options_grouping.py
+++ b/apps/backend/tests/worker/test_options_grouping.py
@@ -108,6 +108,7 @@ def _trade_rows() -> list[dict[str, Any]]:
             "strike": Decimal(strike),
             "expiry": expiry,
             "multiplier": Decimal("100"),
+            "assignment_cash_flow": Decimal("0"),
         }
 
     return [

--- a/apps/backend/tests/worker/test_options_metrics.py
+++ b/apps/backend/tests/worker/test_options_metrics.py
@@ -1,0 +1,74 @@
+"""Worker tests for options monthly metrics persistence."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from app.worker.handlers.options_metrics import compute_options_monthly_metrics
+
+
+class FakeMappings:
+    """Mappings wrapper for fake SELECT statements."""
+
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+
+    def mappings(self) -> list[dict[str, Any]]:
+        """Return mapping rows."""
+
+        return self.rows
+
+
+class FakeSession:
+    """Small SQL recorder for monthly metric worker behavior."""
+
+    def __init__(self) -> None:
+        self.monthly_rows: list[dict[str, Any]] = []
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        """Return deterministic facts and record dashboard inserts."""
+
+        sql = str(statement)
+        params = params or {}
+        if "select distinct household_id" in sql:
+            return FakeMappings([{"household_id": "10000000-0000-0000-0000-000000000001", "account_id": "U1234567"}])
+        if "from public.options_trades" in sql and "union all" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "trade_date": date(2026, 1, 2),
+                        "net_cash_flow": Decimal("200"),
+                        "realized_pnl": Decimal("0"),
+                        "trade_count": 1,
+                    },
+                    {
+                        "trade_date": date(2026, 1, 17),
+                        "net_cash_flow": Decimal("-2900"),
+                        "realized_pnl": Decimal("0"),
+                        "trade_count": 0,
+                    },
+                    {
+                        "trade_date": date(2026, 1, 20),
+                        "net_cash_flow": Decimal("3000"),
+                        "realized_pnl": Decimal("0"),
+                        "trade_count": 1,
+                    },
+                ]
+            )
+        if "insert into public.options_dashboard_monthly" in sql:
+            self.monthly_rows.append(dict(params))
+        return FakeMappings([])
+
+
+def test_monthly_metrics_include_assignment_synthetic_cash_events() -> None:
+    """NFLX-style flow is 200 + (-2900) + 3000 = 300 net cash flow."""
+
+    session = FakeSession()
+
+    result = compute_options_monthly_metrics(session)  # type: ignore[arg-type]
+
+    assert result["row_count"] == 1
+    assert session.monthly_rows[0]["cash_flow_total"] == Decimal("300")
+    assert session.monthly_rows[0]["cash_flow_cumulative"] == Decimal("300")

--- a/apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx
+++ b/apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx
@@ -179,6 +179,9 @@ export default function NetCashFlowVsRealizedChart({ months }: Props) {
         <div>
           <p className="text-xs uppercase tracking-[0.28em] text-slate-500">Income quality</p>
           <h2 className="mt-2 text-xl font-semibold text-slate-100">Net Cash Flow vs Realized P&amp;L</h2>
+          <p className="mt-2 max-w-2xl text-xs text-slate-500">
+            Includes synthetic assignment adjustments: when an option is assigned, the unrealized loss (strike − market) × shares is recorded as cash flow even though the underlying stock leg itself is not tracked.
+          </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
           {([

--- a/apps/frontend/src/components/Options/variance-gap-badge.tsx
+++ b/apps/frontend/src/components/Options/variance-gap-badge.tsx
@@ -28,6 +28,9 @@ export default function VarianceGapBadge({ cumulativeCashFlow, cumulativeRealize
         <div>
           <p className="text-sm text-slate-400">Cumulative Cash Flow</p>
           <p className="text-3xl font-bold tabular-nums text-emerald-300">{formatSignedUsd(cumulativeCashFlow)}</p>
+          <p className="mt-1 text-xs text-slate-500" title="Synthetic assignment adjustments record (strike − market) × shares as cash flow when assigned stock is not tracked.">
+            Includes synthetic assignment adjustments.
+          </p>
         </div>
         <div>
           <p className="text-sm text-slate-400">Cumulative Realized P&amp;L</p>

--- a/supabase/migrations/20260504170000_add_assignment_synthetic_cash_event_category.sql
+++ b/supabase/migrations/20260504170000_add_assignment_synthetic_cash_event_category.sql
@@ -1,0 +1,4 @@
+-- Migration: add_assignment_synthetic_cash_event_category
+-- Purpose: Allow IBKR assignment/exercise stock-leg synthetic cash-flow adjustments.
+
+alter type public.options_cash_event_category add value if not exists 'assignment_synthetic';


### PR DESCRIPTION
## Summary
- Parses IBKR assignment/exercise stock legs into idempotent `assignment_synthetic` cash events using `mtmPnl` or signed quantity × (market − strike).
- Includes synthetic assignment cash in monthly dashboard metrics and strategy-group net cash flow.
- Adds the enum migration plus dashboard copy explaining synthetic assignment adjustments.

## User spec
> "for stock assignment we should calculate the difference between strike to current price as the outflow. (so we don't need to keep track of the stocks). in our scenario the strike was 112, and the price at time of assignment was 83 - so the outflow of cash was 29 per share, or 2900."

## NFLX validation
- Small validation case: 200 + (-2900) + 3000 = 300 ✅
- Cached live XML: NFLX 17APR26 112P assignment emitted `assign_synth:8869640568` for `-28460.000000` ✅

## Tests
- Before: not run in this branch before changes.
- After:
  - `cd apps/backend && uv run pytest -x` → 332 passed
  - `cd apps/backend && uv run ruff check ...` → passed
  - `cd apps/frontend && npm run build` → passed
  - `cd apps/frontend && npm run lint -- --file src/components/Options/net-cash-flow-vs-realized-chart.tsx --file src/components/Options/variance-gap-badge.tsx` → passed
  - `cd apps/frontend && npm run lint` → fails on pre-existing unrelated Plan/* lint errors (`no-explicit-any`, `prefer-const`, hook deps); touched options files pass.

## Backfill summary
- Applied Supabase migration: `add_assignment_synthetic_cash_event_category`.
- Reprocessed cached XML `apps/backend/tmp/flex/trades_20260504T160341Z.xml` for account `U2515365`.
- Parser emitted 13 synthetic assignment events; DB now has 13 `assignment_synthetic` rows for `U2515365`.
- NFLX 112P synthetic confirmed in DB: `2026-01-22`, `-28460.000000`, `NFLX assignment synthetic (strike 112 vs market 83.54, 1000 shares)`.
- Recomputed strategy groups (994) and monthly metrics (13 rows); synthetic total is `-161003.000000`, reducing cumulative cash flow accordingly.
