### PR TITLE
fix(flex): send period=CustomDate so backfill date range is honored

### DIFF
--- a/apps/backend/scripts/flex_probe.py
+++ b/apps/backend/scripts/flex_probe.py
@@ -140,8 +140,16 @@ def flex_error(root: Element) -> tuple[str | None, str | None]:
 
 
 def send_flex_request(config: QueryConfig, token: str, start: date | None, end: date | None) -> str:
-    """Call SendRequest and return the Flex reference code."""
+    """Call SendRequest and return the Flex reference code.
+
+    When start/end are supplied we also send `period=CustomDate` so IBKR honors
+    the override; otherwise the saved query period (e.g. Last365CalendarDays)
+    silently overrides the dates and the response is the wrong window.
+    See IBKR Flex Web Service Guide.
+    """
     params = {"t": token, "q": config.query_id, "v": "3"}
+    if start and end:
+        params["period"] = "CustomDate"
     if start:
         params["startdate"] = start.strftime("%Y%m%d")
     if end:

--- a/apps/backend/tests/test_flex_send_request.py
+++ b/apps/backend/tests/test_flex_send_request.py
@@ -1,0 +1,48 @@
+"""Tests for IBKR Flex SendRequest URL construction."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from xml.etree.ElementTree import fromstring
+
+import pytest
+
+from scripts.flex_probe import QueryConfig, send_flex_request
+
+
+@pytest.fixture()
+def stub_request_xml(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def fake_request_xml(url: str, params: dict[str, str]) -> Any:
+        captured["url"] = url
+        captured["params"] = params
+        return fromstring(
+            "<FlexStatementResponse><Status>Success</Status><ReferenceCode>123</ReferenceCode></FlexStatementResponse>"
+        )
+
+    monkeypatch.setattr("scripts.flex_probe.request_xml", fake_request_xml)
+    return captured
+
+
+def test_send_flex_request_adds_period_customdate_when_dates_supplied(
+    stub_request_xml: dict[str, Any],
+) -> None:
+    config = QueryConfig(name="trades", query_id="1496910")
+    send_flex_request(config, "TOKEN", date(2024, 1, 1), date(2024, 12, 31))
+    params = stub_request_xml["params"]
+    assert params["period"] == "CustomDate"
+    assert params["startdate"] == "20240101"
+    assert params["enddate"] == "20241231"
+
+
+def test_send_flex_request_omits_period_when_dates_missing(
+    stub_request_xml: dict[str, Any],
+) -> None:
+    config = QueryConfig(name="trades", query_id="1496910")
+    send_flex_request(config, "TOKEN", None, None)
+    params = stub_request_xml["params"]
+    assert "period" not in params
+    assert "startdate" not in params
+    assert "enddate" not in params


### PR DESCRIPTION
## Problem
`scripts/backfill_options.py` returns `parsed=0` for any historical date range. Probe revealed IBKR's response carries `period="Last365CalendarDays"` and `fromDate=2025-05-05` regardless of supplied URL dates.

Per IBKR Flex Web Service Guide, `startdate`/`enddate` are only honored when `period=CustomDate` is also supplied.

## Fix
`send_flex_request` now adds `period=CustomDate` whenever both dates are supplied. Verified live — URL now reads:

```
?t=***&q=1496910&v=3&period=CustomDate&startdate=20240601&enddate=20240630
```

(separate `1001` throttle is unrelated, tracked by #257)

## Tests
- `tests/test_flex_send_request.py` — 2 new tests covering both branches
- All existing backfill/options-sync tests still pass

Closes #268.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>