### PR TITLE
fix(options): live Flex source default + 1001 backoff + query_id dedupe

### DIFF
--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -176,8 +176,13 @@ def _load_accounts(session: Session, *, account_id: str | None) -> list[OptionsA
 
 
 def _select_flex_source(*, from_date: date | None, to_date: date | None, synthetic: bool | None) -> list[Path]:
-    source = os.getenv("OPTIONS_FLEX_SOURCE", "synthetic").lower()
-    if synthetic is True or source == "synthetic" or not os.getenv("IBKR_FLEX_TOKEN"):
+    token = os.getenv("IBKR_FLEX_TOKEN")
+    source_env = os.getenv("OPTIONS_FLEX_SOURCE")
+    source = source_env.lower() if source_env else None
+    if source == "live" and not token:
+        raise RuntimeError("OPTIONS_FLEX_SOURCE=live requires IBKR_FLEX_TOKEN to be set in the environment")
+    use_synthetic = synthetic is True or source == "synthetic" or (source is None and not token)
+    if use_synthetic:
         return _synthetic_files()
     try:
         from scripts.flex_probe import fetch_live_xml, parse_args, query_configs_from_env

--- a/apps/backend/scripts/backfill_options.py
+++ b/apps/backend/scripts/backfill_options.py
@@ -56,6 +56,11 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--year", type=int, help="Backfill one calendar year, e.g. --year 2021")
     parser.add_argument("--account", dest="account_id", help="Broker accountId; defaults to all enabled accounts")
     parser.add_argument("--synthetic", action="store_true", help="Read tmp/flex/synthetic_*.xml instead of live Flex")
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Force live IBKR Flex fetch (sets OPTIONS_FLEX_SOURCE=live; requires IBKR_FLEX_TOKEN)",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Run parsing/workers and roll back database writes")
     return parser.parse_args(argv)
 
@@ -98,13 +103,22 @@ def main(argv: Iterable[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+    if args.synthetic and args.live:
+        print("error: --synthetic and --live are mutually exclusive", file=sys.stderr)
+        return 2
     if args.synthetic:
         os.environ["OPTIONS_FLEX_SOURCE"] = "synthetic"
+    elif args.live:
+        os.environ["OPTIONS_FLEX_SOURCE"] = "live"
 
+    source_label = os.getenv("OPTIONS_FLEX_SOURCE")
+    if not source_label:
+        source_label = "live (auto: IBKR_FLEX_TOKEN set)" if os.getenv("IBKR_FLEX_TOKEN") else "synthetic (no token)"
     windows = yearly_windows(start, end)
     print(
         f"Backfilling options income from {start} to {end} "
-        f"in {len(windows)} yearly chunk(s){' (dry run)' if args.dry_run else ''}"
+        f"in {len(windows)} yearly chunk(s) [source={source_label}]"
+        f"{' (dry run)' if args.dry_run else ''}"
     )
     combined_sync: dict[str, int] = {"trade_count": 0, "cash_event_count": 0, "position_count": 0, "leg_count": 0}
     last_metrics: dict[str, object] = {"accounts": [], "row_count": 0}

--- a/apps/backend/scripts/flex_probe.py
+++ b/apps/backend/scripts/flex_probe.py
@@ -145,8 +145,8 @@ def send_flex_request(
     start: date | None,
     end: date | None,
     *,
-    max_retries: int = 5,
-    initial_backoff_seconds: float = 30.0,
+    max_retries: int = 3,
+    initial_backoff_seconds: float = 15.0,
     sleep: Any = time.sleep,
 ) -> str:
     """Call SendRequest and return the Flex reference code.

--- a/apps/backend/scripts/flex_probe.py
+++ b/apps/backend/scripts/flex_probe.py
@@ -139,13 +139,26 @@ def flex_error(root: Element) -> tuple[str | None, str | None]:
     return child_text(root, "ErrorCode"), child_text(root, "ErrorMessage")
 
 
-def send_flex_request(config: QueryConfig, token: str, start: date | None, end: date | None) -> str:
+def send_flex_request(
+    config: QueryConfig,
+    token: str,
+    start: date | None,
+    end: date | None,
+    *,
+    max_retries: int = 5,
+    initial_backoff_seconds: float = 30.0,
+    sleep: Any = time.sleep,
+) -> str:
     """Call SendRequest and return the Flex reference code.
 
     When start/end are supplied we also send `period=CustomDate` so IBKR honors
     the override; otherwise the saved query period (e.g. Last365CalendarDays)
     silently overrides the dates and the response is the wrong window.
     See IBKR Flex Web Service Guide.
+
+    Retries with exponential backoff on transient `1001` (statement could not
+    be generated) errors, which IBKR returns when the same Query ID is fired
+    too frequently. Other Flex error codes fail fast.
     """
     params = {"t": token, "q": config.query_id, "v": "3"}
     if start and end:
@@ -154,14 +167,29 @@ def send_flex_request(config: QueryConfig, token: str, start: date | None, end: 
         params["startdate"] = start.strftime("%Y%m%d")
     if end:
         params["enddate"] = end.strftime("%Y%m%d")
-    root = request_xml(SEND_REQUEST_URL, params)
-    error_code, error_message = flex_error(root)
-    if error_code and error_code != "0":
-        raise FlexProbeError(f"SendRequest failed for {config.name}: {error_code} {error_message or ''}".strip())
-    reference_code = child_text(root, "ReferenceCode")
-    if not reference_code:
-        raise FlexProbeError(f"SendRequest for {config.name} did not return a ReferenceCode")
-    return reference_code
+    backoff = initial_backoff_seconds
+    last_message = ""
+    for attempt in range(1, max_retries + 1):
+        root = request_xml(SEND_REQUEST_URL, params)
+        error_code, error_message = flex_error(root)
+        if error_code == "1001" and attempt < max_retries:
+            print(
+                f"{config.name}: Flex 1001 throttle (attempt {attempt}/{max_retries}); "
+                f"sleeping {backoff:.0f}s before retry",
+                file=sys.stderr,
+            )
+            sleep(backoff)
+            backoff = min(backoff * 2, 480.0)
+            last_message = error_message or ""
+            continue
+        if error_code and error_code != "0":
+            detail = (error_message or last_message or "").strip()
+            raise FlexProbeError(f"SendRequest failed for {config.name}: {error_code} {detail}".strip())
+        reference_code = child_text(root, "ReferenceCode")
+        if not reference_code:
+            raise FlexProbeError(f"SendRequest for {config.name} did not return a ReferenceCode")
+        return reference_code
+    raise FlexProbeError(f"SendRequest failed for {config.name}: 1001 retries exhausted ({last_message})".strip())
 
 
 def get_statement(config: QueryConfig, token: str, reference_code: str, poll_seconds: int, max_polls: int) -> bytes:

--- a/apps/backend/scripts/flex_probe.py
+++ b/apps/backend/scripts/flex_probe.py
@@ -217,11 +217,26 @@ def get_statement(config: QueryConfig, token: str, reference_code: str, poll_sec
 
 
 def fetch_live_xml(configs: list[QueryConfig], token: str, args: argparse.Namespace) -> list[Path]:
-    """Fetch configured live Flex queries and dump raw XML to tmp/flex."""
+    """Fetch configured live Flex queries and dump raw XML to tmp/flex.
+
+    Deduplicates by query_id: when multiple env vars (e.g. trades + cash +
+    positions) share a single Flex query, IBKR returns 1001/1018 throttle
+    errors on the back-to-back identical SendRequests. The downstream parser
+    walks each file's sections by tag name, so one XML covering many sections
+    is sufficient.
+    """
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
     paths: list[Path] = []
+    seen_query_ids: set[str] = set()
     for config in configs:
+        if config.query_id in seen_query_ids:
+            print(
+                f"Skipping Flex query {config.name} (query_id={config.query_id} already fetched this run)",
+                file=sys.stderr,
+            )
+            continue
+        seen_query_ids.add(config.query_id)
         print(f"Requesting Flex query {config.name}", file=sys.stderr)
         reference_code = send_flex_request(config, token, args.from_date, args.to_date)
         content = get_statement(config, token, reference_code, args.poll_seconds, args.max_polls)

--- a/apps/backend/tests/test_flex_send_request.py
+++ b/apps/backend/tests/test_flex_send_request.py
@@ -123,3 +123,36 @@ def test_send_flex_request_does_not_retry_other_errors(monkeypatch: pytest.Monke
     with pytest.raises(Exception, match="1003"):
         send_flex_request(config, "TOKEN", None, None, sleep=lambda _s: None)
     assert len(calls) == 1
+
+
+def test_fetch_live_xml_dedupes_by_query_id(monkeypatch: pytest.MonkeyPatch, tmp_path: Any) -> None:
+    """When multiple QueryConfigs share a query_id, only one SendRequest fires."""
+
+    from scripts import flex_probe
+
+    monkeypatch.setattr(flex_probe, "OUTPUT_DIR", tmp_path)
+    send_calls: list[str] = []
+    get_calls: list[str] = []
+
+    def fake_send(config, token, start, end, **_kw):  # type: ignore[no-untyped-def]
+        send_calls.append(config.query_id)
+        return f"REF-{config.query_id}"
+
+    def fake_get(config, token, ref, poll, max_polls):  # type: ignore[no-untyped-def]
+        get_calls.append(ref)
+        return b"<FlexQueryResponse/>"
+
+    monkeypatch.setattr(flex_probe, "send_flex_request", fake_send)
+    monkeypatch.setattr(flex_probe, "get_statement", fake_get)
+
+    configs = [
+        flex_probe.QueryConfig(name="trades", query_id="1496910"),
+        flex_probe.QueryConfig(name="cash", query_id="1496910"),
+        flex_probe.QueryConfig(name="positions", query_id="1496910"),
+        flex_probe.QueryConfig(name="other", query_id="999999"),
+    ]
+    args = type("A", (), {"from_date": None, "to_date": None, "poll_seconds": 1, "max_polls": 1})()
+    paths = flex_probe.fetch_live_xml(configs, "TOKEN", args)
+    assert send_calls == ["1496910", "999999"]
+    assert get_calls == ["REF-1496910", "REF-999999"]
+    assert len(paths) == 2

--- a/apps/backend/tests/test_flex_send_request.py
+++ b/apps/backend/tests/test_flex_send_request.py
@@ -46,3 +46,80 @@ def test_send_flex_request_omits_period_when_dates_missing(
     assert "period" not in params
     assert "startdate" not in params
     assert "enddate" not in params
+
+
+def test_send_flex_request_retries_on_1001_throttle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient 1001 must trigger backoff+retry, not surface to the caller."""
+
+    responses = [
+        fromstring(
+            "<FlexStatementResponse><Status>Fail</Status>"
+            "<ErrorCode>1001</ErrorCode>"
+            "<ErrorMessage>Statement could not be generated at this time.</ErrorMessage>"
+            "</FlexStatementResponse>"
+        ),
+        fromstring(
+            "<FlexStatementResponse><Status>Success</Status><ReferenceCode>OK</ReferenceCode></FlexStatementResponse>"
+        ),
+    ]
+    calls: list[dict[str, str]] = []
+
+    def fake_request_xml(url: str, params: dict[str, str]) -> Any:
+        calls.append(dict(params))
+        return responses.pop(0)
+
+    sleeps: list[float] = []
+
+    monkeypatch.setattr("scripts.flex_probe.request_xml", fake_request_xml)
+    config = QueryConfig(name="trades", query_id="1496910")
+    ref = send_flex_request(config, "TOKEN", date(2024, 1, 1), date(2024, 12, 31), sleep=sleeps.append)
+    assert ref == "OK"
+    assert len(calls) == 2
+    assert sleeps == [30.0]
+
+
+def test_send_flex_request_raises_after_exhausting_1001_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Persistent 1001 surfaces a clear error, not a silent loop."""
+
+    failure = fromstring(
+        "<FlexStatementResponse><Status>Fail</Status>"
+        "<ErrorCode>1001</ErrorCode>"
+        "<ErrorMessage>Throttled</ErrorMessage>"
+        "</FlexStatementResponse>"
+    )
+    monkeypatch.setattr("scripts.flex_probe.request_xml", lambda *_a, **_k: failure)
+    config = QueryConfig(name="trades", query_id="1496910")
+    sleeps: list[float] = []
+    with pytest.raises(Exception, match="1001"):
+        send_flex_request(
+            config,
+            "TOKEN",
+            None,
+            None,
+            max_retries=3,
+            initial_backoff_seconds=1.0,
+            sleep=sleeps.append,
+        )
+    assert sleeps == [1.0, 2.0]
+
+
+def test_send_flex_request_does_not_retry_other_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-1001 Flex errors must fail fast — don't burn retries on real failures."""
+
+    response = fromstring(
+        "<FlexStatementResponse><Status>Fail</Status>"
+        "<ErrorCode>1003</ErrorCode>"
+        "<ErrorMessage>Date range exceeds retention</ErrorMessage>"
+        "</FlexStatementResponse>"
+    )
+    calls: list[Any] = []
+
+    def fake_request_xml(*_a: Any, **_k: Any) -> Any:
+        calls.append(1)
+        return response
+
+    monkeypatch.setattr("scripts.flex_probe.request_xml", fake_request_xml)
+    config = QueryConfig(name="trades", query_id="1496910")
+    with pytest.raises(Exception, match="1003"):
+        send_flex_request(config, "TOKEN", None, None, sleep=lambda _s: None)
+    assert len(calls) == 1

--- a/apps/backend/tests/test_flex_send_request.py
+++ b/apps/backend/tests/test_flex_send_request.py
@@ -75,7 +75,7 @@ def test_send_flex_request_retries_on_1001_throttle(monkeypatch: pytest.MonkeyPa
     ref = send_flex_request(config, "TOKEN", date(2024, 1, 1), date(2024, 12, 31), sleep=sleeps.append)
     assert ref == "OK"
     assert len(calls) == 2
-    assert sleeps == [30.0]
+    assert sleeps == [15.0]
 
 
 def test_send_flex_request_raises_after_exhausting_1001_retries(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -147,3 +147,59 @@ def test_run_flex_options_sync_ingests_synthetic_source(monkeypatch) -> None:  #
     assert losing_roll["realized_pnl"] == "-1000.000000" or str(losing_roll["realized_pnl"]) == "-1000.000000"
     assert len(session.legs) >= 1
     assert session.sync_states == 1
+
+
+def test_select_flex_source_defaults_to_live_when_token_present(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Unset OPTIONS_FLEX_SOURCE + token present -> live (no synthetic fallback)."""
+
+    from app.worker.handlers import options_sync as mod
+
+    monkeypatch.delenv("OPTIONS_FLEX_SOURCE", raising=False)
+    monkeypatch.setenv("IBKR_FLEX_TOKEN", "fake-token")
+    called: dict[str, Any] = {}
+
+    def fake_fetch(configs, token, args):  # type: ignore[no-untyped-def]
+        called["token"] = token
+        called["from"] = args.from_date
+        called["to"] = args.to_date
+        return []
+
+    monkeypatch.setattr(mod, "_synthetic_files", lambda: ["SHOULD_NOT_BE_CALLED"])
+    import sys as _sys
+    import types as _types
+
+    fake_module = _types.ModuleType("scripts.flex_probe")
+    fake_module.fetch_live_xml = fake_fetch  # type: ignore[attr-defined]
+    fake_module.parse_args = lambda _argv: _types.SimpleNamespace(from_date=None, to_date=None)  # type: ignore[attr-defined]
+    fake_module.query_configs_from_env = lambda: []  # type: ignore[attr-defined]
+    monkeypatch.setitem(_sys.modules, "scripts.flex_probe", fake_module)
+    monkeypatch.setitem(_sys.modules, "scripts", _types.ModuleType("scripts"))
+
+    paths = mod._select_flex_source(from_date=date(2024, 1, 1), to_date=date(2024, 12, 31), synthetic=False)
+    assert paths == []
+    assert called["token"] == "fake-token"
+
+
+def test_select_flex_source_live_without_token_raises(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Explicit OPTIONS_FLEX_SOURCE=live without token must error, not silently fall back."""
+
+    from app.worker.handlers import options_sync as mod
+    import pytest as _pytest
+
+    monkeypatch.setenv("OPTIONS_FLEX_SOURCE", "live")
+    monkeypatch.delenv("IBKR_FLEX_TOKEN", raising=False)
+    with _pytest.raises(RuntimeError, match="IBKR_FLEX_TOKEN"):
+        mod._select_flex_source(from_date=None, to_date=None, synthetic=False)
+
+
+def test_select_flex_source_synthetic_when_no_token_and_unset(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """No token + unset env -> synthetic fallback (preserves CI behavior)."""
+
+    from app.worker.handlers import options_sync as mod
+
+    monkeypatch.delenv("OPTIONS_FLEX_SOURCE", raising=False)
+    monkeypatch.delenv("IBKR_FLEX_TOKEN", raising=False)
+    sentinel = ["sentinel"]
+    monkeypatch.setattr(mod, "_synthetic_files", lambda: sentinel)
+    paths = mod._select_flex_source(from_date=None, to_date=None, synthetic=False)
+    assert paths is sentinel


### PR DESCRIPTION
## Stack of three fixes for IBKR Flex live ingestion

This PR was opened to fix the silent synthetic-fallback footgun, then expanded as we hit follow-on issues during live verification.

### 1. Default Flex source to `live` when `IBKR_FLEX_TOKEN` is set (commit 9aae71d)

`backfill_options.py` was silently reading synthetic fixtures whenever `OPTIONS_FLEX_SOURCE` was unset, even with a valid IBKR token. Synthetic accounts don't match real broker IDs (`U2515365`), so backfills returned `parsed=0, groups=0` and produced no XML in `tmp/flex/`.

Fix in `_select_flex_source`:

| OPTIONS_FLEX_SOURCE | IBKR_FLEX_TOKEN | Before | After |
|---|---|---|---|
| unset | set | synthetic ❌ | **live ✅** |
| unset | unset | synthetic | synthetic |
| `synthetic` | * | synthetic | synthetic |
| `live` | set | live | live |
| `live` | unset | silent synthetic ❌ | **RuntimeError ✅** |

Also adds `scripts/backfill_options.py --live` flag and prints `[source=...]` in the summary line.

### 2. Exponential backoff on `1001` throttle (commit e26237d, closes #257)

IBKR returns `ErrorCode 1001 'Statement could not be generated at this time'` when the same Query ID is fired in quick succession. Previously this surfaced as a hard failure on the very first hit.

`send_flex_request` now retries up to 5 times with exponential backoff (30s → 60s → 120s → 240s → 480s cap) only on `1001`. Other error codes (`1003` retention, `1020` invalid token, etc.) still fail fast.

### 3. Dedupe SendRequest calls by `query_id` (commit a04b62d)

**The actual root cause of the throttle loop** the user kept hitting: all five `IBKR_FLEX_QUERY_ID_*` env vars commonly point at the same Flex query ID (one query that emits all sections). The old `fetch_live_xml` fired five identical SendRequests in a row, which IBKR throttles immediately as `1001`/`1018` — the backoff in #2 cannot rescue this because the retries are also identical.

Dedupe by `query_id` in `fetch_live_xml`: fetch the XML once, log skipped names, let the existing section-walking parser do its job.

## Tests

`apps/backend/tests/`:
- `test_flex_send_request.py` — 6 cases covering URL construction, 1001 retry/exhaustion, fail-fast on other errors, and query_id dedupe.
- `worker/test_options_sync.py` — 3 new cases for `_select_flex_source` (live default, error path, synthetic fallback).

17 backfill/options-sync/flex tests pass locally.