### PR TITLE
ci(e2e): fail-fast secrets guard — fixes #162

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -63,6 +63,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Guard — required secrets must be present
+        env:
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$E2E_SUPABASE_URL" ]               && missing+=(E2E_SUPABASE_URL)
+          [ -z "$E2E_SUPABASE_ANON_KEY" ]          && missing+=(E2E_SUPABASE_ANON_KEY)
+          [ -z "$E2E_SUPABASE_SERVICE_ROLE_KEY" ]  && missing+=(E2E_SUPABASE_SERVICE_ROLE_KEY)
+          if [ ${#missing[@]} -gt 0 ]; then
+            for s in "${missing[@]}"; do
+              echo "::error::Required secret '$s' is empty or not set. Add it under Settings → Secrets → Actions."
+            done
+            exit 1
+          fi
+          echo "✅ All required E2E secrets present."
+
       - name: Setup Node 20
         uses: actions/setup-node@v6
         with:
@@ -126,6 +145,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Guard — required secrets must be present
+        env:
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$E2E_SUPABASE_URL" ]               && missing+=(E2E_SUPABASE_URL)
+          [ -z "$E2E_SUPABASE_ANON_KEY" ]          && missing+=(E2E_SUPABASE_ANON_KEY)
+          [ -z "$E2E_SUPABASE_SERVICE_ROLE_KEY" ]  && missing+=(E2E_SUPABASE_SERVICE_ROLE_KEY)
+          if [ ${#missing[@]} -gt 0 ]; then
+            for s in "${missing[@]}"; do
+              echo "::error::Required secret '$s' is empty or not set. Add it under Settings → Secrets → Actions."
+            done
+            exit 1
+          fi
+          echo "✅ All required E2E secrets present."
 
       - name: Setup Node 20
         uses: actions/setup-node@v6
@@ -213,6 +251,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Guard — required secrets must be present
+        env:
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
+        shell: bash
+        run: |
+          missing=()
+          [ -z "$E2E_SUPABASE_URL" ]               && missing+=(E2E_SUPABASE_URL)
+          [ -z "$E2E_SUPABASE_ANON_KEY" ]          && missing+=(E2E_SUPABASE_ANON_KEY)
+          [ -z "$E2E_SUPABASE_SERVICE_ROLE_KEY" ]  && missing+=(E2E_SUPABASE_SERVICE_ROLE_KEY)
+          if [ ${#missing[@]} -gt 0 ]; then
+            for s in "${missing[@]}"; do
+              echo "::error::Required secret '$s' is empty or not set. Add it under Settings → Secrets → Actions."
+            done
+            exit 1
+          fi
+          echo "✅ All required E2E secrets present."
 
       - name: Setup Node 20
         uses: actions/setup-node@v6

--- a/.squad/decisions/inbox/kujan-r2-secrets-and-migrations-2026-05-05.md
+++ b/.squad/decisions/inbox/kujan-r2-secrets-and-migrations-2026-05-05.md
@@ -1,0 +1,53 @@
+# Kujan R2 — secrets audit + CI migrations — 2026-05-05
+
+## Task A — #162 secrets audit
+
+### Findings
+
+Root cause: the three E2E Supabase secrets were absent during the 03:00 UTC nightly run on 2026-05-03 because they had been rotated and not yet re-added. The secrets were recreated later that morning (07:40–08:01 UTC).
+
+| Secret | Status | Recreated |
+|--------|--------|-----------|
+| `E2E_SUPABASE_URL` | ✅ Set | 2026-05-03 07:40 UTC |
+| `E2E_SUPABASE_ANON_KEY` | ✅ Set | 2026-05-03 07:40 UTC |
+| `E2E_SUPABASE_SERVICE_ROLE_KEY` | ✅ Set | 2026-05-03 08:01 UTC |
+
+All three secrets are repo-scoped (not environment-gated). Secret names in `playwright-e2e.yml` match exactly. No scope misconfiguration found.
+
+### Action
+
+- Commented on #162 with audit findings.
+- Added fail-fast guard step to all three E2E jobs (`e2e-smoke`, `e2e-full`, `e2e-dispatch`) in `playwright-e2e.yml`. Guard emits `::error::` annotations naming each missing secret and exits 1 before installing Node — prevents full suite running to red on a config failure.
+- PR #274 (`squad/162-e2e-secrets-guard`) opened.
+- Issue #162 **closed**.
+
+## Task B — #170 CI migrations
+
+### Approach
+
+Created `.github/workflows/supabase-migrations.yml`.
+
+**Trigger logic:**
+
+| Event | Behaviour |
+|-------|-----------|
+| `push` to `main` + `[apply-migrations]` commit marker | Apply |
+| `push` to `main` without marker | Diff only (safe default) |
+| `workflow_dispatch` dry_run=false | Apply |
+| `workflow_dispatch` dry_run=true | Diff only |
+
+**Safety guards:**
+- Secrets guard (same pattern as #274) — fails fast if `SUPABASE_ACCESS_TOKEN` or `SUPABASE_DB_PASSWORD` are missing.
+- `supabase migration list --linked` diff always shown before any apply.
+- `concurrency: cancel-in-progress: false` — prevents two migration runs overlapping.
+- Uses `supabase db push --linked` (direct connection via Supabase CLI, not the PgBouncer pooler) — consistent with decisions.md connection string strategy.
+
+**Required secrets:** `SUPABASE_ACCESS_TOKEN`, `SUPABASE_DB_PASSWORD`.
+
+### Design choice: opt-in marker vs always-auto-apply
+
+Chose the `[apply-migrations]` marker rather than always-auto-apply. Rationale: not every merge that touches migration files should immediately hit prod (e.g. draft work, squash merges). The marker is a deliberate, visible signal in git history. Emergency apply remains available via `workflow_dispatch` with zero friction.
+
+### PR
+
+PR #275 (`squad/170-ci-auto-migrations`) opened.


### PR DESCRIPTION
## Summary

Working as **Kujan** (DevOps/Platform).

Adds a `Guard — required secrets must be present` step as the **second** step (after checkout) in all three E2E jobs: PR smoke, nightly full suite, and manual dispatch.

## Root Cause (#162)

On 2026-05-03 the nightly ran at **03:00 UTC**. The three Supabase E2E secrets were empty — they had been rotated and were only re-added at 07:40–08:01 UTC the same morning. With no guard, the full test suite ran to red with opaque test-level errors (`NEXT_PUBLIC_SUPABASE_URL must be set`) rather than a clear infrastructure failure.

## What Changed

``.github/workflows/playwright-e2e.yml`` — all three jobs (`e2e-smoke`, `e2e-full`, `e2e-dispatch`):

```bash
# Guard step checks E2E_SUPABASE_URL, E2E_SUPABASE_ANON_KEY, E2E_SUPABASE_SERVICE_ROLE_KEY
# Emits ::error:: annotation for each missing secret, then exits 1
```

The job fails immediately before installing Node/npm, saving ~3–4 min of wasted runner time and surfacing the correct cause in the Actions UI.

## Secrets Audit (Task A findings)

| Secret | Status | Updated |
|--------|--------|---------|
| `E2E_SUPABASE_URL` | ✅ Set | 2026-05-03 07:40 UTC |
| `E2E_SUPABASE_ANON_KEY` | ✅ Set | 2026-05-03 07:40 UTC |
| `E2E_SUPABASE_SERVICE_ROLE_KEY` | ✅ Set | 2026-05-03 08:01 UTC |

All three secrets are repo-scoped (not environment-gated), matching their usage in the workflow. Names align exactly. No scope misconfiguration.

Closes #162