### PR TITLE
ci(migrations): auto-apply Supabase migrations on merge to main — closes #170

### DIFF
--- a/.github/workflows/supabase-migrations.yml
+++ b/.github/workflows/supabase-migrations.yml
@@ -77,10 +77,17 @@ jobs:
       # pushing schema changes. An explicit opt-in is required for push events.
       - name: Determine apply mode
         id: mode
+        # Security: user-controlled fields (commit message) and workflow inputs are
+        # passed via step-scoped env vars, never inlined into the run: body.
+        # Ref: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          GH_INPUT_DRY_RUN: ${{ inputs.dry_run }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            if [ "${{ inputs.dry_run }}" = "true" ]; then
+          if [ "$GH_EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$GH_INPUT_DRY_RUN" = "true" ]; then
               echo "apply=false" >> "$GITHUB_OUTPUT"
               echo "reason=workflow_dispatch dry-run requested" >> "$GITHUB_OUTPUT"
             else
@@ -89,7 +96,6 @@ jobs:
             fi
           else
             # push event — check commit message for opt-in marker
-            COMMIT_MSG="${{ github.event.head_commit.message }}"
             if echo "$COMMIT_MSG" | grep -qF '[apply-migrations]'; then
               echo "apply=true"  >> "$GITHUB_OUTPUT"
               echo "reason=commit message contains [apply-migrations] marker" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Working as **Kujan** (DevOps/Platform).

Adds `.github/workflows/supabase-migrations.yml` — a CI workflow to auto-apply Supabase migrations to production on merge to `main`.

## Problem (#170)

The P1 outage ('Failed to save snapshot') was caused by migration `finance_snapshots_household_pk_fix` sitting in the repo for **2 days** without being deployed to production. Every save 400'd because the DB lacked the PK the app expected.

## Design

### Triggers

| Event | Behaviour |
|-------|-----------|
| `push` to `main` + `[apply-migrations]` in commit message | ✅ Apply |
| `push` to `main` without marker | 🔍 Diff only (show pending, skip apply) |
| `workflow_dispatch` (dry_run=false, default) | ✅ Apply |
| `workflow_dispatch` (dry_run=true) | 🔍 Diff only |

The opt-in marker on push events prevents a rebase/squash that incidentally touches migration files from silently pushing schema changes. An explicit author decision is required.

### Safety Guards

1. **Secrets guard** — fails immediately if `SUPABASE_ACCESS_TOKEN` or `SUPABASE_DB_PASSWORD` are missing (same pattern as #274 for E2E).
2. **Pending migrations diff** — `supabase migration list --linked` always runs and is visible in the Actions log before any apply step.
3. **Concurrency lock** — `cancel-in-progress: false` on the `supabase-migrations-prod` group prevents two runs overlapping mid-migration.
4. **Direct connection** — `supabase db push --linked` uses the Supabase REST/management path (not the transaction pooler), matching the `DIRECT_DATABASE_URL` pattern from decisions.md.

### Required Secrets

| Secret | Purpose |
|--------|---------|
| `SUPABASE_ACCESS_TOKEN` | Supabase management API auth |
| `SUPABASE_DB_PASSWORD` | DB password for the linked project |

Add both under Settings → Secrets and Variables → Actions.

## Acceptance Criteria (from #170)

- [x] `.github/workflows/supabase-migrations.yml` created
- [x] New migrations auto-apply on merge to main (with `[apply-migrations]` marker)
- [x] Failures surface as required checks
- [x] Required secrets documented (in workflow header comments + this PR)
- [x] `workflow_dispatch` for manual replay

## Design Choice: Opt-in Marker vs Always-Auto-Apply

I chose the **`[apply-migrations]` marker** approach rather than always-auto-apply because:
- Not every migration PR wants immediate prod deploy (e.g. draft work merged to main)
- The marker is a deliberate, visible signal in git history
- Emergency manual apply still works via `workflow_dispatch` with zero friction

If the team prefers always-auto-apply (simpler but less control), remove the `[apply-migrations]` check from the push branch — the diff-only fallback can be dropped.

Closes #170