### PR TITLE
feat(options): harden STK assignment pairing using IBKR notes/codes (closes #265)

### DIFF
--- a/apps/backend/app/services/options/flex_parser.py
+++ b/apps/backend/app/services/options/flex_parser.py
@@ -23,7 +23,23 @@ SECTION_ROW_NAMES = {
 }
 MONEY_ZERO = Decimal("0")
 ASSIGNMENT_TRANSACTION_TYPES = {"assignment", "exercise"}
+# IBKR notes codes that appear on assignment/exercise legs.
+# The `notes` attribute is a semicolon-separated string, e.g. "A;C".
+NOTES_CODE_SEPARATOR = ";"
+NOTES_ASSIGNMENT_CODES: frozenset[str] = frozenset({"a", "ex"})  # A=Assignment, Ex=Exercise
 logger = logging.getLogger(__name__)
+
+
+def _notes_codes(notes_str: str | None) -> frozenset[str]:
+    """Return the normalised (lowercase) set of code tokens from an IBKR notes string."""
+    if not notes_str:
+        return frozenset()
+    return frozenset(tok.strip().lower() for tok in notes_str.split(NOTES_CODE_SEPARATOR) if tok.strip())
+
+
+def _notes_has_assignment_code(notes_str: str | None) -> bool:
+    """Return True if the notes field contains an assignment (A) or exercise (Ex) code."""
+    return bool(_notes_codes(notes_str) & NOTES_ASSIGNMENT_CODES)
 
 
 class FlexParserError(RuntimeError):
@@ -140,6 +156,11 @@ class _AssignmentOptionLeg:
     option_trade_id: str
     transaction_type: str
     currency: str
+    # Order-level identifiers for hardened pairing (IBKR Phase 1 / Gap #ibOrderID).
+    # May be None for legacy data where the field was not included in the Flex query.
+    ib_order_id: str | None = None
+    # Raw notes string from the OPT or EAE row, e.g. "A;C" for assigned-close.
+    opt_notes: str | None = None
 
 
 def parse_flex_files(paths: Iterable[Path], account_id: str | None = None) -> FlexParseResult:
@@ -319,23 +340,10 @@ def _assignment_synthetic_cash_events(
         option_leg = _assignment_option_leg(eae, option_rows_by_trade_id)
         if option_leg is None:
             continue
-        matches = [row for row in stock_trade_rows if _stock_row_matches_assignment(row, option_leg)]
-        if len(matches) > 1:
-            counts["assignment_synthetic_skipped_ambiguous"] += 1
-            logger.warning(
-                "Skipping ambiguous assignment synthetic cash event",
-                extra={
-                    "account_id": option_leg.account_id,
-                    "underlying": option_leg.underlying_symbol,
-                    "trade_date": option_leg.trade_date.isoformat(),
-                    "eae_trade_id": option_leg.eae_trade_id,
-                    "stock_trade_ids": [_optional_text(row.get("tradeID")) for row in matches],
-                },
-            )
+        matched_row, tier = _select_best_pairing_with_tier(stock_trade_rows, option_leg, counts)
+        if matched_row is None:
             continue
-        if not matches:
-            continue
-        event = _synthetic_cash_from_stock_row(option_leg, matches[0], counts)
+        event = _synthetic_cash_from_stock_row(option_leg, matched_row, counts, pair_method=tier)
         if event is None or event.source_transaction_id in seen_source_ids:
             continue
         seen_source_ids.add(event.source_transaction_id)
@@ -363,6 +371,12 @@ def _assignment_option_leg(
         return None
     option_row = option_matches[0]
     trade_time = _datetime_attr(option_row, ("dateTime",), fallback_date=None)
+    # Prefer ibOrderID from the OPT row; fall back to the EAE row.
+    # raw_payload["notes"] is available at trade.raw_payload["notes"] per Hockney Phase 0 doc.
+    ib_order_id = _optional_text(
+        option_row.get("ibOrderID") or option_row.get("orderID") or eae.get("ibOrderID") or eae.get("orderID")
+    )
+    opt_notes = _optional_text(option_row.get("notes") or eae.get("notes"))
     return _AssignmentOptionLeg(
         account_id=_required_any(option_row, ("accountId",)),
         underlying_symbol=_required_any(option_row, ("underlyingSymbol", "symbol")),
@@ -376,10 +390,13 @@ def _assignment_option_leg(
         option_trade_id=_required_any(option_row, ("tradeID", "transactionID")),
         transaction_type=transaction_type or "Assignment",
         currency=_currency(option_row),
+        ib_order_id=ib_order_id,
+        opt_notes=opt_notes,
     )
 
 
-def _stock_row_matches_assignment(row: dict[str, str], option_leg: _AssignmentOptionLeg) -> bool:
+def _stock_row_heuristic_match(row: dict[str, str], option_leg: _AssignmentOptionLeg) -> bool:
+    """Original date + underlying + strike + quantity heuristic (kept as fallback)."""
     if _optional_text(row.get("assetCategory")) != "STK":
         return False
     account_id = _optional_text(row.get("accountId"))
@@ -395,8 +412,105 @@ def _stock_row_matches_assignment(row: dict[str, str], option_leg: _AssignmentOp
     )
 
 
+def _stock_row_matches_assignment(row: dict[str, str], option_leg: _AssignmentOptionLeg) -> bool:
+    """Backwards-compatible shim — delegates to the heuristic tier."""
+    return _stock_row_heuristic_match(row, option_leg)
+
+
+def _select_best_pairing_with_tier(
+    stock_trade_rows: list[dict[str, str]],
+    option_leg: _AssignmentOptionLeg,
+    counts: dict[str, int],
+) -> tuple[dict[str, str] | None, str]:
+    """Select the best matching STK row for an assignment OPT leg.
+
+    Pairing strategy (in priority order):
+
+    1. **order_id** — Both the OPT row and the STK row carry the same ``ibOrderID``
+       (or ``orderID``).  This is a definitive IBKR-level link and requires no
+       additional validation.
+
+    2. **heuristic_notes** — The classic date + underlying + strike + quantity
+       heuristic returns exactly one candidate *and* that candidate's ``notes``
+       field contains an assignment/exercise code (``A`` or ``Ex``).  The notes
+       code confirms the heuristic hit is genuinely an assignment leg.
+
+    3. **heuristic** — The classic heuristic returns exactly one candidate (legacy
+       behaviour).
+
+    When the heuristic returns multiple candidates the notes field is used to
+    *narrow* the set.  If exactly one candidate has a confirming notes code that
+    single candidate is chosen (tier ``heuristic_notes_narrowed``).  Otherwise the
+    situation is flagged as ambiguous and ``(None, "ambiguous")`` is returned.
+
+    Returns ``(matched_row, tier_name)`` or ``(None, "no_match"|"ambiguous")``.
+    """
+    # ── Tier 1: ibOrderID match ────────────────────────────────────────────────
+    if option_leg.ib_order_id:
+        order_matches = [
+            row
+            for row in stock_trade_rows
+            if _optional_text(row.get("assetCategory")) == "STK"
+            and _optional_text(row.get("accountId")) == option_leg.account_id
+            and _optional_text(row.get("ibOrderID") or row.get("orderID")) == option_leg.ib_order_id
+        ]
+        if len(order_matches) == 1:
+            counts["assignment_paired_by_order_id"] = counts.get("assignment_paired_by_order_id", 0) + 1
+            return (order_matches[0], "order_id")
+        if len(order_matches) > 1:
+            # Multiple STK rows with the same ibOrderID — data anomaly; fall through.
+            logger.warning(
+                "Multiple STK rows share ibOrderID — falling through to heuristic",
+                extra={
+                    "account_id": option_leg.account_id,
+                    "ib_order_id": option_leg.ib_order_id,
+                    "stock_trade_ids": [_optional_text(row.get("tradeID")) for row in order_matches],
+                },
+            )
+
+    # ── Tiers 2 & 3: heuristic (possibly narrowed by notes) ───────────────────
+    heuristic_matches = [row for row in stock_trade_rows if _stock_row_heuristic_match(row, option_leg)]
+
+    if not heuristic_matches:
+        return (None, "no_match")
+
+    if len(heuristic_matches) == 1:
+        stk_row = heuristic_matches[0]
+        if _notes_has_assignment_code(_optional_text(stk_row.get("notes"))):
+            counts["assignment_paired_by_notes"] = counts.get("assignment_paired_by_notes", 0) + 1
+            return (stk_row, "heuristic_notes")
+        counts["assignment_paired_by_heuristic"] = counts.get("assignment_paired_by_heuristic", 0) + 1
+        return (stk_row, "heuristic")
+
+    # Multiple heuristic matches — try to narrow by notes code.
+    notes_confirmed = [row for row in heuristic_matches if _notes_has_assignment_code(_optional_text(row.get("notes")))]
+    if len(notes_confirmed) == 1:
+        counts["assignment_paired_by_notes"] = counts.get("assignment_paired_by_notes", 0) + 1
+        return (notes_confirmed[0], "heuristic_notes_narrowed")
+
+    # Still ambiguous — flag for manual review.
+    counts["assignment_synthetic_skipped_ambiguous"] += 1
+    logger.warning(
+        "Skipping ambiguous assignment synthetic cash event",
+        extra={
+            "account_id": option_leg.account_id,
+            "underlying": option_leg.underlying_symbol,
+            "trade_date": option_leg.trade_date.isoformat(),
+            "eae_trade_id": option_leg.eae_trade_id,
+            "heuristic_candidate_count": len(heuristic_matches),
+            "notes_confirmed_count": len(notes_confirmed),
+            "stock_trade_ids": [_optional_text(row.get("tradeID")) for row in heuristic_matches],
+        },
+    )
+    return (None, "ambiguous")
+
+
 def _synthetic_cash_from_stock_row(
-    option_leg: _AssignmentOptionLeg, stock_row: dict[str, str], counts: dict[str, int]
+    option_leg: _AssignmentOptionLeg,
+    stock_row: dict[str, str],
+    counts: dict[str, int],
+    *,
+    pair_method: str = "heuristic",
 ) -> FlexCashTransaction | None:
     mtm_pnl = _optional_decimal(stock_row, "mtmPnl")
     close_price = _optional_decimal(stock_row, "closePrice")
@@ -434,6 +548,7 @@ def _synthetic_cash_from_stock_row(
         "quantity": str(quantity),
         "formula": formula,
         "transaction_type": option_leg.transaction_type,
+        "pair_method": pair_method,
     }
     return FlexCashTransaction(
         account_id=option_leg.account_id,

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -250,13 +250,21 @@ def _assignment_rows(
     strike: str,
     close: str,
     mtm: str | None = None,
+    opt_order_id: str | None = None,
+    stk_order_id: str | None = None,
+    opt_notes: str | None = None,
+    stk_notes: str | None = None,
 ) -> str:
     mtm_attr = f' mtmPnl="{mtm}"' if mtm is not None else ""
-    return f'''
-<Trade accountId="U1234567" assetCategory="OPT" currency="USD" symbol="{prefix} OPT" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-opt" multiplier="100" strike="{strike}" expiry="2026-01-17" dateTime="2026-01-17;120000" putCall="{right}" quantity="{opt_qty}" tradePrice="0" proceeds="0" netCash="0" fifoPnlRealized="0" />
-<Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="{prefix.upper()}" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-stk" multiplier="1" dateTime="2026-01-17;120000" quantity="{stk_qty}" tradePrice="{strike}" closePrice="{close}" proceeds="0" netCash="0"{mtm_attr} />
+    opt_order_attr = f' ibOrderID="{opt_order_id}"' if opt_order_id else ""
+    stk_order_attr = f' ibOrderID="{stk_order_id}"' if stk_order_id else ""
+    opt_notes_attr = f' notes="{opt_notes}"' if opt_notes else ""
+    stk_notes_attr = f' notes="{stk_notes}"' if stk_notes else ""
+    return f"""
+<Trade accountId="U1234567" assetCategory="OPT" currency="USD" symbol="{prefix} OPT" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-opt" multiplier="100" strike="{strike}" expiry="2026-01-17" dateTime="2026-01-17;120000" putCall="{right}" quantity="{opt_qty}" tradePrice="0" proceeds="0" netCash="0" fifoPnlRealized="0"{opt_order_attr}{opt_notes_attr} />
+<Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="{prefix.upper()}" underlyingSymbol="{prefix.upper()}" tradeID="{prefix}-stk" multiplier="1" dateTime="2026-01-17;120000" quantity="{stk_qty}" tradePrice="{strike}" closePrice="{close}" proceeds="0" netCash="0"{mtm_attr}{stk_order_attr}{stk_notes_attr} />
 <!--EAE {prefix}-opt {transaction}-->
-'''
+"""
 
 
 def _eae_row(group: str) -> str:
@@ -432,3 +440,253 @@ def test_phase0_opt_fields_extracted_from_assignment_stub(tmp_path: Path) -> Non
     assert synth.raw_payload["underlying"] == "SPY"
     assert synth.raw_payload["strike"] == "450"
     assert result.section_counts["assignment_synthetic_emitted"] == 1
+
+
+# ── Hardened pairing tests (Issue #265) ───────────────────────────────────────
+
+
+def test_pairing_uses_order_id_as_primary_key() -> None:
+    """ibOrderID match bypasses the heuristic and resolves definitively."""
+
+    output_dir = Path("tmp/test-pairing-order-id")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "order_id.xml"
+    path.write_text(
+        _flex_xml(
+            [
+                _assignment_rows(
+                    "spy-assign",
+                    transaction="Assignment",
+                    right="P",
+                    opt_qty="1",
+                    stk_qty="100",
+                    strike="450",
+                    close="420",
+                    mtm="-3000",
+                    opt_order_id="ORD-99901",
+                    stk_order_id="ORD-99901",
+                    opt_notes="A;C",
+                    stk_notes="A",
+                )
+            ]
+        )
+    )
+
+    parsed = parse_flex_files([path])
+    synthetics = [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"]
+
+    assert len(synthetics) == 1
+    assert synthetics[0].raw_payload["pair_method"] == "order_id"
+    assert synthetics[0].amount == Decimal("-3000")
+    assert parsed.section_counts.get("assignment_paired_by_order_id") == 1
+
+
+def test_pairing_order_id_resolves_same_day_multi_assignment_ambiguity() -> None:
+    """With ibOrderID, two same-day same-strike SPY assignments pair to their correct STK legs."""
+
+    output_dir = Path("tmp/test-pairing-order-id-multi")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "multi.xml"
+    # Two SPY short-put assignments on the same date, same strike, same quantity —
+    # the heuristic alone would flag them as ambiguous; ibOrderID resolves each cleanly.
+    rows_a = _assignment_rows(
+        "spy-a",
+        transaction="Assignment",
+        right="P",
+        opt_qty="1",
+        stk_qty="100",
+        strike="450",
+        close="420",
+        mtm="-3000",
+        opt_order_id="ORD-AAA",
+        stk_order_id="ORD-AAA",
+    )
+    rows_b = _assignment_rows(
+        "spy-b",
+        transaction="Assignment",
+        right="P",
+        opt_qty="1",
+        stk_qty="100",
+        strike="450",
+        close="420",
+        mtm="-3100",
+        opt_order_id="ORD-BBB",
+        stk_order_id="ORD-BBB",
+    )
+    # Rewrite underlyingSymbol to SPY in both sets to maximise heuristic collision.
+    for old, new in [("SPY-A", "SPY"), ("SPY-B", "SPY")]:
+        rows_a = rows_a.replace(old, new)
+        rows_b = rows_b.replace(old, new).replace(old.lower(), new.lower())
+    path.write_text(_flex_xml([rows_a, rows_b]))
+
+    parsed = parse_flex_files([path])
+    synthetics = [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"]
+
+    assert len(synthetics) == 2
+    assert all(c.raw_payload["pair_method"] == "order_id" for c in synthetics)
+    assert sorted(c.amount for c in synthetics) == [Decimal("-3100"), Decimal("-3000")]
+
+
+def test_pairing_exercise_pair_via_notes_code() -> None:
+    """Exercise (Ex) notes code on the STK row is recognised as an assignment-family code."""
+
+    output_dir = Path("tmp/test-pairing-exercise-notes")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "exercise.xml"
+    path.write_text(
+        _flex_xml(
+            [
+                _assignment_rows(
+                    "aapl-ex",
+                    transaction="Exercise",
+                    right="C",
+                    opt_qty="10",
+                    stk_qty="1000",
+                    strike="180",
+                    close="200",
+                    mtm="20000",
+                    stk_notes="Ex",
+                )
+            ]
+        )
+    )
+
+    parsed = parse_flex_files([path])
+    synthetics = [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"]
+
+    assert len(synthetics) == 1
+    assert synthetics[0].raw_payload["pair_method"] in {"heuristic_notes", "heuristic"}
+    assert synthetics[0].amount == Decimal("20000")
+
+
+def test_pairing_notes_narrows_ambiguous_heuristic_match() -> None:
+    """When two STK rows pass the heuristic, the one with notes='A' wins."""
+
+    output_dir = Path("tmp/test-pairing-notes-narrowing")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "narrowing.xml"
+    # Main assignment rows — STK leg has notes="A".
+    rows = _assignment_rows(
+        "qqqm",
+        transaction="Assignment",
+        right="P",
+        opt_qty="2",
+        stk_qty="200",
+        strike="100",
+        close="90",
+        mtm="-2000",
+        stk_notes="A",
+    )
+    # Inject a second STK row (same account/underlying/date/price/qty) WITHOUT notes.
+    noise_stk = (
+        '<Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="QQQM"'
+        ' underlyingSymbol="QQQM" tradeID="qqqm-stk-noise" multiplier="1"'
+        ' dateTime="2026-01-17;120000" quantity="200" tradePrice="100"'
+        ' closePrice="90" proceeds="0" netCash="0" />'
+    )
+    xml = _flex_xml([rows])
+    xml = xml.replace("</Trades>", noise_stk + "</Trades>")
+    path.write_text(xml)
+
+    parsed = parse_flex_files([path])
+    synthetics = [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"]
+
+    assert len(synthetics) == 1
+    assert synthetics[0].raw_payload["pair_method"] == "heuristic_notes_narrowed"
+    assert synthetics[0].raw_payload["stk_trade_id"] == "qqqm-stk"
+    assert synthetics[0].amount == Decimal("-2000")
+
+
+def test_pairing_expiration_emits_no_stk_leg() -> None:
+    """Expired options (transactionType=Expiration) are outside ASSIGNMENT_TRANSACTION_TYPES."""
+
+    output_dir = Path("tmp/test-pairing-expiration")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "expiry.xml"
+    xml = (
+        "<FlexQueryResponse><FlexStatements>"
+        '<FlexStatement accountId="U1234567" fromDate="20260101" toDate="20260131">'
+        "<Trades>"
+        '<Trade accountId="U1234567" assetCategory="OPT" currency="USD" symbol="IWM OPT"'
+        ' underlyingSymbol="IWM" tradeID="exp-opt-1" multiplier="100" strike="180"'
+        ' expiry="2026-01-17" dateTime="2026-01-17;160000" putCall="P"'
+        ' quantity="1" tradePrice="0" proceeds="0" netCash="0" fifoPnlRealized="0"'
+        ' notes="Ep" />'
+        "</Trades>"
+        "<OptionEAE>"
+        '<OptionEAE accountId="U1234567" currency="USD" symbol="IWM OPT"'
+        ' underlyingSymbol="IWM" transactionType="Expiration" tradeID="exp-opt-1" />'
+        "</OptionEAE>"
+        "</FlexStatement></FlexStatements></FlexQueryResponse>"
+    )
+    path.write_text(xml)
+
+    parsed = parse_flex_files([path])
+    assert [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"] == []
+    assert parsed.section_counts.get("assignment_synthetic_emitted", 0) == 0
+
+
+def test_pairing_ambiguous_without_notes_flags_for_review(caplog) -> None:  # type: ignore[no-untyped-def]
+    """Two STK rows same date/underlying/strike/qty, neither with notes → ambiguous."""
+
+    output_dir = Path("tmp/test-pairing-ambiguous-no-notes")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "ambiguous-no-notes.xml"
+    rows = _assignment_rows(
+        "xlf",
+        transaction="Assignment",
+        right="P",
+        opt_qty="1",
+        stk_qty="100",
+        strike="38",
+        close="35",
+        mtm="-300",
+    )
+    duplicate_stk = (
+        '<Trade accountId="U1234567" assetCategory="STK" currency="USD" symbol="XLF"'
+        ' underlyingSymbol="XLF" tradeID="xlf-stk-2" multiplier="1"'
+        ' dateTime="2026-01-17;120000" quantity="100" tradePrice="38"'
+        ' closePrice="35" proceeds="0" netCash="0" />'
+    )
+    xml = _flex_xml([rows])
+    xml = xml.replace("</Trades>", duplicate_stk + "</Trades>")
+    path.write_text(xml)
+
+    with caplog.at_level("WARNING", logger="app.services.options.flex_parser"):
+        parsed = parse_flex_files([path])
+
+    assert [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"] == []
+    assert parsed.section_counts["assignment_synthetic_skipped_ambiguous"] == 1
+    assert "ambiguous" in caplog.text.lower()
+
+
+def test_pairing_heuristic_fallback_when_no_order_id_or_notes() -> None:
+    """Legacy data without ibOrderID or notes still pairs via classic heuristic."""
+
+    output_dir = Path("tmp/test-pairing-heuristic-fallback")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "heuristic.xml"
+    path.write_text(
+        _flex_xml(
+            [
+                _assignment_rows(
+                    "voo",
+                    transaction="Assignment",
+                    right="P",
+                    opt_qty="1",
+                    stk_qty="100",
+                    strike="400",
+                    close="390",
+                    mtm="-1000",
+                    # No opt_order_id, stk_order_id, or notes — pure legacy data.
+                )
+            ]
+        )
+    )
+
+    parsed = parse_flex_files([path])
+    synthetics = [c for c in parsed.cash_transactions if c.event_category == "assignment_synthetic"]
+
+    assert len(synthetics) == 1
+    assert synthetics[0].raw_payload["pair_method"] == "heuristic"
+    assert synthetics[0].amount == Decimal("-1000")


### PR DESCRIPTION
## Summary

Working as **McManus** (Data/Finance Dev)

Closes #265. Hardens the OPT→STK assignment pairing in `flex_parser.py` by replacing the single heuristic path with a three-tier algorithm that uses IBKR `ibOrderID` and `notes` codes as primary signals.

## Pairing Algorithm

| Tier | Key | When used |
|------|-----|-----------|
| `order_id` | `ibOrderID` / `orderID` match | Primary — definitive IBKR order-level link |
| `heuristic_notes` / `heuristic_notes_narrowed` | Classic heuristic + `notes` code (A/Ex) | Confirms/narrows when ibOrderID absent |
| `heuristic` | Date + underlying + strike + qty | Legacy fallback — unchanged behaviour |

Ambiguous matches (multiple heuristic candidates that notes cannot narrow) are **rejected and logged** with `assignment_synthetic_skipped_ambiguous` for manual review.

## Changes

- **`apps/backend/app/services/options/flex_parser.py`**
  - `NOTES_ASSIGNMENT_CODES`, `_notes_codes()`, `_notes_has_assignment_code()`
  - `_AssignmentOptionLeg` gets `ib_order_id` + `opt_notes` fields
  - `_assignment_option_leg()` extracts `ibOrderID`/`notes` from OPT+EAE rows
  - `_select_best_pairing_with_tier()` — new three-tier selector
  - `pair_method` key in every synthetic cash event `raw_payload` (observability)
  - Per-tier counters in `section_counts`

- **`apps/backend/tests/services/options/test_flex_parser.py`**
  - 7 new tests: order_id primary, multi-assignment dedup via order_id, exercise (Ex) notes, notes narrowing, expiration no-STK, ambiguous-no-notes flag, legacy fallback
  - All **342 backend tests passing**

## Coordination

- **Hockney (PR #276):** reads `notes` from raw XML attrs (`raw_payload["notes"]` per Phase 0 doc). When Hockney's typed `notes` field lands, migration is a one-line swap — no behavioural change.
- No DB migration needed — pairing is in-memory. `pair_method` in raw_payload covers observability.

⚠️ This task touches financial pairing logic — please have McManus / Keaton review before merging.