### PR TITLE
fix(backend): require DATABASE_URL/DIRECT_DATABASE_URL — no localhost default (closes #126)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,12 +21,26 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # BACKEND — Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
 # =============================================================================
 
-# Full PostgreSQL connection string for legacy local-dev compose (includes credentials — treat as secret)
-DATABASE_URL=postgresql://user:password@localhost:5432/trading-journal
+# =============================================================================
+# BACKEND — Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
+# =============================================================================
 
-# Supabase Postgres or pooler URL for docker-compose.backend.yml.
-# Include sslmode=require when using Supabase direct Postgres.
-DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
+# Full PostgreSQL connection string — REQUIRED; no default.
+# The backend will refuse to start if this is not set or points to localhost.
+# Use the Supabase transaction-mode pooler URL (aws-1 region, NOT aws-0):
+#
+#   DATABASE_URL=postgresql://postgres.{project-ref}:{password}@aws-1-{region}.pooler.supabase.com:6543/postgres?sslmode=require
+#
+# Get it from: Supabase Dashboard → Project Settings → Database →
+#              Connection string → Transaction mode
+# REQUIRED — replace with your Supabase pooler URL before starting the backend:
+DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
+
+# Supabase Postgres pooler URL for docker-compose.backend.yml.
+# docker-compose maps DIRECT_DATABASE_URL → DATABASE_URL inside the container.
+# Same format as DATABASE_URL above.
+# REQUIRED for Docker Compose setup — replace with your Supabase pooler URL:
+DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
 
 # Supabase project URL for backend Auth/JWKS checks and Storage access.
 SUPABASE_URL=https://your-project-ref.supabase.co

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -1,8 +1,15 @@
 # Database
-DATABASE_URL=postgresql://user:password@localhost/trading_journal
+# REQUIRED — no default. The backend refuses to start if this is unset or
+# resolves to localhost outside of APP_ENV=development.
+# Use the Supabase transaction-mode pooler URL (aws-1 region, NOT aws-0).
+# Get it from: Supabase Dashboard → Project Settings → Database →
+#              Connection string → Transaction mode
+DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
 
 # Supabase-backed local Docker worker mode
-DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-0-region.pooler.supabase.com:6543/postgres?sslmode=require
+# docker-compose maps DIRECT_DATABASE_URL → DATABASE_URL inside the container.
+# Same format and requirements as DATABASE_URL above.
+DIRECT_DATABASE_URL=postgresql://postgres.your-project-ref:your-password@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
 SUPABASE_URL=https://your-project-ref.supabase.co
 
 # Server-only Supabase key for Storage access or privileged worker writes.

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -8,16 +8,37 @@ The worker runs in Docker on Jony's laptop, reads inputs from Supabase with a se
 
 Copy the root `.env.example` or `apps/backend/.env.example` to a local `.env` and fill server-only values. Never commit real credentials.
 
+> **Important:** `DATABASE_URL` has no default. The backend **refuses to start** if it is missing or resolves to `localhost` outside of a local dev environment. See [Obtaining the Supabase pooler URL](#obtaining-the-supabase-pooler-url) below.
+
 | Variable | Required | Purpose |
 | --- | --- | --- |
-| `DATABASE_URL` | Yes | Supabase Postgres direct or pooler connection string used by the worker for reads and writes. Use an elevated role only on the server-side worker and include `sslmode=require` for Supabase-hosted Postgres. |
-| `DIRECT_DATABASE_URL` | Compose convenience | `docker-compose.backend.yml` maps this value into `DATABASE_URL`; set it to the Supabase direct or pooler URL. |
+| `DATABASE_URL` | **Yes — no default** | Supabase transaction-mode pooler URL. Backend will not start without this. |
+| `DIRECT_DATABASE_URL` | Compose convenience | `docker-compose.backend.yml` maps this value into `DATABASE_URL`; same format as `DATABASE_URL`. |
 | `SUPABASE_URL` | Yes | Supabase project URL for Auth/JWKS checks and Storage client access. |
 | `SUPABASE_SERVICE_ROLE_KEY` | Optional, server-only | Required only when worker code needs Supabase Storage access or privileged writes that cannot be performed with the database connection. This key bypasses RLS; never expose it to the browser and never prefix it with `NEXT_PUBLIC_`. |
+| `APP_ENV` | Optional | Set to `development` or `local` to allow localhost DATABASE_URL in dev. Defaults to production-mode validation. |
 | `WORKER_TIMEZONE` | Optional | APScheduler timezone. Defaults to `Asia/Jerusalem`. |
 | `WORKER_POLL_INTERVAL_SECONDS` | Optional | `compute_jobs` polling interval. Defaults to `5`. |
 | `IB_GATEWAY_HOST` / `IB_GATEWAY_PORT` | Optional | IB Gateway TCP endpoint used by the scheduled trading sync health check and IBKR connection. Defaults to `127.0.0.1:4002`. Legacy `IB_HOST` / `IB_PORT` are also honored. |
 | `OTEL_SERVICE_NAME` / `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional | Local observability settings. |
+
+## Obtaining the Supabase pooler URL
+
+The backend requires the **transaction-mode pooler** URL (PgBouncer, port 6543).
+
+1. Open the [Supabase Dashboard](https://supabase.com/dashboard) → select your project
+2. Go to **Project Settings → Database → Connection string**
+3. Choose **Transaction mode** from the dropdown
+4. Copy the connection string — it looks like:
+   ```
+   postgresql://postgres.{project-ref}:{password}@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require
+   ```
+
+**Gotchas:**
+- Region prefix is `aws-1`, **not** `aws-0` (commonly assumed from copy-pasted snippets)
+- Username contains a dot: `postgres.{project-ref}`
+- `sslmode=require` is mandatory — omitting it causes GSSAPI negotiation errors
+- Use port `6543` (pooler), **not** `5432` (direct) — `pg_dump` needs port 5432, but the worker uses the pooler
 
 ## Adding a scheduled batch job
 

--- a/apps/backend/app/dal/database.py
+++ b/apps/backend/app/dal/database.py
@@ -1,9 +1,14 @@
 import os
-from urllib.parse import quote_plus
+from urllib.parse import quote_plus, urlparse
 
 from dotenv import load_dotenv
 from sqlalchemy import text
 from sqlmodel import Session, create_engine
+
+# Sentinel used when no DATABASE_URL env var is set.
+# A real connection attempt will fail immediately with a clear error, but
+# importing this module (e.g. in tests that override get_session) is safe.
+_DB_URL_NOT_CONFIGURED = "postgresql://not-configured:not-configured@not-configured/not-configured"
 
 
 def _normalize_database_url(raw_url: str) -> str:
@@ -25,12 +30,74 @@ def _normalize_database_url(raw_url: str) -> str:
     return f"postgresql://{username}:{password}@{host}:{port}/{database}"
 
 
+def _resolve_database_url() -> str:
+    """Resolve DATABASE_URL from environment variables.
+
+    Priority: DIRECT_DATABASE_URL > DATABASE_URL.
+    Returns the sentinel constant when neither is set so that the module can
+    be imported safely (e.g. in tests that override get_session).  Real
+    validation happens at application startup via validate_database_url().
+    """
+    raw = os.getenv("DIRECT_DATABASE_URL") or os.getenv("DATABASE_URL")
+    if not raw:
+        return _DB_URL_NOT_CONFIGURED
+    return _normalize_database_url(raw)
+
+
+def validate_database_url() -> None:
+    """Fail loud at startup if DATABASE_URL is missing or points at localhost.
+
+    Call this from the FastAPI lifespan so misconfigured deployments crash
+    immediately with an actionable error instead of returning 5xx on every
+    request.
+
+    Raises:
+        RuntimeError: if DATABASE_URL is unset or resolves to a localhost
+            address outside of a local/development/test environment.
+    """
+    if DATABASE_URL == _DB_URL_NOT_CONFIGURED:
+        raise RuntimeError(
+            "\n"
+            "DATABASE_URL is not set — the backend cannot start.\n"
+            "\n"
+            "Set it in apps/backend/.env (copy from apps/backend/.env.example).\n"
+            "Expected format — Supabase transaction-mode pooler (aws-1 region):\n"
+            "\n"
+            "  DATABASE_URL=postgresql://postgres.{project-ref}:{password}"
+            "@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require\n"
+            "\n"
+            "Get the exact URL from:\n"
+            "  Supabase Dashboard → Project Settings → Database → "
+            "Connection string → Transaction mode\n"
+            "Note: use the aws-1-* host, NOT aws-0-* (different region prefix).\n"
+        )
+
+    env = os.getenv("APP_ENV", os.getenv("ENVIRONMENT", "")).lower()
+    is_local = env in {"local", "development", "dev", "test"}
+
+    if not is_local:
+        hostname = urlparse(DATABASE_URL).hostname or ""
+        localhost_hosts = {"localhost", "127.0.0.1", "0.0.0.0", "not-configured"}
+        if hostname in localhost_hosts:
+            raise RuntimeError(
+                f"\n"
+                f"DATABASE_URL resolves to '{hostname}', which is a localhost address.\n"
+                f"This will not connect to Supabase in a deployed environment.\n"
+                f"\n"
+                f"  Got: {DATABASE_URL!r}\n"
+                f"\n"
+                f"Set DATABASE_URL to your Supabase pooler URL, e.g.:\n"
+                f"  postgresql://postgres.{{ref}}:{{pass}}"
+                f"@aws-1-{{region}}.pooler.supabase.com:6543/postgres?sslmode=require\n"
+                f"\n"
+                f"To suppress this check in local dev: "
+                f"set APP_ENV=development in your .env\n"
+            )
+
+
 load_dotenv()
 
-DATABASE_URL = _normalize_database_url(
-    os.getenv("DIRECT_DATABASE_URL")
-    or os.getenv("DATABASE_URL", "postgresql://user:password@localhost/trading-journal")
-)
+DATABASE_URL = _resolve_database_url()
 
 engine = create_engine(
     DATABASE_URL,

--- a/apps/backend/main.py
+++ b/apps/backend/main.py
@@ -8,7 +8,7 @@ import uvicorn
 from contextlib import asynccontextmanager
 from fastapi.middleware.cors import CORSMiddleware
 from app.middleware.security_headers import SecurityHeadersMiddleware
-from app.dal.database import check_database_connection, create_db_and_tables
+from app.dal.database import check_database_connection, create_db_and_tables, validate_database_url
 from app.utils.decimal_encoder import decimal_default
 from app.dependencies import get_current_user
 from app.api import (
@@ -80,6 +80,7 @@ class DecimalSafeJSONResponse(JSONResponse):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    validate_database_url()
     print("Creating tables..")
     create_db_and_tables()
     await _warmup_jwks_cache()

--- a/apps/backend/tests/test_database_url_validation.py
+++ b/apps/backend/tests/test_database_url_validation.py
@@ -1,0 +1,79 @@
+"""Tests for database URL fail-loud validation.
+
+Ensures the backend refuses to start with a missing or localhost DATABASE_URL
+outside of a local development environment.
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+class TestValidateDatabaseUrl:
+    """validate_database_url() raises on misconfigured DATABASE_URL."""
+
+    def test_raises_when_not_configured(self) -> None:
+        """Sentinel DATABASE_URL must raise RuntimeError at startup."""
+        from app.dal.database import _DB_URL_NOT_CONFIGURED, validate_database_url
+        import app.dal.database as db_module
+
+        with (
+            patch.object(db_module, "DATABASE_URL", _DB_URL_NOT_CONFIGURED),
+        ):
+            with pytest.raises(RuntimeError, match="DATABASE_URL is not set"):
+                validate_database_url()
+
+    def test_raises_on_localhost_in_production(self) -> None:
+        """Localhost DATABASE_URL must raise when APP_ENV is not local/dev/test."""
+        from app.dal.database import validate_database_url
+        import app.dal.database as db_module
+
+        localhost_url = "postgresql://user:password@localhost:5432/trading-journal"
+        with (
+            patch.object(db_module, "DATABASE_URL", localhost_url),
+            patch.dict("os.environ", {"APP_ENV": ""}, clear=False),
+        ):
+            with pytest.raises(RuntimeError, match="localhost"):
+                validate_database_url()
+
+    def test_raises_on_127_0_0_1_in_production(self) -> None:
+        """127.0.0.1 DATABASE_URL must raise when APP_ENV is not local/dev/test."""
+        from app.dal.database import validate_database_url
+        import app.dal.database as db_module
+
+        loopback_url = "postgresql://user:password@127.0.0.1:5432/trading-journal"
+        with (
+            patch.object(db_module, "DATABASE_URL", loopback_url),
+            patch.dict("os.environ", {"APP_ENV": ""}, clear=False),
+        ):
+            with pytest.raises(RuntimeError, match="127.0.0.1"):
+                validate_database_url()
+
+    def test_localhost_allowed_in_development(self) -> None:
+        """Localhost DATABASE_URL must NOT raise when APP_ENV=development."""
+        from app.dal.database import validate_database_url
+        import app.dal.database as db_module
+
+        localhost_url = "postgresql://user:password@localhost:5432/trading-journal"
+        for env in ("development", "dev", "local", "test"):
+            with (
+                patch.object(db_module, "DATABASE_URL", localhost_url),
+                patch.dict("os.environ", {"APP_ENV": env}, clear=False),
+            ):
+                # Should NOT raise
+                validate_database_url()
+
+    def test_valid_supabase_url_passes(self) -> None:
+        """A real Supabase pooler URL must pass validation."""
+        from app.dal.database import validate_database_url
+        import app.dal.database as db_module
+
+        supabase_url = (
+            "postgresql://postgres.abcdefghij:s3cr3t"
+            "@aws-1-eu-central-1.pooler.supabase.com:6543/postgres?sslmode=require"
+        )
+        with (
+            patch.object(db_module, "DATABASE_URL", supabase_url),
+            patch.dict("os.environ", {"APP_ENV": ""}, clear=False),
+        ):
+            # Should NOT raise
+            validate_database_url()


### PR DESCRIPTION
Working as **Kujan** (DevOps/Platform)

Closes #126

## Problem

The backend shipped with a silent `localhost` fallback for `DATABASE_URL`. Against a Supabase-hosted DB this caused every API call to return 5xx with generic asyncpg connection errors, no hint that the root cause was a misconfigured URL.

## Approach: Option A + B + C

**A — Remove the silent default:**
`database.py` no longer falls back to `localhost`. If neither `DIRECT_DATABASE_URL` nor `DATABASE_URL` is set, the module uses an internal sentinel constant. Importing the module stays safe for tests (they override `get_session` with SQLite).

**B — Fail loud at startup:**
New `validate_database_url()` called from FastAPI `lifespan()`. Raises `RuntimeError` with an actionable message if:
1. URL is the sentinel (unset), or
2. URL resolves to `localhost`/`127.0.0.1` and `APP_ENV` is not `development`/`local`/`dev`/`test`

**C — Fix the docs and examples:**
- Root `.env.example`: replace `localhost:5432` with the correct Supabase pooler shape
- `apps/backend/.env.example`: same, with `aws-1` region and `sslmode=require`  
- `apps/backend/README.md`: new **Obtaining the Supabase pooler URL** section with step-by-step instructions and gotchas (`aws-1` not `aws-0`, dot in username, sslmode=require, port 6543)

## Tests

`apps/backend/tests/test_database_url_validation.py` — 5 unit tests:
- Raises when URL is unset (sentinel)
- Raises on `localhost` in production
- Raises on `127.0.0.1` in production
- Allows localhost when `APP_ENV=development/local/dev/test`
- Passes on a real Supabase pooler URL

## Migration impact

None — schema unchanged. Workers with a valid `DATABASE_URL` are unaffected.