### PR TITLE
ci(security): harden playwright-e2e.yml — move user-controlled inputs to env:

### DIFF
--- a/.github/workflows/playwright-e2e.yml
+++ b/.github/workflows/playwright-e2e.yml
@@ -293,8 +293,12 @@ jobs:
       - name: Resolve grep pattern
         id: grep
         shell: bash
+        # Security: inputs.suite is passed via env var (not interpolated into shell body)
+        # to prevent shell-injection. Ref: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+        env:
+          SUITE: ${{ inputs.suite }}
         run: |
-          case "${{ inputs.suite }}" in
+          case "$SUITE" in
             smoke)  echo "pattern=@smoke"           >> "$GITHUB_OUTPUT" ;;
             auth)   echo "pattern=@auth"            >> "$GITHUB_OUTPUT" ;;
             flows)  echo "pattern=@flow"            >> "$GITHUB_OUTPUT" ;;
@@ -302,9 +306,12 @@ jobs:
           esac
 
       - name: Run ${{ inputs.suite || 'all' }} tests
-        run: npx playwright test --grep "${{ steps.grep.outputs.pattern }}" --project=chromium
+        # Security: steps output is passed via env var (not interpolated into shell body)
+        # to prevent shell-injection if the pattern value were ever tainted.
+        run: npx playwright test --grep "$GREP_PATTERN" --project=chromium
         env:
           CI: true
+          GREP_PATTERN: ${{ steps.grep.outputs.pattern }}
           BASE_URL: ${{ inputs.base_url || secrets.E2E_BASE_URL }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Summary

Closes #281

Working as **Kujan** (DevOps/Platform)

Hardens `playwright-e2e.yml` against shell-injection by moving user-controlled GitHub Actions expressions out of `run:` shell bodies and into step-scoped `env:` variables. This is the same fix pattern applied in PR #275 (`supabase-migrations.yml`).

## The Shell-Injection Vector

When a GitHub Actions expression like `${{ inputs.suite }}` is interpolated directly into a `run:` shell body, an attacker who can influence that value can inject arbitrary shell commands. Even when the input is a `type: choice` (constrained today), the pattern is unsafe by convention: if the input type is ever changed, the vulnerability becomes immediately exploitable.

**Reference:** https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

## Occurrences Fixed

### 1. `.github/workflows/playwright-e2e.yml` — line 297

**Before (unsafe):**
```yaml
- name: Resolve grep pattern
  id: grep
  shell: bash
  run: |
    case "${{ inputs.suite }}" in
      smoke)  echo "pattern=@smoke"   >> "$GITHUB_OUTPUT" ;;
```

**After (safe):**
```yaml
- name: Resolve grep pattern
  id: grep
  shell: bash
  env:
    SUITE: ${{ inputs.suite }}   # <-- moved here
  run: |
    case "$SUITE" in
      smoke)  echo "pattern=@smoke"   >> "$GITHUB_OUTPUT" ;;
```

### 2. `.github/workflows/playwright-e2e.yml` — line 305

**Before (unsafe):**
```yaml
- name: Run ${{ inputs.suite || 'all' }} tests
  run: npx playwright test --grep "${{ steps.grep.outputs.pattern }}" --project=chromium
  env:
    CI: true
```

**After (safe):**
```yaml
- name: Run ${{ inputs.suite || 'all' }} tests
  run: npx playwright test --grep "$GREP_PATTERN" --project=chromium
  env:
    CI: true
    GREP_PATTERN: ${{ steps.grep.outputs.pattern }}   # <-- moved here
```

## Other Workflows Swept

All `.github/workflows/*.yml` files were audited for the same pattern. No additional unsafe `${{ ... }}` interpolations inside `run:` bodies were found. The other `${{ ... }}` usages are in non-shell contexts (`concurrency:`, `name:`, `with:`, `env:`), which are safe.

## No Logic Changes

Only the mechanism for passing values to the shell was changed. Workflow behaviour is identical.