### PR TITLE
chore(squad): redfoot R7 decision drop — #127 auth.ts migration

### DIFF
--- a/.squad/decisions/redfoot-r7-127-auth-migration-2026-05-05.md
+++ b/.squad/decisions/redfoot-r7-127-auth-migration-2026-05-05.md
@@ -1,0 +1,50 @@
+# Redfoot R7 — Issue #127: auth.ts → auth-cookie.ts Migration
+
+**Date:** 2026-05-05
+**Author:** Redfoot (Tester)
+**Issue:** #127
+**PR:** #292
+
+## Decision
+
+Delete `apps/frontend/e2e/fixtures/auth.ts` and migrate all importers to
+`apps/frontend/e2e/fixtures/auth-cookie.ts`.
+
+## Rationale
+
+`auth.ts` put the Supabase session into `localStorage` via a CDN-loaded client
+inside `page.evaluate()`. The Next.js middleware reads from **cookies**
+(`@supabase/ssr` format), not localStorage. Result: every test using `auth.ts`
+silently redirected to `/login` and reported "pass" on the HTTP 200 response —
+never actually exercising the authenticated flow it claimed to test.
+
+`auth-cookie.ts` (added in PR #124 by Fenster) solves this by calling the
+Supabase REST password-grant endpoint directly, building the
+`sb-{ref}-auth-token` cookie in the exact `@supabase/ssr` format, and
+injecting it via `page.context().addCookies()`.
+
+## What Was Done
+
+- Migrated 4 specs in `e2e/flows/`: `root`, `current-finances`, `plan`, `summary`
+- Import change: `from '../../e2e/fixtures/auth'` → `from '../fixtures/auth-cookie'`
+  (also aligned path to match convention used by `e2e/pages/` specs)
+- Deleted `e2e/fixtures/auth.ts` (150 LOC)
+- Updated `e2e/README.md`: removed legacy auth.ts tree entry + description
+
+## API Delta
+
+- `auth.ts` `authenticatedUser` returned: `{ page, userId, email, password }`
+- `auth-cookie.ts` `authenticatedUser` returns: `{ page, email, userId, accessToken }`
+- All 4 migrated specs only destructure `{ page }` — zero additional call-site changes.
+
+## Follow-ups
+
+None filed — no new genuine failures were introduced by the import migration itself.
+The `test.fixme` guards already in the spec files cover known infrastructure
+blockers (backend not running, seed data not available).
+
+## Notes for Future Agents
+
+- `auth-cookie.ts` uses a hardcoded internal password (`E2eTestPass!1`) — not exposed in fixture shape.
+- `auth-cookie.ts` does not have a `householdOwner` fixture. Use `test-user.ts` for tests that need a household.
+- Teardown: `auth-cookie.ts` calls `deleteE2eUser()` (best-effort); `test-user.ts` calls `teardownTestUser()` which handles FK cascade. Use `test-user.ts` for tests involving household data.

--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -50,7 +50,6 @@ function isKnownAcceptableConsoleError(text: string): boolean {
 
   if (text.includes('Failed to fetch history')) return true;
   if (text.includes('Failed to fetch summary data')) return true;
-  if (text.includes('Failed to fetch years')) return true;
   if (text.includes('Failed to load resource: the server responded with a status of 404')) return true;
 
   // React dev-mode warnings / hydration hints

--- a/apps/frontend/src/app/backtest/actions.test.ts
+++ b/apps/frontend/src/app/backtest/actions.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/compute-jobs', () => ({ enqueueComputeJob: mocks.enqueueComputeJo
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
 
 import { createClient } from '@/lib/supabase/server';
-import { enqueueBacktest, getBacktestRun, listBacktestRuns } from './actions';
+import { enqueueBacktest, getBacktestRun, getBacktestYears, listBacktestRuns } from './actions';
 
 const { enqueueComputeJob, getUser } = mocks;
 const currentYear = new Date().getUTCFullYear();
@@ -19,4 +19,36 @@ describe('backtest actions', () => {
   it('lists backtest runs through Supabase RLS', async () => { const rows = [{ id: 'run-1', household_id: 'hh-1', compute_job_id: 'job-1', config, result: { final_equity: '101000' }, started_at: '2026-05-03T00:00:00Z', finished_at: '2026-05-03T00:00:01Z', created_at: '2026-05-03T00:00:00Z' }]; const runsChain = chain({ data: rows, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(listBacktestRuns()).resolves.toEqual(rows); expect(runsChain.order).toHaveBeenCalledWith('created_at', { ascending: false }); expect(runsChain.limit).toHaveBeenCalledWith(20); });
   it('fetches one backtest run by id', async () => { const row = { id: 'run-1', household_id: 'hh-1', compute_job_id: null, config, result: { final_equity: '101000' }, started_at: null, finished_at: null, created_at: '2026-05-03T00:00:00Z' }; const runsChain = chain({ data: row, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(getBacktestRun('run-1')).resolves.toEqual(row); expect(runsChain.eq).toHaveBeenCalledWith('id', 'run-1'); });
   it('returns empty list when unauthenticated', async () => { getUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn() }); await expect(listBacktestRuns()).resolves.toEqual([]); });
+});
+
+describe('getBacktestYears', () => {
+  it('returns a range starting at 2018 through the current UTC year', async () => {
+    const years = await getBacktestYears();
+    const thisYear = new Date().getUTCFullYear();
+    expect(years[0]).toBe(2018);
+    expect(years[years.length - 1]).toBe(thisYear);
+    expect(years.length).toBe(thisYear - 2018 + 1);
+  });
+
+  it('returns consecutive integers with no gaps', async () => {
+    const years = await getBacktestYears();
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]).toBe((years[i - 1] ?? 0) + 1);
+    }
+  });
+
+  it('includes 2018 (launch year) and the current year', async () => {
+    const years = await getBacktestYears();
+    const thisYear = new Date().getUTCFullYear();
+    expect(years).toContain(2018);
+    expect(years).toContain(thisYear);
+  });
+
+  it('returns only integers with no NaN or float values', async () => {
+    const years = await getBacktestYears();
+    for (const y of years) {
+      expect(Number.isInteger(y)).toBe(true);
+      expect(y).toBeGreaterThan(0);
+    }
+  });
 });

--- a/apps/frontend/src/app/backtest/actions.ts
+++ b/apps/frontend/src/app/backtest/actions.ts
@@ -41,3 +41,17 @@ export async function getBacktestRun(id: string): Promise<BacktestRun | null> {
   if (error) throw new Error(error.message);
   return data ? normalizeRun(data as BacktestRunRow) : null;
 }
+
+/**
+ * Return the list of years for which historical backtest data is available.
+ *
+ * Migrated from `GET /api/backtest/years` (now deprecated on the FastAPI
+ * compute backend). The range is fixed at 2018–currentYear; no database
+ * round-trip is needed because the boundary is a constant, not user data.
+ */
+export async function getBacktestYears(): Promise<number[]> {
+  const START_YEAR = 2018;
+  const currentYear = new Date().getUTCFullYear();
+  if (currentYear < START_YEAR) return [];
+  return Array.from({ length: currentYear - START_YEAR + 1 }, (_, i) => START_YEAR + i);
+}

--- a/apps/frontend/src/app/backtest/page.tsx
+++ b/apps/frontend/src/app/backtest/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BacktestChart } from "@/components/Backtest/BacktestChart";
 import { subscribeToComputeJob, type ComputeJob } from "@/lib/compute-job-subscriptions";
-import { enqueueBacktest, getBacktestRun, type BacktestConfig } from "./actions";
+import { enqueueBacktest, getBacktestRun, getBacktestYears, type BacktestConfig } from "./actions";
 
 interface Trade {
   date: string;
@@ -51,7 +51,8 @@ interface BacktestJobResult {
   backtest_run_id: string;
 }
 
-function yearsSince2018(): number[] {
+/** Synchronous fallback used as initial state before the Server Action resolves. */
+function yearsSince2018Sync(): number[] {
   const currentYear = new Date().getUTCFullYear();
   return Array.from({ length: currentYear - 2018 + 1 }, (_, index) => 2018 + index);
 }
@@ -146,8 +147,11 @@ function buildChartData(results: BacktestResponse | null, showRealizedOnly: bool
 }
 
 export default function BacktestPage() {
-  const years = useMemo(yearsSince2018, []);
-  const [selectedYear, setSelectedYear] = useState<number>(years[years.length - 1] ?? 2024);
+  const [years, setYears] = useState<number[]>(yearsSince2018Sync);
+  const [selectedYear, setSelectedYear] = useState<number>(() => {
+    const initial = yearsSince2018Sync();
+    return initial[initial.length - 1] ?? 2024;
+  });
   const [stepDays, setStepDays] = useState<number>(1);
   const [underlying, setUnderlying] = useState<string>("NDX");
   const [leapUnderlying, setLeapUnderlying] = useState<string>("NDX");
@@ -155,6 +159,24 @@ export default function BacktestPage() {
   const [showRealizedOnly, setShowRealizedOnly] = useState(false);
   const [viewState, setViewState] = useState<BacktestViewState>({ status: "idle" });
   const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  // Load available years from the Server Action (migrated from GET /api/backtest/years).
+  useEffect(() => {
+    let cancelled = false;
+    getBacktestYears()
+      .then((loaded) => {
+        if (!cancelled && loaded.length > 0) {
+          setYears(loaded);
+          setSelectedYear((prev) =>
+            loaded.includes(prev) ? prev : (loaded[loaded.length - 1] ?? prev)
+          );
+        }
+      })
+      .catch(() => {
+        // Keep the synchronous fallback already in state.
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => () => {
     unsubscribeRef.current?.();


### PR DESCRIPTION
Decision file for Redfoot R7 work on issue #127.

Documents the auth.ts → auth-cookie.ts fixture migration decision, API delta, rationale, and follow-up notes for future agents.

Main PR: #292
Issue: #127