### PR TITLE
feat(backtest): migrate /api/backtest/years to Server Action (closes #188)

### DIFF
--- a/apps/frontend/e2e/walkthrough/all-pages.spec.ts
+++ b/apps/frontend/e2e/walkthrough/all-pages.spec.ts
@@ -50,7 +50,6 @@ function isKnownAcceptableConsoleError(text: string): boolean {
 
   if (text.includes('Failed to fetch history')) return true;
   if (text.includes('Failed to fetch summary data')) return true;
-  if (text.includes('Failed to fetch years')) return true;
   if (text.includes('Failed to load resource: the server responded with a status of 404')) return true;
 
   // React dev-mode warnings / hydration hints

--- a/apps/frontend/src/app/backtest/actions.test.ts
+++ b/apps/frontend/src/app/backtest/actions.test.ts
@@ -5,7 +5,7 @@ vi.mock('@/lib/compute-jobs', () => ({ enqueueComputeJob: mocks.enqueueComputeJo
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
 
 import { createClient } from '@/lib/supabase/server';
-import { enqueueBacktest, getBacktestRun, listBacktestRuns } from './actions';
+import { enqueueBacktest, getBacktestRun, getBacktestYears, listBacktestRuns } from './actions';
 
 const { enqueueComputeJob, getUser } = mocks;
 const currentYear = new Date().getUTCFullYear();
@@ -19,4 +19,36 @@ describe('backtest actions', () => {
   it('lists backtest runs through Supabase RLS', async () => { const rows = [{ id: 'run-1', household_id: 'hh-1', compute_job_id: 'job-1', config, result: { final_equity: '101000' }, started_at: '2026-05-03T00:00:00Z', finished_at: '2026-05-03T00:00:01Z', created_at: '2026-05-03T00:00:00Z' }]; const runsChain = chain({ data: rows, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(listBacktestRuns()).resolves.toEqual(rows); expect(runsChain.order).toHaveBeenCalledWith('created_at', { ascending: false }); expect(runsChain.limit).toHaveBeenCalledWith(20); });
   it('fetches one backtest run by id', async () => { const row = { id: 'run-1', household_id: 'hh-1', compute_job_id: null, config, result: { final_equity: '101000' }, started_at: null, finished_at: null, created_at: '2026-05-03T00:00:00Z' }; const runsChain = chain({ data: row, error: null }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn(() => runsChain) }); await expect(getBacktestRun('run-1')).resolves.toEqual(row); expect(runsChain.eq).toHaveBeenCalledWith('id', 'run-1'); });
   it('returns empty list when unauthenticated', async () => { getUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') }); (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser }, from: vi.fn() }); await expect(listBacktestRuns()).resolves.toEqual([]); });
+});
+
+describe('getBacktestYears', () => {
+  it('returns a range starting at 2018 through the current UTC year', async () => {
+    const years = await getBacktestYears();
+    const thisYear = new Date().getUTCFullYear();
+    expect(years[0]).toBe(2018);
+    expect(years[years.length - 1]).toBe(thisYear);
+    expect(years.length).toBe(thisYear - 2018 + 1);
+  });
+
+  it('returns consecutive integers with no gaps', async () => {
+    const years = await getBacktestYears();
+    for (let i = 1; i < years.length; i++) {
+      expect(years[i]).toBe((years[i - 1] ?? 0) + 1);
+    }
+  });
+
+  it('includes 2018 (launch year) and the current year', async () => {
+    const years = await getBacktestYears();
+    const thisYear = new Date().getUTCFullYear();
+    expect(years).toContain(2018);
+    expect(years).toContain(thisYear);
+  });
+
+  it('returns only integers with no NaN or float values', async () => {
+    const years = await getBacktestYears();
+    for (const y of years) {
+      expect(Number.isInteger(y)).toBe(true);
+      expect(y).toBeGreaterThan(0);
+    }
+  });
 });

--- a/apps/frontend/src/app/backtest/actions.ts
+++ b/apps/frontend/src/app/backtest/actions.ts
@@ -41,3 +41,17 @@ export async function getBacktestRun(id: string): Promise<BacktestRun | null> {
   if (error) throw new Error(error.message);
   return data ? normalizeRun(data as BacktestRunRow) : null;
 }
+
+/**
+ * Return the list of years for which historical backtest data is available.
+ *
+ * Migrated from `GET /api/backtest/years` (now deprecated on the FastAPI
+ * compute backend). The range is fixed at 2018–currentYear; no database
+ * round-trip is needed because the boundary is a constant, not user data.
+ */
+export async function getBacktestYears(): Promise<number[]> {
+  const START_YEAR = 2018;
+  const currentYear = new Date().getUTCFullYear();
+  if (currentYear < START_YEAR) return [];
+  return Array.from({ length: currentYear - START_YEAR + 1 }, (_, i) => START_YEAR + i);
+}

--- a/apps/frontend/src/app/backtest/page.tsx
+++ b/apps/frontend/src/app/backtest/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BacktestChart } from "@/components/Backtest/BacktestChart";
 import { subscribeToComputeJob, type ComputeJob } from "@/lib/compute-job-subscriptions";
-import { enqueueBacktest, getBacktestRun, type BacktestConfig } from "./actions";
+import { enqueueBacktest, getBacktestRun, getBacktestYears, type BacktestConfig } from "./actions";
 
 interface Trade {
   date: string;
@@ -51,7 +51,8 @@ interface BacktestJobResult {
   backtest_run_id: string;
 }
 
-function yearsSince2018(): number[] {
+/** Synchronous fallback used as initial state before the Server Action resolves. */
+function yearsSince2018Sync(): number[] {
   const currentYear = new Date().getUTCFullYear();
   return Array.from({ length: currentYear - 2018 + 1 }, (_, index) => 2018 + index);
 }
@@ -146,8 +147,11 @@ function buildChartData(results: BacktestResponse | null, showRealizedOnly: bool
 }
 
 export default function BacktestPage() {
-  const years = useMemo(yearsSince2018, []);
-  const [selectedYear, setSelectedYear] = useState<number>(years[years.length - 1] ?? 2024);
+  const [years, setYears] = useState<number[]>(yearsSince2018Sync);
+  const [selectedYear, setSelectedYear] = useState<number>(() => {
+    const initial = yearsSince2018Sync();
+    return initial[initial.length - 1] ?? 2024;
+  });
   const [stepDays, setStepDays] = useState<number>(1);
   const [underlying, setUnderlying] = useState<string>("NDX");
   const [leapUnderlying, setLeapUnderlying] = useState<string>("NDX");
@@ -155,6 +159,24 @@ export default function BacktestPage() {
   const [showRealizedOnly, setShowRealizedOnly] = useState(false);
   const [viewState, setViewState] = useState<BacktestViewState>({ status: "idle" });
   const unsubscribeRef = useRef<(() => void) | null>(null);
+
+  // Load available years from the Server Action (migrated from GET /api/backtest/years).
+  useEffect(() => {
+    let cancelled = false;
+    getBacktestYears()
+      .then((loaded) => {
+        if (!cancelled && loaded.length > 0) {
+          setYears(loaded);
+          setSelectedYear((prev) =>
+            loaded.includes(prev) ? prev : (loaded[loaded.length - 1] ?? prev)
+          );
+        }
+      })
+      .catch(() => {
+        // Keep the synchronous fallback already in state.
+      });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => () => {
     unsubscribeRef.current?.();


### PR DESCRIPTION
## Summary

Working as **Hockney (Backend Dev)**

Closes #188 — TJ-018k: Migrate /api/backtest (years + run) to compute backend
Part of #71

---

## Port choice — (A) Server Action for `years`, job-queue already in place for `run`

The two endpoints had different complexity profiles:

| Endpoint | Choice | Rationale |
|---|---|---|
| `GET /api/backtest/years` | **TypeScript Server Action** | Pure constant derivation (2018→currentYear). No DB needed, <1ms, safe to move to Next.js layer. |
| `POST /api/backtest/run` | **Job queue (already done)** | Heavy compute (~870 LOC backtester, 5-60s). PR #228 migrated this to `compute_jobs` → `run_backtest_job` worker in the FastAPI compute backend. |

This PR completes the `years` half that was left open after #228.

---

## Changes

- **`actions.ts`** — adds `getBacktestYears(): Promise<number[]>` Server Action, formally replacing `GET /api/backtest/years`. Documented with migration note.
- **`page.tsx`** — replaces `useMemo(yearsSince2018)` (client-side) with `useEffect` calling `getBacktestYears` on mount + synchronous fallback so SSR initial render is instant.
- **`actions.test.ts`** — 4 new unit tests: range boundaries (2018→currentYear), consecutive integers, includes launch year and current year, no-float/NaN guard.
- **`e2e/walkthrough/all-pages.spec.ts`** — removes stale `'Failed to fetch years'` allowed-console-error entry. The page no longer issues any API call for year metadata.

---

## Test coverage

| Before | After |
|---|---|
| 235 tests | **239 tests** (+4) |

All 34 test files pass.

---

## FastAPI endpoints — left in place (deprecated)

`GET /api/backtest/years` and `POST /api/backtest/run` remain in the FastAPI compute backend with `deprecated=True`. The frontend no longer calls either endpoint directly:
- `years` → answered by `getBacktestYears()` Server Action
- `run` → enqueued via `enqueueBacktest()` → `compute_jobs` table → worker `run_backtest_job`

FastAPI removal is a follow-up Hockney task (when all TJ-018 migrations are complete).

---

## Acceptance criteria ✅

- [x] `years` endpoint served from Server Action (no FastAPI call)
- [x] `run` endpoint served from compute_jobs worker (FastAPI compute backend via queue, #228)
- [x] Frontend uses no `apiFetch` for backtest operations
- [x] `/api/backtest` not in walkthrough allow-list (`TEMPORARILY_ALLOWED_COMPUTE_API_PATHS = []`)
- [x] No FastAPI removal — compute backend IS FastAPI (still processes backtest jobs)

---

## Wire compatibility

No change to the data shape consumed by the frontend. `BacktestConfig`, `BacktestRun`, and all fields are unchanged.

---

## Follow-up

- Remove deprecated FastAPI `/api/backtest/years` and `/api/backtest/run` once all TJ-018 migrations are confirmed complete (Hockney R8).