### PR TITLE
chore(db): close #191 #192 — options & ladder schema (McManus R8)

### DIFF
--- a/supabase/migrations/20260505120000_options_ladder_schema_close.sql
+++ b/supabase/migrations/20260505120000_options_ladder_schema_close.sql
@@ -1,0 +1,84 @@
+-- Migration: options_ladder_schema_close
+-- Purpose: Close-out migration for #191 (options schema) and #192 (ladder schema).
+--          All major tables landed in earlier migrations; this file addresses the
+--          single gap flagged by the Supabase performance advisor: the FK column
+--          `options_margin_snapshots.account_config_id` had no covering index.
+--
+-- Tables already in place (no changes needed here):
+--   options (#191):
+--     options_income                  — 20260503142446
+--     options_flex_sync_state         — 20260504134438
+--     options_legs                    — 20260504134438
+--     options_strategy_groups         — 20260504134438
+--     options_trades                  — 20260504134438
+--     options_cash_events             — 20260504134438
+--     options_positions               — 20260504134438
+--     options_roll_events             — 20260504134438
+--     options_dashboard_monthly       — 20260504134438
+--     options_strategy_capital_history — 20260504150112
+--     options_margin_snapshots        — 20260504150112
+--   ladder (#192):
+--     ladder_rungs                    — 20260503142507
+--     ladder_bonds                    — 20260503142507
+--
+-- All tables above have RLS enabled and household-scoped member/writer policies.
+
+-- ── options_margin_snapshots: add index for account_config_id FK ─────────────
+-- Supabase performance advisor (2026-05-05) flagged this FK as unindexed.
+-- account_config_id is nullable (outer-join query path), so a partial index
+-- covering non-null values keeps it small while still satisfying the FK scan.
+CREATE INDEX IF NOT EXISTS options_margin_snapshots_account_config_id_idx
+  ON public.options_margin_snapshots (account_config_id)
+  WHERE account_config_id IS NOT NULL;
+
+-- ── Table documentation ───────────────────────────────────────────────────────
+-- Options domain (#191)
+COMMENT ON TABLE public.options_income IS
+  'Yearly options premium income rollup per household. Lightweight dashboard aggregate.';
+
+COMMENT ON TABLE public.options_flex_sync_state IS
+  'Per-account IBKR Flex / ib_gateway sync cursor and status. Prevents duplicate ingestion.';
+
+COMMENT ON TABLE public.options_legs IS
+  'Canonical option contract definitions (symbol, expiry, strike, right, multiplier). '
+  'One row per unique option leg; referenced by options_trades and options_positions.';
+
+COMMENT ON TABLE public.options_strategy_groups IS
+  'Groups related option trades into named strategies (CSP, vertical spread, roll chain). '
+  'Tracks aggregate P&L, capital-at-risk, and strategy lifecycle status.';
+
+COMMENT ON TABLE public.options_trades IS
+  'Individual fill-level option trade events (open, close, expire, assign, exercise). '
+  'Source of truth for FIFO lot matching and realized-P&L calculation.';
+
+COMMENT ON TABLE public.options_cash_events IS
+  'Non-trade cash movements related to options accounts: commissions, dividends, '
+  'interest, transfers, and tax withholding.';
+
+COMMENT ON TABLE public.options_positions IS
+  'Current open option positions per account/leg. Rebuilt on each sync pass from trades.';
+
+COMMENT ON TABLE public.options_roll_events IS
+  'Detected roll pairs: a closing trade and the opening trade that rolled it. '
+  'Classified as positive/negative/neutral; used by roll-efficiency dashboard metrics.';
+
+COMMENT ON TABLE public.options_dashboard_monthly IS
+  'Monthly aggregated options dashboard metrics: premium, commissions, roll counts, '
+  'capital-at-risk, and margin utilization. Consumed by the frontend chart widgets.';
+
+COMMENT ON TABLE public.options_strategy_capital_history IS
+  'Point-in-time capital-at-risk snapshots for each strategy group. '
+  'Enables trend charts and time-weighted return-on-capital calculations.';
+
+COMMENT ON TABLE public.options_margin_snapshots IS
+  'Account-wide margin/buying-power snapshots captured on each sync pass. '
+  'Powers the margin utilization gauge on the options dashboard.';
+
+-- Ladder domain (#192)
+COMMENT ON TABLE public.ladder_rungs IS
+  'Bond/CD ladder rungs (years). Each rung defines a maturity window, target principal, '
+  'and current allocated principal. Parent record for ladder_bonds.';
+
+COMMENT ON TABLE public.ladder_bonds IS
+  'Individual bonds or CDs allocated to a ladder rung. Tracks issuer, face value, '
+  'coupon rate, coupon frequency, and maturity date.';


### PR DESCRIPTION
Working as McManus (Data/Finance Dev)

Closes #191
Closes #192

---

## Summary

Issues #191 (options schema) and #192 (ladder schema) were filed on 2026-05-03. The underlying schema work landed across four prior merged PRs but none used `Closes` syntax, leaving both issues open. This PR formally closes them and adds the one gap found by the Supabase performance advisor.

---

## Migration added: `20260505120000_options_ladder_schema_close.sql`

**Gap fix (performance advisor 2026-05-05):**
```sql
CREATE INDEX IF NOT EXISTS options_margin_snapshots_account_config_id_idx
  ON public.options_margin_snapshots (account_config_id)
  WHERE account_config_id IS NOT NULL;
```
`options_margin_snapshots.account_config_id` FK was flagged as unindexed. Partial index (nullable column, sparse).

**Documentation:** Added `COMMENT ON TABLE` for all 13 options/ladder tables.

---

## Tables in place — options (#191)

| Table | Migration | RLS |
|---|---|---|
| `options_income` | 20260503142446 | ✅ member-read / writer-write |
| `options_flex_sync_state` | 20260504134438 | ✅ |
| `options_legs` | 20260504134438 | ✅ |
| `options_strategy_groups` | 20260504134438 | ✅ |
| `options_trades` | 20260504134438 | ✅ |
| `options_cash_events` | 20260504134438 | ✅ |
| `options_positions` | 20260504134438 | ✅ |
| `options_roll_events` | 20260504134438 | ✅ |
| `options_dashboard_monthly` | 20260504134438 | ✅ |
| `options_strategy_capital_history` | 20260504150112 | ✅ (join-based via strategy_groups) |
| `options_margin_snapshots` | 20260504150112 | ✅ |

**RLS pattern:**
```sql
-- SELECT
USING (household_id IS NOT NULL AND public.is_household_member(household_id))
-- INSERT/UPDATE/DELETE
WITH CHECK (household_id IS NOT NULL AND public.is_household_writer(household_id))
```

**Enums defined:** `option_right`, `options_strategy_kind`, `options_strategy_status`, `options_trade_event_type`, `options_trade_side`, `options_cash_event_category`, `options_roll_classification`, `options_roll_detection_status`, `options_sync_source`, `options_sync_status`

---

## Tables in place — ladder (#192)

| Table | Migration | RLS |
|---|---|---|
| `ladder_rungs` | 20260503142507 | ✅ member-read / writer-write |
| `ladder_bonds` | 20260503142507 | ✅ |

Both use composite PK `(household_id, id)`. `ladder_bonds.rung_id` → `ladder_rungs` with `ON DELETE CASCADE`.

---

## Monetary precision

All money columns: `NUMERIC(18,6)` — matches the project baseline convention (Decision #2).

---

## Deferred (not in this PR)

- Index on `options_dashboard_monthly.account_id` — add when query patterns from Server Action layer (#183) emerge.
- Unused index warnings (`ladder_rungs_household_id_idx`, etc.) — INFO-level, tables are fresh with zero data; re-evaluate after first production sync.

---

Decision drop: `.squad/decisions/mcmanus-r8-options-ladder-schema-2026-05-05.md`