### PR TITLE
fix(infra): migrate hardcoded env values to env vars (closes #67)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,9 +13,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key-here
 # Canonical app URL for Supabase auth redirects (e.g. http://localhost:3000 locally)
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
-# NEXT_PUBLIC_API_URL is intentionally not used. The frontend talks only to
-# Supabase tables, Auth, Storage, and Realtime; it never proxies to the backend.
-# NEXT_PUBLIC_API_URL=
+# Backend API URL — only needed when running the full local Docker stack (docker-compose.yml).
+# In Vercel/Supabase deployments the frontend talks directly to Supabase and this is unused.
+# Default in docker-compose.yml: http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # =============================================================================
 # BACKEND — Python worker (🔴 Server-only; never add NEXT_PUBLIC_ prefix)
@@ -98,6 +99,22 @@ RELOGIN_AFTER_TWOFA_TIMEOUT=yes
 
 # Gateway timezone (TZ database name)
 TIME_ZONE=Asia/Jerusalem
+
+# =============================================================================
+# DOCKER COMPOSE LOCAL STACK — postgres credentials for docker-compose.yml only
+# =============================================================================
+# These set the Postgres superuser credentials for the local `db` container.
+# Used in healthcheck and DATABASE_URL construction when running `docker compose up`.
+# Safe to leave at dev defaults locally; never use these values against a remote DB.
+
+# Local Postgres username (container default: user)
+POSTGRES_USER=user
+
+# Local Postgres password (container default: password)
+POSTGRES_PASSWORD=password
+
+# Local Postgres database name (container default: trading_journal)
+POSTGRES_DB=trading_journal
 
 # =============================================================================
 # LOCAL DEV — Supabase CLI (🔴 Never commit; set in shell or .env)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
     image: postgres:13
     container_name: trading_journal_db
     environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: trading_journal
+      POSTGRES_USER: ${POSTGRES_USER:-user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      POSTGRES_DB: ${POSTGRES_DB:-trading_journal}
     volumes:
       - postgres_data:/var/lib/postgresql/data/
     ports:
@@ -14,7 +14,7 @@ services:
     networks:
       - trading-journal-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U user -d trading_journal"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-user} -d ${POSTGRES_DB:-trading_journal}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -30,7 +30,9 @@ services:
     ports:
       - "8000:8000"
     environment:
-      DATABASE_URL: "postgresql://user:password@db:5432/trading_journal"
+      # Use ${DATABASE_URL} to allow overriding with an external DB (e.g. Supabase pooler).
+      # Default uses the Docker-internal Postgres service on the dev credentials below.
+      DATABASE_URL: ${DATABASE_URL:-postgresql://user:password@db:5432/trading_journal}
       OTEL_SERVICE_NAME: "trading-journal-backend"
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
       OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
@@ -60,7 +62,9 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NEXT_PUBLIC_API_URL: "http://localhost:8000"
+      # NEXT_PUBLIC_API_URL is the backend URL visible from the browser.
+      # Override with the actual backend hostname in non-local environments.
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8000}
     depends_on:
       backend:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Closes #67. Per Keaton's hosting-migration Wave 1 plan (PR #296).
Working as **Kujan** (DevOps/Platform).

⚠️ This task was flagged as "needs review" — please have a squad member review before merging.

## Audit results

Full grep of `apps/frontend/src/`, `apps/frontend/app/`, `apps/backend/app/` for hardcoded URLs, localhost, and 127.0.0.1:

| Finding | Location | Status |
|---|---|---|
| `NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000'` | `apps/frontend/src/app/login/page.tsx:18` | ✅ Already env-driven (env var with safe fallback) |
| CORS `allow_origins` | `apps/backend/main.py` | ✅ Already env-driven (`BACKEND_CORS_ORIGINS` / `CORS_ORIGINS`) |
| `DATABASE_URL` backend config | `apps/backend/app/dal/database.py` | ✅ Already env-driven (`DIRECT_DATABASE_URL` > `DATABASE_URL`) |
| OTel endpoint | `apps/backend/main.py` | ✅ Already env-driven (`OTEL_EXPORTER_OTLP_ENDPOINT`) |
| `DATABASE_URL: "postgresql://user:password@db:5432/trading_journal"` | `docker-compose.yml:33` | ❌ **FIXED** |
| `NEXT_PUBLIC_API_URL: "http://localhost:8000"` | `docker-compose.yml:63` | ❌ **FIXED** |
| `POSTGRES_USER: user` / `POSTGRES_PASSWORD: password` / `POSTGRES_DB: trading_journal` | `docker-compose.yml:7-9` | ❌ **FIXED** |

**Intentionally retained (not env-driven):**
- Healthcheck `curl -f http://localhost:8000/health` — probes the container's own port from inside; must always be localhost
- `docker-compose.backend.yml` — already fully env-driven with fail-fast guards

## Changes

### `docker-compose.yml`
- `POSTGRES_USER/PASSWORD/DB` → `${VAR:-default}` with local dev defaults preserved
- `DATABASE_URL` → `${DATABASE_URL:-postgresql://user:password@db:5432/trading_journal}` — allows Supabase pooler URL override without rebuilding
- `NEXT_PUBLIC_API_URL` → `${NEXT_PUBLIC_API_URL:-http://localhost:8000}` — no hardcoded localhost URL in committed code
- Healthcheck uses `${POSTGRES_USER:-user}` and `${POSTGRES_DB:-trading_journal}` to stay consistent

### `.env.example`
- `NEXT_PUBLIC_API_URL` documented (Docker Compose full-stack only; unused in Vercel deployments)
- New `DOCKER COMPOSE LOCAL STACK` section added with `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`

## Verification

- No secrets committed (`git grep` clean)
- Pre-commit hooks passed (secrets scan, YAML lint, private key detection)
- TypeScript source unchanged — pre-existing TS errors in `src/test/setup.ts` are unrelated to this PR
- `docker-compose.backend.yml` untouched (already correct)

## Unblocks

- #63 (env completeness for CRUD wiring)
- #69 (OAuth — env vars in place)
