### PR TITLE
docs(squad): kujan r9 decision drop

### DIFF
--- a/.squad/decisions/inbox/kujan-r9-wave1-2026-05-05.md
+++ b/.squad/decisions/inbox/kujan-r9-wave1-2026-05-05.md
@@ -1,0 +1,106 @@
+# Kujan — Round 9 Decision Drop
+_Author: Kujan (DevOps/Platform) · Date: 2026-05-05 · Round: 9_
+
+## Context
+
+Wave 1 of the hosting-migration epic (Keaton's plan, PR #296). Two issues resolved in
+parallel: #53 (free-tier audit) and #67 (env var migration).
+
+---
+
+## PR-A — #53 Free-Tier Audit (PR #299)
+
+**Branch:** `squad/53-free-tier-audit`
+**Artifact:** `docs/design-hosting/baseline-facts.md`
+
+### Confirmed limits
+
+| Platform | Key limits |
+|---|---|
+| Supabase free | 500 MB DB · 50k MAU · 60 direct Postgres connections · 500k edge fn/mo · 1-day backup retention · auto-pause after 7 days · 2 active projects max |
+| Vercel Hobby | 100 GB egress · 6k build-min/mo · 1M serverless invocations · no commercial use · hard caps, no overages |
+
+### Design doc correction
+
+`docs/design-hosting/sections/04-deployment-cicd.md` listed Supabase free as having
+"2 concurrent connections". Correct figure: **60 direct Postgres connections** (nano
+compute). Always use the pooler URL (port 6543) for web traffic; direct only for Alembic.
+Scribe should update the table in section 04 in a future cleanup pass.
+
+### Baseline estimate
+
+Local Docker stack was not running at audit time. Derived from 43 migration files / 49 tables:
+- **~5–15 MB schema-only** (empty DB after migrations)
+- **~50–150 MB post-backfill** (IBKR history 3–5 yr)
+- Both comfortably within the 500 MB free-tier limit
+
+### Blockers surfaced (actionable before Wave 2)
+
+1. **Before #65 backfill:** Manual `pg_dump` encrypted backup required. Free-tier PITR
+   is only 1 day — insufficient for a bulk migration. McManus must take a snapshot before
+   starting #65.
+2. **Before #79 prod deploy:** Auto-pause mitigation must be in place (a 3-day uptime
+   ping via GitHub Actions cron or similar). Project auto-pauses after 7 days of
+   inactivity; an unpaused production database will break the app for Jony without warning.
+
+### Follow-up issues to file
+
+- [ ] File issue: "Add uptime-ping cron to prevent Supabase project auto-pause" — assigned
+  Kujan, blocks #79
+- [ ] File issue: "Add TTL/pruning policy on historicaloptionbar and raw.market_data_quotes"
+  — assigned McManus, milestone: post-launch
+
+---
+
+## PR-B — #67 Env Var Migration (PR #300)
+
+**Branch:** `squad/67-hardcoded-env-vars`
+**Files changed:** `docker-compose.yml`, `.env.example`
+
+### Audit summary
+
+Scanned `apps/frontend/src/`, `apps/frontend/app/`, `apps/backend/app/` for hardcoded
+URLs, localhost, and 127.0.0.1. **All app-layer code was already env-driven.** The only
+hardcoded values were in `docker-compose.yml` (local dev orchestration file).
+
+### Migrations applied (3 hardcoded values → env vars)
+
+| Variable | Before | After |
+|---|---|---|
+| `POSTGRES_USER` | `user` (literal) | `${POSTGRES_USER:-user}` |
+| `POSTGRES_PASSWORD` | `password` (literal) | `${POSTGRES_PASSWORD:-password}` |
+| `POSTGRES_DB` | `trading_journal` (literal) | `${POSTGRES_DB:-trading_journal}` |
+| `DATABASE_URL` | `"postgresql://user:password@db:5432/trading_journal"` (literal) | `${DATABASE_URL:-postgresql://user:password@db:5432/trading_journal}` |
+| `NEXT_PUBLIC_API_URL` | `"http://localhost:8000"` (literal) | `${NEXT_PUBLIC_API_URL:-http://localhost:8000}` |
+
+All defaults preserved — `docker compose up` with no `.env` continues to work identically
+for local development. Setting `DATABASE_URL` in `.env` now allows pointing the local
+backend at a Supabase pooler URL without modifying the compose file.
+
+### Intentionally unchanged
+
+- Healthcheck `curl` and `pg_isready` commands use `localhost` — correct, these probe
+  the container's own network interface from inside the container.
+- `docker-compose.backend.yml` — already fully env-driven with fail-fast guards.
+- `apps/backend/main.py` `uvicorn.run(... host="0.0.0.0", port=8001)` — dev-only path,
+  not production, acceptable constant.
+
+### `.env.example` additions
+
+- `NEXT_PUBLIC_API_URL` — documented with context (Docker Compose full-stack only)
+- New `DOCKER COMPOSE LOCAL STACK` section with `POSTGRES_USER`, `POSTGRES_PASSWORD`,
+  `POSTGRES_DB`
+
+---
+
+## Decisions for Scribe
+
+1. **Supabase concurrent connections:** Correct the "2 concurrent connections" entry in
+   `docs/design-hosting/sections/04-deployment-cicd.md` to **60 direct Postgres
+   connections (nano compute); unlimited via PgBouncer pooler**.
+2. **Supabase projects:** Two free projects are fully consumed (dev + prod). Local Docker
+   is the mandatory third environment. No third cloud project should be provisioned on
+   free tier.
+3. **docker-compose.yml scope:** `docker-compose.yml` is a local development orchestration
+   file only. `docker-compose.backend.yml` is the Supabase-connected worker compose. Do
+   not conflate the two.


### PR DESCRIPTION
Kujan Round 9 decision drop. Adds `.squad/decisions/inbox/kujan-r9-wave1-2026-05-05.md`.

Summarises findings from:
- PR #299 — #53 free-tier audit
- PR #300 — #67 env var migration

For Scribe: three decisions to incorporate into `decisions.md`:
1. Correct Supabase concurrent-connections figure (60 direct, not 2)
2. Two free Supabase projects fully consumed — local Docker is mandatory third env
3. `docker-compose.yml` is local-dev only; `docker-compose.backend.yml` is Supabase-worker
