### PR TITLE
docs(squad): Fenster R12 decision drop — dashboard cooked tables TJ-020

### DIFF
--- a/.squad/decisions/fenster-r12-dashboard-cooked-2026-05-05.md
+++ b/.squad/decisions/fenster-r12-dashboard-cooked-2026-05-05.md
@@ -1,0 +1,61 @@
+# Fenster R12 — Dashboard Cooked Tables (TJ-020 / #73)
+
+_Author: Fenster (Frontend Dev)_
+_Date: 2026-05-05_
+_PR: #322 — squad/73-dashboard-cooked-tables_
+
+---
+
+## Decisions made
+
+### 1. Cooked tables consumed by the dashboard
+
+Read from the three cooked tables introduced in `20260430140300_cooked_tables.sql`:
+
+| Table | Used for |
+|-------|---------|
+| `cooked.daily_performance` | PnL curve (last 90 days, DESC) |
+| `cooked.dashboard_summary` | Net Worth / Daily P&L / YTD KPI row (most recent `period='day'` row) |
+| `public.household_refresh_state` | Staleness calculation (job_type = `pnl_daily`) |
+
+**Not used:** `cooked.position_history` — position snapshot view is out of scope for this wave; deferred to Wave 4 (Redfoot / TJ-021).
+
+### 2. Freshness thresholds (confirmed from issue #73)
+
+Issue #73 acceptance criteria explicitly states: *"Stale threshold configurable (default: data older than 24 hours)"*. Thresholds in `STALE_THRESHOLD_MS`:
+
+| State | Condition |
+|-------|-----------|
+| 🟢 fresh | `last_succeeded_at` within 24 h, no active job |
+| 🔄 refreshing | `compute_jobs` row with `status IN ('pending', 'running')` for this household |
+| 🟡 stale | `last_succeeded_at` > 24 h ago, or never ran, no active job |
+| 🔴 failed | `last_failed_at` > `last_succeeded_at` (most recent run failed) |
+
+**Deviation from mission brief:** The mission brief suggested 5 min / 60 min thresholds. The issue body takes precedence (24 h). If sub-day staleness granularity is needed in future, raise a follow-up.
+
+### 3. Refresh trigger UX
+
+- "Refresh Now" button in the dashboard header (always visible).
+- Server-side rate limit: **30 seconds** minimum gap between user-triggered refreshes (from mission brief; issue does not specify a rate limit).
+- Also blocks if an active `compute_jobs` row exists for the household.
+- Surfaces rate-limit error inline below the button (no modal/toast).
+- On success, immediately re-fetches the snapshot to update the badge.
+
+### 4. Empty-cooked-table / first-run handling
+
+When both `cooked.daily_performance` and `cooked.dashboard_summary` return no rows for the household (`isFirstRun = true`):
+- Show a friendly empty state: "Crunching your data — first refresh in progress".
+- Fall back to legacy `public.dailysummary` for the PnL curve (backward compat).
+- Dashboard does not crash or show blank content.
+
+### 5. FastAPI endpoints left in place
+
+No FastAPI dashboard endpoints were touched. Deprecation follows the `#287 / #294 / #308` pattern — to be removed in a future wave by Hockney.
+
+---
+
+## Follow-up issues to consider
+
+- `cooked.position_history` surface in a positions panel (Wave 4, Redfoot).
+- Configurable stale threshold in user Settings (currently hardcoded 24 h).
+- Auto-poll: re-fetch snapshot while `freshnessStatus === 'refreshing'` until job completes (could use Supabase Realtime subscription on `compute_jobs`).

--- a/apps/frontend/src/app/dashboard/actions.test.ts
+++ b/apps/frontend/src/app/dashboard/actions.test.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  computeFreshnessStatus,
+  secondsSince,
+  getDashboardSnapshot,
+  triggerHouseholdRefresh,
+  STALE_THRESHOLD_MS,
+  REFRESH_RATE_LIMIT_SECONDS,
+  type HouseholdRefreshState,
+} from './actions';
+
+// ─── Unit tests for pure helpers ──────────────────────────────────────────────
+
+describe('computeFreshnessStatus', () => {
+  it('returns refreshing when hasActiveJob is true regardless of state', () => {
+    expect(computeFreshnessStatus(null, true)).toBe('refreshing');
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: new Date(Date.now() - 1000).toISOString(),
+      lastFailedAt: null,
+      lastError: null,
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, true)).toBe('refreshing');
+  });
+
+  it('returns stale when refreshState is null and no active job', () => {
+    expect(computeFreshnessStatus(null, false)).toBe('stale');
+  });
+
+  it('returns failed when only lastFailedAt is set', () => {
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: null,
+      lastFailedAt: new Date(Date.now() - 5000).toISOString(),
+      lastError: 'division by zero',
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, false)).toBe('failed');
+  });
+
+  it('returns fresh when lastSucceededAt is within STALE_THRESHOLD_MS', () => {
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: new Date(Date.now() - 60_000).toISOString(), // 1 min ago
+      lastFailedAt: null,
+      lastError: null,
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, false)).toBe('fresh');
+  });
+
+  it('returns stale when lastSucceededAt is older than STALE_THRESHOLD_MS', () => {
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: new Date(Date.now() - STALE_THRESHOLD_MS - 1000).toISOString(),
+      lastFailedAt: null,
+      lastError: null,
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, false)).toBe('stale');
+  });
+
+  it('returns failed when lastFailedAt is newer than lastSucceededAt', () => {
+    const succeeded = new Date(Date.now() - 3600_000).toISOString(); // 1 h ago
+    const failed = new Date(Date.now() - 600_000).toISOString();    // 10 min ago
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: succeeded,
+      lastFailedAt: failed,
+      lastError: 'compute error',
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, false)).toBe('failed');
+  });
+
+  it('returns fresh when lastSucceededAt is newer than lastFailedAt', () => {
+    const failed = new Date(Date.now() - 3600_000).toISOString();
+    const succeeded = new Date(Date.now() - 60_000).toISOString();
+    const state: HouseholdRefreshState = {
+      jobType: 'pnl_daily',
+      lastSucceededAt: succeeded,
+      lastFailedAt: failed,
+      lastError: null,
+      lastRunId: null,
+    };
+    expect(computeFreshnessStatus(state, false)).toBe('fresh');
+  });
+});
+
+describe('secondsSince', () => {
+  it('returns null for null input', () => {
+    expect(secondsSince(null)).toBeNull();
+  });
+
+  it('returns positive integer for a past ISO timestamp', () => {
+    const fiveSecondsAgo = new Date(Date.now() - 5000).toISOString();
+    const result = secondsSince(fiveSecondsAgo);
+    expect(result).not.toBeNull();
+    expect(result!).toBeGreaterThanOrEqual(4);
+    expect(result!).toBeLessThanOrEqual(6);
+  });
+
+  it('returns 0 for a future timestamp (clamped)', () => {
+    const future = new Date(Date.now() + 10_000).toISOString();
+    expect(secondsSince(future)).toBe(0);
+  });
+});
+
+// ─── Server Action tests ──────────────────────────────────────────────────────
+
+const mockGetUser = vi.fn();
+
+function buildChain(result: unknown) {
+  const b = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+    single: vi.fn().mockResolvedValue(result),
+    then: (cb: (v: unknown) => unknown) => Promise.resolve(result).then(cb),
+  };
+  return b;
+}
+
+function authOk(householdId = 'hh-1') {
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null });
+  return householdId;
+}
+
+function authFail() {
+  mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+}
+
+beforeEach(() => vi.resetAllMocks());
+
+describe('getDashboardSnapshot — unauthenticated', () => {
+  it('returns isFirstRun=true snapshot when user is not authenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    const result = await getDashboardSnapshot();
+
+    expect(result.isFirstRun).toBe(true);
+    expect(result.dailyPerformance).toEqual([]);
+    expect(result.dashboardSummary).toBeNull();
+    expect(result.refreshState).toBeNull();
+  });
+});
+
+describe('getDashboardSnapshot — empty cooked tables', () => {
+  it('returns isFirstRun=true when no cooked rows exist', async () => {
+    authOk();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({ data: null, error: null });
+        if (table === 'daily_performance')
+          return { ...buildChain({ data: [], error: null }), maybeSingle: vi.fn() };
+        if (table === 'dashboard_summary')
+          return buildChain({ data: null, error: null });
+        if (table === 'compute_jobs')
+          return { ...buildChain({ data: [], error: null }), maybeSingle: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getDashboardSnapshot();
+    expect(result.isFirstRun).toBe(true);
+    expect(result.freshnessStatus).toBe('stale');
+  });
+});
+
+describe('getDashboardSnapshot — populated cooked tables', () => {
+  it('returns fresh status and daily performance rows', async () => {
+    authOk();
+    const freshTimestamp = new Date(Date.now() - 60_000).toISOString();
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({
+            data: {
+              job_type: 'pnl_daily',
+              last_succeeded_at: freshTimestamp,
+              last_failed_at: null,
+              last_error: null,
+              last_run_id: null,
+            },
+            error: null,
+          });
+        if (table === 'daily_performance') {
+          return {
+            ...buildChain({
+              data: [
+                {
+                  date: '2026-05-01',
+                  currency: 'USD',
+                  performance_payload: { total_pnl: '1234.56', winning_trades: 5, losing_trades: 2, win_rate: 0.71 },
+                  _computed_at: freshTimestamp,
+                },
+              ],
+              error: null,
+            }),
+            maybeSingle: vi.fn(),
+          };
+        }
+        if (table === 'dashboard_summary')
+          return buildChain({ data: null, error: null });
+        if (table === 'compute_jobs')
+          return { ...buildChain({ data: [], error: null }), maybeSingle: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getDashboardSnapshot();
+    expect(result.isFirstRun).toBe(false);
+    expect(result.freshnessStatus).toBe('fresh');
+    expect(result.dailyPerformance).toHaveLength(1);
+    expect(result.dailyPerformance[0].totalPnl).toBe('1234.56');
+  });
+});
+
+describe('getDashboardSnapshot — missing refresh_state row', () => {
+  it('handles null refresh_state gracefully and returns stale', async () => {
+    authOk();
+    const perfRow = {
+      date: '2026-05-01',
+      currency: 'USD',
+      performance_payload: { total_pnl: '100.00' },
+      _computed_at: new Date().toISOString(),
+    };
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({ data: null, error: null });
+        if (table === 'daily_performance')
+          return { ...buildChain({ data: [perfRow], error: null }), maybeSingle: vi.fn() };
+        if (table === 'dashboard_summary')
+          return buildChain({ data: null, error: null });
+        if (table === 'compute_jobs')
+          return { ...buildChain({ data: [], error: null }), maybeSingle: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await getDashboardSnapshot();
+    expect(result.refreshState).toBeNull();
+    expect(result.freshnessStatus).toBe('stale');
+    expect(result.isFirstRun).toBe(false);
+  });
+});
+
+describe('triggerHouseholdRefresh', () => {
+  it('returns error when unauthenticated', async () => {
+    authFail();
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn(),
+    });
+
+    const result = await triggerHouseholdRefresh();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/Authentication/i);
+  });
+
+  it('rejects if last_succeeded_at is within rate-limit window', async () => {
+    authOk();
+    const recentTimestamp = new Date(
+      Date.now() - (REFRESH_RATE_LIMIT_SECONDS - 5) * 1000,
+    ).toISOString();
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({ data: { last_succeeded_at: recentTimestamp }, error: null });
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await triggerHouseholdRefresh();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/wait/i);
+  });
+
+  it('rejects if an active job is already running', async () => {
+    authOk();
+    const oldTimestamp = new Date(Date.now() - 120_000).toISOString();
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({ data: { last_succeeded_at: oldTimestamp }, error: null });
+        if (table === 'compute_jobs')
+          return { ...buildChain({ data: [{ id: 'job-1' }], error: null }), maybeSingle: vi.fn() };
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await triggerHouseholdRefresh();
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/progress/i);
+  });
+
+  it('enqueues a job and returns ok when conditions are met', async () => {
+    authOk();
+    const oldTimestamp = new Date(Date.now() - 120_000).toISOString();
+
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({
+      auth: { getUser: mockGetUser },
+      from: vi.fn((table: string) => {
+        if (table === 'household_members')
+          return buildChain({ data: { household_id: 'hh-1' }, error: null });
+        if (table === 'household_refresh_state')
+          return buildChain({ data: { last_succeeded_at: oldTimestamp }, error: null });
+        if (table === 'compute_jobs') {
+          const chain = buildChain({ data: [], error: null });
+          chain.single = vi.fn().mockResolvedValue({ data: { id: 'new-job-42' }, error: null });
+          return chain;
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    });
+
+    const result = await triggerHouseholdRefresh();
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.jobId).toBe('new-job-42');
+  });
+});

--- a/apps/frontend/src/app/dashboard/actions.ts
+++ b/apps/frontend/src/app/dashboard/actions.ts
@@ -1,0 +1,334 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import Decimal from 'decimal.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type FreshnessStatus = 'fresh' | 'refreshing' | 'stale' | 'failed';
+
+/** 24-hour stale threshold (issue #73 default). */
+export const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+
+/** Minimum seconds between user-triggered refreshes (rate-limit guard). */
+export const REFRESH_RATE_LIMIT_SECONDS = 30;
+
+export interface HouseholdRefreshState {
+  jobType: string;
+  lastSucceededAt: string | null;
+  lastFailedAt: string | null;
+  lastError: string | null;
+  lastRunId: string | null;
+}
+
+export interface DailyPerformanceRow {
+  date: string;
+  currency: string;
+  /** Stored as string for decimal safety — use Decimal(row.totalPnl) on the client. */
+  totalPnl: string;
+  winningTrades: number;
+  losingTrades: number;
+  winRate: number;
+  computedAt: string;
+}
+
+export interface DashboardSummaryRow {
+  period: string;
+  asOfDate: string;
+  currency: string;
+  netWorth: string;
+  dailyPnl: string;
+  ytdPnl: string;
+  computedAt: string;
+}
+
+export interface DashboardSnapshot {
+  refreshState: HouseholdRefreshState | null;
+  freshnessStatus: FreshnessStatus;
+  /** Seconds since last successful refresh, or null if never run. */
+  stalenessSeconds: number | null;
+  dailyPerformance: DailyPerformanceRow[];
+  dashboardSummary: DashboardSummaryRow | null;
+  /** True when cooked tables have no rows for this household (first run pending). */
+  isFirstRun: boolean;
+}
+
+export type TriggerRefreshResult =
+  | { ok: true; jobId: string }
+  | { ok: false; error: string };
+
+// ─── Pure helpers (exported for unit testing) ─────────────────────────────────
+
+/**
+ * Compute the UI freshness status from refresh-state metadata.
+ *
+ * States (per issue #73 acceptance criteria):
+ *   fresh      — last_succeeded_at within 24 h, no active job
+ *   refreshing — active compute job (pending | running)
+ *   stale      — last_succeeded_at > 24 h ago (or never), no active job
+ *   failed     — last_failed_at > last_succeeded_at (most recent run failed)
+ */
+export function computeFreshnessStatus(
+  refreshState: HouseholdRefreshState | null,
+  hasActiveJob: boolean,
+): FreshnessStatus {
+  if (hasActiveJob) return 'refreshing';
+
+  if (!refreshState?.lastSucceededAt) {
+    if (refreshState?.lastFailedAt) return 'failed';
+    return 'stale'; // never successfully run
+  }
+
+  const lastSucceeded = new Date(refreshState.lastSucceededAt).getTime();
+  const lastFailed = refreshState.lastFailedAt
+    ? new Date(refreshState.lastFailedAt).getTime()
+    : null;
+
+  if (lastFailed !== null && lastFailed > lastSucceeded) return 'failed';
+
+  const ageMs = Date.now() - lastSucceeded;
+  return ageMs <= STALE_THRESHOLD_MS ? 'fresh' : 'stale';
+}
+
+/** Seconds elapsed since the given ISO timestamp, or null. */
+export function secondsSince(iso: string | null): number | null {
+  if (!iso) return null;
+  return Math.max(0, Math.floor((Date.now() - new Date(iso).getTime()) / 1000));
+}
+
+// ─── Row normalizers ──────────────────────────────────────────────────────────
+
+function normalizeRefreshState(row: Record<string, unknown>): HouseholdRefreshState {
+  return {
+    jobType: String(row.job_type ?? ''),
+    lastSucceededAt: row.last_succeeded_at != null ? String(row.last_succeeded_at) : null,
+    lastFailedAt: row.last_failed_at != null ? String(row.last_failed_at) : null,
+    lastError: row.last_error != null ? String(row.last_error) : null,
+    lastRunId: row.last_run_id != null ? String(row.last_run_id) : null,
+  };
+}
+
+function normalizeDailyPerformanceRow(row: Record<string, unknown>): DailyPerformanceRow {
+  const payload =
+    typeof row.performance_payload === 'object' && row.performance_payload !== null
+      ? (row.performance_payload as Record<string, unknown>)
+      : {};
+
+  return {
+    date: String(row.date ?? ''),
+    currency: String(row.currency ?? 'USD'),
+    totalPnl: new Decimal(
+      String(payload.total_pnl ?? payload.totalPnl ?? '0'),
+    ).toFixed(2),
+    winningTrades: Number(payload.winning_trades ?? payload.winningTrades ?? 0),
+    losingTrades: Number(payload.losing_trades ?? payload.losingTrades ?? 0),
+    winRate: Number(payload.win_rate ?? payload.winRate ?? 0),
+    computedAt: String(row._computed_at ?? ''),
+  };
+}
+
+function normalizeDashboardSummaryRow(row: Record<string, unknown>): DashboardSummaryRow {
+  const payload =
+    typeof row.summary_payload === 'object' && row.summary_payload !== null
+      ? (row.summary_payload as Record<string, unknown>)
+      : {};
+
+  return {
+    period: String(row.period ?? 'day'),
+    asOfDate: String(row.as_of_date ?? ''),
+    currency: String(row.currency ?? 'USD'),
+    netWorth: new Decimal(String(payload.net_worth ?? payload.netWorth ?? '0')).toFixed(2),
+    dailyPnl: new Decimal(String(payload.daily_pnl ?? payload.dailyPnl ?? '0')).toFixed(2),
+    ytdPnl: new Decimal(String(payload.ytd_pnl ?? payload.ytdPnl ?? '0')).toFixed(2),
+    computedAt: String(row._computed_at ?? ''),
+  };
+}
+
+async function requireHouseholdId(): Promise<string | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) return null;
+
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('household_id')
+    .eq('user_id', user.id)
+    .is('left_at', null)
+    .limit(1)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data.household_id as string;
+}
+
+// ─── Server Actions ───────────────────────────────────────────────────────────
+
+/**
+ * Fetch the dashboard snapshot for the current user's household.
+ *
+ * Reads from:
+ *   - cooked.daily_performance   (last 90 days, DESC)
+ *   - cooked.dashboard_summary   (most recent 'day' period row)
+ *   - public.household_refresh_state  (pnl_daily job type)
+ *   - public.compute_jobs         (pending/running count for "refreshing" state)
+ *
+ * If cooked tables are empty, isFirstRun = true so the UI can show a
+ * friendly "Crunching your data — first refresh in progress" state.
+ */
+export async function getDashboardSnapshot(): Promise<DashboardSnapshot> {
+  const supabase = await createClient();
+
+  const householdId = await requireHouseholdId();
+  if (!householdId) {
+    return {
+      refreshState: null,
+      freshnessStatus: 'stale',
+      stalenessSeconds: null,
+      dailyPerformance: [],
+      dashboardSummary: null,
+      isFirstRun: true,
+    };
+  }
+
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+
+  const [refreshStateRes, dailyPerfRes, summaryRes, activeJobsRes] = await Promise.all([
+    supabase
+      .from('household_refresh_state')
+      .select('job_type, last_succeeded_at, last_failed_at, last_error, last_run_id')
+      .eq('household_id', householdId)
+      .eq('job_type', 'pnl_daily')
+      .maybeSingle(),
+
+    supabase
+      .from('daily_performance')
+      .select('date, currency, performance_payload, _computed_at')
+      .eq('household_id', householdId)
+      .gte('date', ninetyDaysAgo)
+      .order('date', { ascending: false })
+      .limit(90),
+
+    supabase
+      .from('dashboard_summary')
+      .select('period, as_of_date, currency, summary_payload, _computed_at')
+      .eq('household_id', householdId)
+      .eq('period', 'day')
+      .order('as_of_date', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+
+    supabase
+      .from('compute_jobs')
+      .select('id')
+      .eq('household_id', householdId)
+      .in('status', ['pending', 'running'])
+      .limit(1),
+  ]);
+
+  if (refreshStateRes.error) {
+    console.error('[getDashboardSnapshot] refresh_state error:', refreshStateRes.error.message);
+  }
+  if (dailyPerfRes.error) {
+    console.error('[getDashboardSnapshot] daily_performance error:', dailyPerfRes.error.message);
+  }
+  if (summaryRes.error) {
+    console.error('[getDashboardSnapshot] dashboard_summary error:', summaryRes.error.message);
+  }
+
+  const refreshState = refreshStateRes.data
+    ? normalizeRefreshState(refreshStateRes.data as Record<string, unknown>)
+    : null;
+
+  const hasActiveJob = (activeJobsRes.data?.length ?? 0) > 0;
+
+  const dailyPerformance = (dailyPerfRes.data ?? []).map((r) =>
+    normalizeDailyPerformanceRow(r as Record<string, unknown>),
+  );
+
+  const dashboardSummary = summaryRes.data
+    ? normalizeDashboardSummaryRow(summaryRes.data as Record<string, unknown>)
+    : null;
+
+  const isFirstRun = dailyPerformance.length === 0 && dashboardSummary === null;
+
+  return {
+    refreshState,
+    freshnessStatus: computeFreshnessStatus(refreshState, hasActiveJob),
+    stalenessSeconds: secondsSince(refreshState?.lastSucceededAt ?? null),
+    dailyPerformance,
+    dashboardSummary,
+    isFirstRun,
+  };
+}
+
+/**
+ * Trigger a manual pnl_daily refresh for the current user's household.
+ *
+ * Rate-limited: rejects if last_succeeded_at was < 30 s ago, or if a
+ * compute job is already queued/running for this household.
+ */
+export async function triggerHouseholdRefresh(): Promise<TriggerRefreshResult> {
+  const supabase = await createClient();
+
+  const householdId = await requireHouseholdId();
+  if (!householdId) {
+    return { ok: false, error: 'Authentication required.' };
+  }
+
+  // Rate-limit check
+  const { data: state, error: stateError } = await supabase
+    .from('household_refresh_state')
+    .select('last_succeeded_at')
+    .eq('household_id', householdId)
+    .eq('job_type', 'pnl_daily')
+    .maybeSingle();
+
+  if (stateError) {
+    console.error('[triggerHouseholdRefresh] state query error:', stateError.message);
+  }
+
+  if (state?.last_succeeded_at) {
+    const elapsedSeconds =
+      (Date.now() - new Date(state.last_succeeded_at as string).getTime()) / 1000;
+    if (elapsedSeconds < REFRESH_RATE_LIMIT_SECONDS) {
+      const wait = Math.ceil(REFRESH_RATE_LIMIT_SECONDS - elapsedSeconds);
+      return { ok: false, error: `Please wait ${wait}s before triggering another refresh.` };
+    }
+  }
+
+  // Block if a job is already running
+  const { data: activeJobs } = await supabase
+    .from('compute_jobs')
+    .select('id')
+    .eq('household_id', householdId)
+    .in('status', ['pending', 'running'])
+    .limit(1);
+
+  if ((activeJobs?.length ?? 0) > 0) {
+    return { ok: false, error: 'A refresh is already in progress.' };
+  }
+
+  const { data: job, error: insertError } = await supabase
+    .from('compute_jobs')
+    .insert({
+      household_id: householdId,
+      job_type: 'pnl_daily',
+      payload: { triggered_by: 'user_manual' },
+    })
+    .select('id')
+    .single();
+
+  if (insertError || !job?.id) {
+    const msg = insertError?.message ?? 'Failed to enqueue refresh job.';
+    console.error('[triggerHouseholdRefresh] insert error:', msg);
+    return { ok: false, error: msg };
+  }
+
+  return { ok: true, jobId: String(job.id) };
+}

--- a/apps/frontend/src/app/dashboard/page.tsx
+++ b/apps/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,11 @@
+export const dynamic = 'force-dynamic';
+
+import Dashboard from '@/components/Dashboard/Dashboard';
+
+export default function DashboardPage() {
+  return (
+    <div className="container mx-auto p-4">
+      <Dashboard />
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/apps/frontend/src/components/Dashboard/Dashboard.tsx
@@ -1,42 +1,75 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import Decimal from "decimal.js";
+import { getDashboardSnapshot, type DashboardSnapshot } from "@/app/dashboard/actions";
 import { getLatestMonthSummary, getMonthSummary, type DailySummary } from "@/app/summary/actions";
+import DashboardFreshnessBadge from "./DashboardFreshnessBadge";
+import RefreshNowButton from "./RefreshNowButton";
 import TradesList from "./TradesList";
 import AddTradeForm from "./AddTradeForm";
 import PnLCurve from "./PnLCurve";
 import CalendarView from "./Calendar";
 
-
 export default function Dashboard() {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [pnlData, setPnlData] = useState<{ time: string; value: number }[]>([]);
+  const [snapshot, setSnapshot] = useState<DashboardSnapshot | null>(null);
 
+  // Load cooked snapshot (freshness state + daily performance)
+  const loadSnapshot = useCallback(async () => {
+    try {
+      const data = await getDashboardSnapshot();
+      setSnapshot(data);
+
+      // If cooked daily_performance has rows, prefer them for the PnL curve
+      if (data.dailyPerformance.length > 0) {
+        const sorted = [...data.dailyPerformance].sort(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+        );
+        let cumulative = new Decimal(0);
+        const chartData = sorted.map((row) => {
+          cumulative = cumulative.plus(new Decimal(row.totalPnl));
+          return { time: row.date, value: cumulative.toDecimalPlaces(2).toNumber() };
+        });
+        setPnlData(chartData);
+      }
+    } catch (err) {
+      console.error("Failed to load dashboard snapshot:", err);
+    }
+  }, []);
+
+  useEffect(() => { void loadSnapshot(); }, [loadSnapshot]);
+
+  // Fallback: if cooked data is empty, initialize date from legacy dailysummary
   useEffect(() => {
-    const initializeDate = async () => {
+    if (snapshot === null) return; // wait for snapshot first
+    if (snapshot.dailyPerformance.length > 0) return; // cooked data available
+
+    const initLegacyDate = async () => {
       try {
         const latest = await getLatestMonthSummary();
-        if (!latest) {
-          return;
-        }
+        if (!latest) return;
         setCurrentDate(new Date(latest.year, latest.month - 1, 1));
       } catch (error) {
         console.error("Failed to fetch latest summary month:", error);
       }
     };
+    void initLegacyDate();
+  }, [snapshot]);
 
-    initializeDate();
-  }, []);
-
+  // Fallback: load legacy PnL data when cooked tables are empty
   useEffect(() => {
-    const fetchData = async () => {
+    if (snapshot === null) return;
+    if (snapshot.dailyPerformance.length > 0) return; // cooked data already loaded
+
+    const fetchLegacyData = async () => {
       const year = currentDate.getFullYear();
       const month = currentDate.getMonth() + 1;
       try {
         const summaries: DailySummary[] = await getMonthSummary(year, month);
-
         summaries.sort(
-          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
         );
 
         let cumulativePnl = 0;
@@ -49,29 +82,89 @@ export default function Dashboard() {
         const dayBeforeMonth = new Date(monthStartDate);
         dayBeforeMonth.setDate(dayBeforeMonth.getDate() - 1);
 
-        const finalData = [
+        setPnlData([
           { time: dayBeforeMonth.toISOString().split("T")[0], value: 0 },
           ...chartData,
-        ];
-
-        setPnlData(finalData);
+        ]);
       } catch (error) {
         console.error("Failed to fetch PnL data:", error);
-        const year = currentDate.getFullYear();
-        const month = currentDate.getMonth();
-        const firstDayOfMonth = new Date(year, month, 1)
+        const firstDayOfMonth = new Date(year, currentDate.getMonth(), 1)
           .toISOString()
           .split("T")[0];
         setPnlData([{ time: firstDayOfMonth, value: 0 }]);
       }
     };
 
-    fetchData();
-  }, [currentDate]);
+    void fetchLegacyData();
+  }, [currentDate, snapshot]);
 
   return (
     <div>
-      <h2 className="text-2xl font-bold">Dashboard</h2>
+      {/* Header row with freshness badge and refresh trigger */}
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-bold">Dashboard</h2>
+        <div className="flex items-center gap-3">
+          {snapshot && (
+            <DashboardFreshnessBadge
+              freshnessStatus={snapshot.freshnessStatus}
+              refreshState={snapshot.refreshState}
+              stalenessSeconds={snapshot.stalenessSeconds}
+            />
+          )}
+          <RefreshNowButton onRefreshTriggered={loadSnapshot} />
+        </div>
+      </div>
+
+      {/* First-run empty state */}
+      {snapshot?.isFirstRun && (
+        <div className="rounded-lg border border-slate-700 bg-slate-800/50 p-6 mb-4 text-center text-sm text-slate-400">
+          <p className="font-medium text-slate-200 mb-1">
+            Crunching your data — first refresh in progress
+          </p>
+          <p>
+            Your trading data is being processed. This usually takes less than a minute.
+            Hit <strong>Refresh Now</strong> above to enqueue a run.
+          </p>
+        </div>
+      )}
+
+      {/* Dashboard summary KPIs (from cooked.dashboard_summary) */}
+      {snapshot?.dashboardSummary && (
+        <div className="grid grid-cols-3 gap-3 mb-4 text-sm">
+          <div className="rounded-md bg-slate-800 border border-slate-700 p-3">
+            <span className="text-slate-400 block text-xs mb-1">Net Worth</span>
+            <span className="font-mono text-slate-100 text-lg">
+              {snapshot.dashboardSummary.currency}{" "}
+              {new Decimal(snapshot.dashboardSummary.netWorth).toFixed(2)}
+            </span>
+          </div>
+          <div className="rounded-md bg-slate-800 border border-slate-700 p-3">
+            <span className="text-slate-400 block text-xs mb-1">Daily P&amp;L</span>
+            <span
+              className={`font-mono text-lg ${
+                new Decimal(snapshot.dashboardSummary.dailyPnl).gte(0)
+                  ? "text-green-400"
+                  : "text-red-400"
+              }`}
+            >
+              {new Decimal(snapshot.dashboardSummary.dailyPnl).toFixed(2)}
+            </span>
+          </div>
+          <div className="rounded-md bg-slate-800 border border-slate-700 p-3">
+            <span className="text-slate-400 block text-xs mb-1">YTD P&amp;L</span>
+            <span
+              className={`font-mono text-lg ${
+                new Decimal(snapshot.dashboardSummary.ytdPnl).gte(0)
+                  ? "text-green-400"
+                  : "text-red-400"
+              }`}
+            >
+              {new Decimal(snapshot.dashboardSummary.ytdPnl).toFixed(2)}
+            </span>
+          </div>
+        </div>
+      )}
+
       <PnLCurve data={pnlData} />
       <CalendarView date={currentDate} onDateChange={setCurrentDate} />
       <AddTradeForm />

--- a/apps/frontend/src/components/Dashboard/DashboardFreshnessBadge.tsx
+++ b/apps/frontend/src/components/Dashboard/DashboardFreshnessBadge.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useMemo } from 'react';
+import type { FreshnessStatus, HouseholdRefreshState } from '@/app/dashboard/actions';
+
+interface DashboardFreshnessBadgeProps {
+  freshnessStatus: FreshnessStatus;
+  refreshState: HouseholdRefreshState | null;
+  /** Seconds since last successful refresh — used for tooltip copy. */
+  stalenessSeconds: number | null;
+}
+
+/** Human-readable "X ago" string for the tooltip. */
+function formatAgo(seconds: number): string {
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+  return `${Math.floor(seconds / 86400)}d ago`;
+}
+
+const STATUS_CONFIG = {
+  fresh: {
+    dot: 'bg-green-500',
+    label: 'Fresh',
+    labelClass: 'text-green-400',
+    badgeClass: 'border-green-800/50 bg-green-900/20',
+  },
+  refreshing: {
+    dot: 'bg-amber-400 animate-pulse',
+    label: 'Refreshing…',
+    labelClass: 'text-amber-400',
+    badgeClass: 'border-amber-800/50 bg-amber-900/20',
+  },
+  stale: {
+    dot: 'bg-amber-500',
+    label: 'Stale',
+    labelClass: 'text-amber-400',
+    badgeClass: 'border-amber-800/50 bg-amber-900/20',
+  },
+  failed: {
+    dot: 'bg-red-500',
+    label: 'Failed',
+    labelClass: 'text-red-400',
+    badgeClass: 'border-red-800/50 bg-red-900/20',
+  },
+} as const satisfies Record<FreshnessStatus, {
+  dot: string;
+  label: string;
+  labelClass: string;
+  badgeClass: string;
+}>;
+
+/**
+ * Small badge shown near the dashboard header indicating data freshness.
+ *
+ * States (issue #73):
+ *   🟢 fresh      — data refreshed within the last 24 hours
+ *   🔄 refreshing — a compute job is in progress
+ *   🟡 stale      — data > 24 h old or never refreshed
+ *   🔴 failed     — the most recent compute run failed
+ */
+export default function DashboardFreshnessBadge({
+  freshnessStatus,
+  refreshState,
+  stalenessSeconds,
+}: DashboardFreshnessBadgeProps) {
+  const config = STATUS_CONFIG[freshnessStatus];
+
+  const tooltipText = useMemo(() => {
+    if (freshnessStatus === 'refreshing') return 'Data refresh in progress';
+    if (!refreshState?.lastSucceededAt) {
+      if (refreshState?.lastFailedAt) {
+        const failedAgo = Math.max(
+          0,
+          Math.floor((Date.now() - new Date(refreshState.lastFailedAt).getTime()) / 1000),
+        );
+        return `Last refresh failed ${formatAgo(failedAgo)}${refreshState.lastError ? ` — ${refreshState.lastError}` : ''}`;
+      }
+      return 'No successful refresh yet';
+    }
+    const ago = stalenessSeconds != null ? formatAgo(stalenessSeconds) : 'unknown';
+    if (freshnessStatus === 'failed' && refreshState?.lastError) {
+      return `Last refresh failed — last success ${ago}`;
+    }
+    return `Last updated ${ago}`;
+  }, [freshnessStatus, refreshState, stalenessSeconds]);
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md border text-xs font-medium ${config.badgeClass}`}
+      title={tooltipText}
+      aria-label={`Data freshness: ${config.label}. ${tooltipText}`}
+      data-testid="freshness-badge"
+      data-status={freshnessStatus}
+    >
+      <span
+        className={`w-2 h-2 rounded-full flex-shrink-0 ${config.dot}`}
+        aria-hidden="true"
+      />
+      <span className={config.labelClass}>{config.label}</span>
+      {stalenessSeconds != null && freshnessStatus !== 'refreshing' && (
+        <span className="text-slate-500 ml-0.5">· {formatAgo(stalenessSeconds)}</span>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Dashboard/RefreshNowButton.tsx
+++ b/apps/frontend/src/components/Dashboard/RefreshNowButton.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { triggerHouseholdRefresh } from '@/app/dashboard/actions';
+
+interface RefreshNowButtonProps {
+  /** Called when a refresh job is successfully enqueued. */
+  onRefreshTriggered?: () => void;
+}
+
+/**
+ * Button that enqueues a pnl_daily compute job for the current household.
+ * Rate-limited server-side (30 s minimum gap between triggers).
+ */
+export default function RefreshNowButton({ onRefreshTriggered }: RefreshNowButtonProps) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+
+  function handleClick() {
+    setError(null);
+    startTransition(async () => {
+      const result = await triggerHouseholdRefresh();
+      if (result.ok) {
+        onRefreshTriggered?.();
+      } else {
+        setError(result.error);
+      }
+    });
+  }
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={isPending}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium border
+          border-slate-700 bg-slate-800 text-slate-200 hover:bg-slate-700 hover:border-slate-600
+          disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        aria-label="Trigger a data refresh"
+        data-testid="refresh-now-button"
+      >
+        <RefreshCw
+          size={12}
+          className={isPending ? 'animate-spin' : ''}
+          aria-hidden="true"
+        />
+        {isPending ? 'Queuing…' : 'Refresh Now'}
+      </button>
+      {error && (
+        <p className="text-xs text-amber-400" role="alert" data-testid="refresh-error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Dashboard/__tests__/DashboardFreshnessBadge.test.tsx
+++ b/apps/frontend/src/components/Dashboard/__tests__/DashboardFreshnessBadge.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import DashboardFreshnessBadge from '../DashboardFreshnessBadge';
+import type { HouseholdRefreshState } from '@/app/dashboard/actions';
+
+const BASE_STATE: HouseholdRefreshState = {
+  jobType: 'pnl_daily',
+  lastSucceededAt: null,
+  lastFailedAt: null,
+  lastError: null,
+  lastRunId: null,
+};
+
+describe('DashboardFreshnessBadge', () => {
+  it('renders fresh state with green styling', () => {
+    const freshState: HouseholdRefreshState = {
+      ...BASE_STATE,
+      lastSucceededAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="fresh"
+        refreshState={freshState}
+        stalenessSeconds={60}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('data-status', 'fresh');
+    expect(screen.getByText('Fresh')).toBeInTheDocument();
+    expect(screen.getByText('· 1m ago')).toBeInTheDocument();
+  });
+
+  it('renders refreshing state with amber/pulse styling and no "ago" text', () => {
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="refreshing"
+        refreshState={BASE_STATE}
+        stalenessSeconds={300}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge).toHaveAttribute('data-status', 'refreshing');
+    expect(screen.getByText('Refreshing…')).toBeInTheDocument();
+    // No "ago" text shown during refresh
+    expect(screen.queryByText(/ago/)).toBeNull();
+  });
+
+  it('renders stale state with amber warning', () => {
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="stale"
+        refreshState={BASE_STATE}
+        stalenessSeconds={90000}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge).toHaveAttribute('data-status', 'stale');
+    expect(screen.getByText('Stale')).toBeInTheDocument();
+  });
+
+  it('renders failed state with red banner styling', () => {
+    const failedState: HouseholdRefreshState = {
+      ...BASE_STATE,
+      lastFailedAt: new Date(Date.now() - 300_000).toISOString(),
+      lastError: 'compute error: division by zero',
+    };
+
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="failed"
+        refreshState={failedState}
+        stalenessSeconds={null}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge).toHaveAttribute('data-status', 'failed');
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('shows tooltip with "No successful refresh yet" when state is null', () => {
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="stale"
+        refreshState={null}
+        stalenessSeconds={null}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge).toHaveAttribute('title', 'No successful refresh yet');
+  });
+
+  it('shows "last updated X ago" in tooltip for fresh state', () => {
+    const freshState: HouseholdRefreshState = {
+      ...BASE_STATE,
+      lastSucceededAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    };
+
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="fresh"
+        refreshState={freshState}
+        stalenessSeconds={300}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge.getAttribute('title')).toMatch(/Last updated 5m ago/);
+  });
+
+  it('shows failure message in tooltip for failed state with error', () => {
+    const failedState: HouseholdRefreshState = {
+      ...BASE_STATE,
+      lastSucceededAt: new Date(Date.now() - 7200_000).toISOString(),
+      lastFailedAt: new Date(Date.now() - 600_000).toISOString(),
+      lastError: 'worker crash',
+    };
+
+    render(
+      <DashboardFreshnessBadge
+        freshnessStatus="failed"
+        refreshState={failedState}
+        stalenessSeconds={7200}
+      />,
+    );
+
+    const badge = screen.getByTestId('freshness-badge');
+    expect(badge.getAttribute('title')).toMatch(/Last refresh failed/);
+  });
+});

--- a/apps/frontend/src/components/Layout/MainLayout.tsx
+++ b/apps/frontend/src/components/Layout/MainLayout.tsx
@@ -137,6 +137,13 @@ function MainLayoutInner({ children }: { children: ReactNode }) {
                             Trading
                         </div>
                         <Link
+                            href="/dashboard"
+                            className="block px-6 py-3 text-base font-medium text-slate-300 hover:text-white hover:bg-slate-800 transition-colors"
+                            onClick={() => setMenuOpen(false)}
+                        >
+                            Dashboard
+                        </Link>
+                        <Link
                             href="/trading/accounts"
                             className="block px-6 py-3 text-base font-medium text-slate-300 hover:text-white hover:bg-slate-800 transition-colors"
                             onClick={() => setMenuOpen(false)}


### PR DESCRIPTION
Decision drop for PR #322 (closes #73 work).

Covers: cooked table choices (daily_performance, dashboard_summary), freshness thresholds (24 h from issue #73 — overrides 5/60 min from brief), refresh trigger UX (30 s rate limit), first-run empty-state strategy, FastAPI deprecation pattern.