### PR TITLE
fix(options): infer lifecycle event_type from notes+PnL for backfill trades

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -48,3 +48,47 @@ This is the **template for all 32 MOVE endpoints**. See decision note at:
 **Merge:** PR #163 rebased on top of #164 (Hockney's RPC), CI green, merged (commit 168171d). Conflict resolution during rebase preserved #163's household context logic.
 
 **Downstream:** PR #166 (Redfoot's comprehensive E2E coverage) depended on #163's household UI, merged successfully after rebase.
+
+## Dual Y-axis: Net Cash Flow vs Realized P&L (2026-05-06)
+
+**Issue:** `NetCashFlowVsRealizedChart` rendered cash-flow bars and cumulative P&L line on a single shared Y-axis, making the bars (±$1K-$10K) invisible against the cumulative line (~$219K).
+
+**Solution:** Dual Y-axis using lightweight-charts' built-in `leftPriceScale` / `rightPriceScale` with `priceScaleId` per series.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx` | Dual axes, currency formatter, axis-hint labels |
+| `apps/frontend/src/components/Options/__tests__/NetCashFlowVsRealizedChart.test.tsx` | +2 tests (dual-axes, tooltip hints) |
+
+### Implementation details
+
+- `leftPriceScale: { visible: true, borderColor: '#22c55e', scaleMargins: { top: 0.1, bottom: 0.1 } }` — emerald, matches cash-flow bars
+- `rightPriceScale: { borderColor: '#60a5fa', scaleMargins: ... }` — blue, matches P&L line
+- Cash-flow histogram: `priceScaleId: 'left'`
+- Realized P&L + tax lines: `priceScaleId: 'right'`
+- Currency format: `Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 })` passed as `priceFormat: { type: 'custom', formatter }`
+- Legend buttons show axis direction hints: `← left axis` / `right axis →`
+- Tooltip shows `Cash Flow (←)` and `Cumulative P&L (→)`
+
+## Learnings
+
+**Charting library:** `lightweight-charts` v5 (canvas-based, not SVG).
+
+**Dual-axis pattern for this project:**
+```typescript
+// Chart creation
+createChart(el, {
+  leftPriceScale:  { visible: true, borderColor: SERIES_A_COLOR, scaleMargins: { top: 0.1, bottom: 0.1 } },
+  rightPriceScale: {                 borderColor: SERIES_B_COLOR, scaleMargins: { top: 0.1, bottom: 0.1 } },
+});
+
+// Series assignment
+chart.addSeries(HistogramSeries, { priceScaleId: 'left',  priceFormat: { type: 'custom', formatter: currencyFn, minMove: 1 } });
+chart.addSeries(LineSeries,      { priceScaleId: 'right', priceFormat: { type: 'custom', formatter: currencyFn, minMove: 1 } });
+```
+
+**Testing dual axes:** The lightweight-charts mock (in `src/test/setup.ts`) exposes `vi.mocked(createChart).mock.calls` — assert `calls[n][1].leftPriceScale.visible === true` to verify dual-axis config without needing DOM introspection.
+
+Reusable pattern documented in `.squad/skills/dual-axis-chart/SKILL.md`.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -450,3 +450,18 @@ Ran the actual production backfill using 4 manually-exported Activity Flex XML f
 **Key insight:** Python stdout buffering delayed log output during the run, but DB monitoring confirmed steady data ingestion. No failures file generated — all 4 yearly chunks parsed and committed successfully. The database now has complete options history 2022–2025, ready for daily incremental sync to handle 2026-01-01 onward.
 
 📌 Team update (2026-05-06): Flex backfill resilience shipped — 4 rounds completed (Phase A session/CLI flags + failure log + --xml-dir mode + production run 2022–2025). Keaton's pre-merge review in flight.
+
+📌 Team update (2026-07-02): Lifecycle classifier fix shipped — Trade Lifecycle Timeline and Roll Efficiency Donut charts were broken because the 2022–2025 IBKR backfill omitted `openCloseIndicator` from the Flex report template. This caused `_event_type_from_open_close(None)` to return `"adjustment"` for all trades, making the strategy grouper classify every trade as an ungrouped singleton with status "open" (3,562/3,562), and leaving `options_roll_events` completely empty.
+
+**Root cause:** IBKR Flex `Trades` section in backfill XML lacked `openCloseIndicator` attribute → "adjustment" event_type fallback → both `_is_open()` / `_is_close()` fail → no groups form → no rolls detected.
+
+**Fix:**
+1. `flex_parser.py`: New `_event_type_from_trade_attrs()` function infers event_type via: OCI → notes codes (Ep/Ex/A) → fifoPnlRealized != 0 → default "open"
+2. `options_grouping.py`: SQL CASE expressions in `_load_strategy_trades()` apply same inference to existing DB rows at reclassification time
+3. `scripts/reclassify_options.py`: One-shot runner for existing backfill data
+
+**Key learnings:**
+- IBKR `notes` field codes: `Ep` = Expired, `Ex` = Exercised, `A` = Assignment — use these before PnL inference
+- `realized_pnl != 0` is a reliable proxy for "closing trade" in standard FIFO accounting
+- `"P"` notes code was found ~50/50 buy/sell split — meaning unconfirmed, NOT used in inference
+- Reclassification needs both `compute_options_strategy_groups` AND `compute_options_monthly_metrics` re-run to fix donut chart counts

--- a/.squad/skills/dual-axis-chart/SKILL.md
+++ b/.squad/skills/dual-axis-chart/SKILL.md
@@ -1,0 +1,108 @@
+# Skill: Dual Y-Axis Chart (lightweight-charts v5)
+
+**Owner:** Fenster  
+**Last updated:** 2026-05-06  
+**Applies to:** Any chart in `apps/frontend/src/components/**` that uses `lightweight-charts`
+
+---
+
+## When to use this pattern
+
+When a chart renders two series whose values differ by **more than ~5×**, a single shared Y-axis makes the smaller series nearly invisible. Add a dual axis: one scale per series.
+
+Common cases:
+- Monthly per-bar values vs. cumulative line (e.g., cash flow vs. cumulative P&L)
+- Volume histogram vs. price line
+- Percentage return vs. absolute dollar value
+
+---
+
+## Pattern
+
+### 1. Enable both price scales in `createChart`
+
+```typescript
+const chart = createChart(containerEl, {
+  // ...layout, grid, timeScale options...
+  leftPriceScale: {
+    visible: true,                  // MUST be explicit — hidden by default
+    borderColor: SERIES_A_COLOR,    // color-match to the series on this axis
+    scaleMargins: { top: 0.1, bottom: 0.1 },
+  },
+  rightPriceScale: {
+    borderColor: SERIES_B_COLOR,    // color-match to the series on this axis
+    scaleMargins: { top: 0.1, bottom: 0.1 },
+  },
+});
+```
+
+### 2. Assign each series to its axis
+
+```typescript
+const seriesA = chart.addSeries(HistogramSeries, {
+  priceScaleId: 'left',
+  priceFormat: { type: 'custom', formatter: currencyFormatter, minMove: 1 },
+});
+
+const seriesB = chart.addSeries(LineSeries, {
+  color: SERIES_B_COLOR,
+  priceScaleId: 'right',
+  priceFormat: { type: 'custom', formatter: currencyFormatter, minMove: 1 },
+});
+```
+
+### 3. Currency formatter (USD, no decimals, thousands separator)
+
+```typescript
+const currencyFormatter = (price: number): string =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(price);
+```
+
+### 4. UX: label each axis in the legend and tooltip
+
+Legend buttons:
+```tsx
+['cashFlow', 'Monthly cash flow',    'bg-emerald-500', '← left axis'],
+['realized', 'Cumulative P&L',       'bg-blue-400',    'right axis →'],
+```
+
+Tooltip:
+```tsx
+<p>Cash Flow (←): {formatSignedUsd(tooltip.cashFlow)}</p>
+<p>Cumulative P&L (→): {formatSignedUsd(tooltip.cumulativePnl)}</p>
+```
+
+---
+
+## Testing dual axes
+
+The project's lightweight-charts mock (`src/test/setup.ts`) exposes all `createChart` calls via `vi.mocked(createChart).mock.calls`. Assert the axis config was passed correctly — no canvas/DOM introspection needed:
+
+```typescript
+import { createChart } from 'lightweight-charts';
+import { vi } from 'vitest';
+
+it('creates dual Y-axes', async () => {
+  render(<MyChart data={data} />);
+  await waitFor(() => expect(screen.getByTestId('my-chart')).toBeInTheDocument());
+
+  const calls = vi.mocked(createChart).mock.calls;
+  const opts = calls[calls.length - 1][1] as {
+    leftPriceScale?: { visible?: boolean };
+    rightPriceScale?: { borderColor?: string };
+  };
+  expect(opts?.leftPriceScale?.visible).toBe(true);
+  expect(opts?.rightPriceScale?.borderColor).toBeDefined();
+});
+```
+
+---
+
+## Reference implementation
+
+`apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx`  
+Test: `apps/frontend/src/components/Options/__tests__/NetCashFlowVsRealizedChart.test.tsx`

--- a/apps/backend/app/services/options/flex_parser.py
+++ b/apps/backend/app/services/options/flex_parser.py
@@ -228,7 +228,7 @@ def parse_trade_confirm(attrs: dict[str, str], fallback_date: date | None = None
         source_trade_id=_required_any(attrs, ("tradeID", "transactionID")),
         source_transaction_id=_optional_text(attrs.get("transactionID")),
         source_exec_id=_optional_text(attrs.get("ibExecID")),
-        event_type=_event_type_from_open_close(attrs.get("openCloseIndicator")),
+        event_type=_event_type_from_trade_attrs(attrs),
         side=side,
         trade_time=trade_time,
         trade_date=_date_attr(attrs, ("tradeDate", "dateTime"), fallback=trade_time.date()),
@@ -747,6 +747,34 @@ def _event_type_from_open_close(value: str | None) -> str:
     if normalized in {"c", "close"}:
         return "close"
     return "adjustment"
+
+
+def _event_type_from_trade_attrs(attrs: dict[str, str]) -> str:
+    """Derive event_type from trade attributes with notes/PnL fallback.
+
+    When ``openCloseIndicator`` is absent (common in Activity Statement ``Trades``
+    sections that omit that field), falls back to IBKR lifecycle note codes and
+    then to realized-PnL sign:
+
+    1. ``openCloseIndicator`` O/C → "open" / "close"
+    2. notes ``Ep`` → "expire", ``Ex`` → "exercise", ``A`` → "assign"
+    3. ``fifoPnlRealized`` != 0 → "close"  (PnL can only be realized on a close)
+    4. default → "open"
+    """
+    oci = _event_type_from_open_close(attrs.get("openCloseIndicator"))
+    if oci != "adjustment":
+        return oci
+    notes = _notes_codes(attrs.get("notes"))
+    if "ep" in notes:
+        return "expire"
+    if "ex" in notes:
+        return "exercise"
+    if "a" in notes:
+        return "assign"
+    realized_pnl = _optional_decimal(attrs, "fifoPnlRealized")
+    if realized_pnl is not None and realized_pnl != Decimal("0"):
+        return "close"
+    return "open"
 
 
 def _event_type_from_lifecycle(value: str | None) -> str:

--- a/apps/backend/app/worker/handlers/options_grouping.py
+++ b/apps/backend/app/worker/handlers/options_grouping.py
@@ -109,13 +109,29 @@ def _load_strategy_trades(
                    t.account_id,
                    t.trade_time,
                    t.trade_date,
-                   t.event_type::text as event_type,
+                   case
+                     when t.event_type not in ('adjustment')
+                       then t.event_type::text
+                     when t.raw_payload->>'notes' = 'Ep' then 'expire'
+                     when t.raw_payload->>'notes' = 'Ex' then 'exercise'
+                     when t.raw_payload->>'notes' = 'A' then 'assign'
+                     when t.realized_pnl != 0 then 'close'
+                     else 'open'
+                   end as event_type,
                    t.side::text as side,
                    t.quantity,
                    t.net_cash_flow,
                    t.realized_pnl,
                    t.currency,
-                   t.raw_payload ->> 'openCloseIndicator' as open_close_indicator,
+                   case
+                     when t.raw_payload->>'openCloseIndicator' is not null
+                       then t.raw_payload->>'openCloseIndicator'
+                     when t.raw_payload->>'notes' in ('Ep', 'Ex', 'A')
+                       then 'C'
+                     when t.realized_pnl != 0
+                       then 'C'
+                     else 'O'
+                   end as open_close_indicator,
                    l.underlying_symbol,
                    l."right"::text as right,
                    l.strike,

--- a/apps/backend/scripts/reclassify_options.py
+++ b/apps/backend/scripts/reclassify_options.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""One-shot reclassification of options strategy groups and roll events.
+
+Re-runs the strategy grouper and monthly metrics worker against all existing
+backfill data without re-syncing from IBKR. Use this after the lifecycle
+classifier fix to populate correct group statuses and roll-event counts.
+
+Usage::
+
+    # All accounts
+    uv run python scripts/reclassify_options.py
+
+    # Single account
+    uv run python scripts/reclassify_options.py --account U2515365
+
+    # With date window
+    uv run python scripts/reclassify_options.py --from 2022-01-01 --to 2025-12-31
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from datetime import date
+
+from sqlmodel import Session
+
+from app.dal.database import engine
+from app.worker.handlers.options_grouping import compute_options_strategy_groups
+from app.worker.handlers.options_metrics import compute_options_monthly_metrics
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Reclassify options strategy groups and roll events.")
+    parser.add_argument("--account", help="Restrict to a single IBKR account ID (e.g. U2515365)")
+    parser.add_argument("--from", dest="from_date", help="Inclusive start date (YYYY-MM-DD)")
+    parser.add_argument("--to", dest="to_date", help="Inclusive end date (YYYY-MM-DD)")
+    parser.add_argument("--dry-run", action="store_true", help="Run without committing changes")
+    return parser.parse_args()
+
+
+def _parse_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    return date.fromisoformat(value)
+
+
+def main() -> None:
+    args = _parse_args()
+    from_date = _parse_date(args.from_date)
+    to_date = _parse_date(args.to_date)
+
+    logger.info(
+        "Starting options reclassification: account=%s from=%s to=%s dry_run=%s",
+        args.account or "all",
+        from_date or "all",
+        to_date or "all",
+        args.dry_run,
+    )
+
+    with Session(engine) as session:
+        logger.info("Re-running strategy grouper (groups + roll events)…")
+        grouping_result = compute_options_strategy_groups(
+            session,
+            account_id=args.account,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        logger.info(
+            "Grouping complete — groups=%d rolls=%d trades=%d",
+            grouping_result["group_count"],
+            grouping_result["roll_event_count"],
+            grouping_result["trade_count"],
+        )
+
+        logger.info("Rebuilding monthly dashboard metrics…")
+        metrics_result = compute_options_monthly_metrics(
+            session,
+            account_id=args.account,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        logger.info("Metrics complete — monthly_rows=%d", metrics_result["row_count"])
+
+        if args.dry_run:
+            logger.info("Dry-run mode — rolling back changes.")
+            session.rollback()
+        else:
+            session.commit()
+            logger.info("Changes committed successfully.")
+
+    for account in grouping_result.get("accounts", []):
+        logger.info(
+            "  account=%s groups=%d rolls=%d trades=%d",
+            account["account_id"],
+            account["groups"],
+            account["roll_events"],
+            account["trades"],
+        )
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        logger.exception("Reclassification failed: %s", exc)
+        sys.exit(1)

--- a/apps/backend/tests/services/options/test_flex_parser.py
+++ b/apps/backend/tests/services/options/test_flex_parser.py
@@ -7,7 +7,12 @@ import textwrap
 from decimal import Decimal
 from pathlib import Path
 
-from app.services.options.flex_parser import parse_flex_files, parse_open_position, parse_trade_confirm
+from app.services.options.flex_parser import (
+    parse_flex_files,
+    parse_open_position,
+    parse_trade_confirm,
+    _event_type_from_trade_attrs,
+)
 from scripts.flex_synthetic import write_synthetic_files
 
 
@@ -88,7 +93,82 @@ def test_parse_live_flex_trade_and_open_position_aliases() -> None:
     assert position.open_cash_flow == Decimal("-198.95")
 
 
-def test_assignment_synthetic_cash_events_cover_all_sign_cases() -> None:
+# ---------------------------------------------------------------------------
+# event_type inference from notes + fifoPnlRealized
+# ---------------------------------------------------------------------------
+
+_BASE_TRADE_ATTRS: dict[str, str] = {
+    "accountId": "U2515365",
+    "assetCategory": "OPT",
+    "conid": "462456687",
+    "currency": "USD",
+    "dateTime": "20220104;132957",
+    "expiry": "20220121",
+    "multiplier": "100",
+    "putCall": "P",
+    "quantity": "-1",
+    "strike": "315",
+    "symbol": "MSFT  220121P00315000",
+    "tradeID": "4368718712",
+    "tradePrice": "2.48",
+    "underlyingSymbol": "MSFT",
+    "netCash": "-248.65135",
+    "proceeds": "-248",
+    "ibCommission": "-0.65135",
+}
+
+
+def _attrs(**overrides: str) -> dict[str, str]:
+    return {**_BASE_TRADE_ATTRS, **overrides}
+
+
+def test_event_type_open_when_no_oci_no_notes_zero_pnl() -> None:
+    """Backfill rows without openCloseIndicator default to 'open' when fifoPnlRealized is zero."""
+    result = _event_type_from_trade_attrs(_attrs(fifoPnlRealized="0"))
+    assert result == "open"
+
+
+def test_event_type_close_when_no_oci_nonzero_pnl() -> None:
+    """Backfill rows without openCloseIndicator become 'close' when fifoPnlRealized != 0."""
+    result = _event_type_from_trade_attrs(_attrs(fifoPnlRealized="150.00"))
+    assert result == "close"
+
+
+def test_event_type_expire_from_ep_notes() -> None:
+    """IBKR Ep notes code maps to 'expire' regardless of PnL."""
+    result = _event_type_from_trade_attrs(_attrs(notes="Ep", fifoPnlRealized="200.00"))
+    assert result == "expire"
+
+
+def test_event_type_exercise_from_ex_notes() -> None:
+    """IBKR Ex notes code maps to 'exercise'."""
+    result = _event_type_from_trade_attrs(_attrs(notes="Ex", fifoPnlRealized="0"))
+    assert result == "exercise"
+
+
+def test_event_type_assign_from_a_notes() -> None:
+    """IBKR A notes code maps to 'assign' even when fifoPnlRealized is zero."""
+    result = _event_type_from_trade_attrs(_attrs(notes="A", fifoPnlRealized="0"))
+    assert result == "assign"
+
+
+def test_event_type_oci_takes_priority_over_notes() -> None:
+    """Explicit openCloseIndicator=O overrides any notes code."""
+    result = _event_type_from_trade_attrs(_attrs(openCloseIndicator="O", notes="Ep", fifoPnlRealized="200"))
+    assert result == "open"
+
+
+def test_parse_trade_confirm_backfill_row_gets_correct_event_type() -> None:
+    """parse_trade_confirm produces 'close' for a backfill row with non-zero realized PnL."""
+    trade = parse_trade_confirm(_attrs(fifoPnlRealized="150.00"))
+    assert trade.event_type == "close"
+
+
+def test_parse_trade_confirm_backfill_open_row_gets_open_event_type() -> None:
+    """parse_trade_confirm produces 'open' for a backfill row with zero realized PnL."""
+    trade = parse_trade_confirm(_attrs(fifoPnlRealized="0"))
+    assert trade.event_type == "open"
+
     """Assigned/exercised stock legs create correctly signed synthetic cash flow."""
 
     output_dir = Path("tmp/test-options-assignment-synthetic")

--- a/apps/backend/tests/worker/test_options_grouping.py
+++ b/apps/backend/tests/worker/test_options_grouping.py
@@ -119,3 +119,166 @@ def _trade_rows() -> list[dict[str, Any]]:
         row("close-rolled", date(2025, 3, 21), "buy", "C", "535", date(2025, 4, 18), "-3200", "2000", 0),
         row("close-long", date(2025, 3, 21), "sell", "C", "545", date(2025, 3, 21), "2700", "0", 1),
     ]
+
+
+# ---------------------------------------------------------------------------
+# Tests for backfill rows — event_type="adjustment", open_close_indicator inferred
+# from the CASE logic in _load_strategy_trades SQL (simulated via fake session).
+# ---------------------------------------------------------------------------
+
+
+class FakeSessionBackfill:
+    """Fake session returning backfill-style rows (event_type='adjustment', no OCI).
+
+    The SQL fix in _load_strategy_trades rewrites those to open/close/expire/assign
+    via a CASE expression. This session simulates rows *as the fixed SQL would return
+    them*, which is how the grouper sees them after the patch.
+    """
+
+    def __init__(self) -> None:
+        self.groups: list[dict[str, Any]] = []
+        self.rolls: list[dict[str, Any]] = []
+        self.trade_updates: dict[str, str] = {}
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        sql = str(statement)
+        params = params or {}
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [{"id": 1, "household_id": "10000000-0000-0000-0000-000000000001", "account_id": "U2515365"}]
+            )
+        if "from public.options_trades t" in sql:
+            return FakeMappings(_backfill_trade_rows())
+        if "insert into public.options_strategy_groups" in sql:
+            self.groups.append(params)
+        elif "update public.options_trades" in sql:
+            self.trade_updates[str(params["trade_id"])] = str(params["group_id"])
+        elif "insert into public.options_roll_events" in sql:
+            self.rolls.append(params)
+        return FakeMappings([])
+
+
+def _backfill_trade_rows() -> list[dict[str, Any]]:
+    """Simulate what the fixed SQL returns for backfill data.
+
+    These rows have been re-classified from 'adjustment' / null OCI by the CASE
+    expression in _load_strategy_trades. Realized-PnL != 0 rows become 'close'/'C',
+    zero-PnL rows become 'open'/'O', and 'Ep' notes rows become 'expire'/'C'.
+    """
+    household_id = "10000000-0000-0000-0000-000000000001"
+
+    def row(
+        trade_id: str,
+        day: date,
+        side: str,
+        indicator: str,
+        event_type: str,
+        strike: str,
+        expiry: date,
+        cash: str,
+        pnl: str,
+        minute: int = 0,
+    ) -> dict[str, Any]:
+        return {
+            "trade_id": trade_id,
+            "household_id": household_id,
+            "account_id": "U2515365",
+            "trade_time": datetime(day.year, day.month, day.day, 10, minute, tzinfo=timezone.utc),
+            "trade_date": day,
+            "event_type": event_type,
+            "side": side,
+            "quantity": Decimal("-1") if side == "sell" else Decimal("1"),
+            "net_cash_flow": Decimal(cash),
+            "realized_pnl": Decimal(pnl),
+            "currency": "USD",
+            "open_close_indicator": indicator,
+            "underlying_symbol": "MSFT",
+            "right": "put",
+            "strike": Decimal(strike),
+            "expiry": expiry,
+            "multiplier": Decimal("100"),
+            "assignment_cash_flow": Decimal("0"),
+        }
+
+    return [
+        # Open: sold short put, PnL=0 → inferred as open/O
+        row("sell-open", date(2022, 1, 4), "sell", "O", "open", "315", date(2022, 1, 21), "248", "0"),
+        # Close: bought back, PnL != 0 → inferred as close/C
+        row("buy-close", date(2022, 1, 14), "buy", "C", "close", "315", date(2022, 1, 21), "-100", "148"),
+    ]
+
+
+def test_backfill_rows_inferred_as_open_close_form_csp_group() -> None:
+    """Backfill rows with inferred open/close indicators form a closed CSP group."""
+
+    session = FakeSessionBackfill()
+    result = compute_options_strategy_groups(session)  # type: ignore[arg-type]
+
+    assert result["group_count"] == 1
+    assert session.groups[0]["kind"] == "csp"
+    assert session.groups[0]["status"] == "closed"
+    assert set(session.trade_updates) == {"sell-open", "buy-close"}
+
+
+def test_backfill_expired_trade_sets_group_status_to_expired() -> None:
+    """An 'Ep' notes backfill row (inferred as event_type=expire) gives group status 'expired'."""
+
+    household_id = "10000000-0000-0000-0000-000000000001"
+
+    class FakeSessionExpiry(FakeSessionBackfill):
+        def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+            sql = str(statement)
+            if "from public.trading_account_config" in sql:
+                return FakeMappings([{"id": 1, "household_id": household_id, "account_id": "U2515365"}])
+            if "from public.options_trades t" in sql:
+                return FakeMappings(
+                    [
+                        {
+                            "trade_id": "sell-open",
+                            "household_id": household_id,
+                            "account_id": "U2515365",
+                            "trade_time": datetime(2022, 1, 4, 10, 0, tzinfo=timezone.utc),
+                            "trade_date": date(2022, 1, 4),
+                            "event_type": "open",
+                            "side": "sell",
+                            "quantity": Decimal("-1"),
+                            "net_cash_flow": Decimal("248"),
+                            "realized_pnl": Decimal("0"),
+                            "currency": "USD",
+                            "open_close_indicator": "O",
+                            "underlying_symbol": "MSFT",
+                            "right": "put",
+                            "strike": Decimal("315"),
+                            "expiry": date(2022, 1, 21),
+                            "multiplier": Decimal("100"),
+                            "assignment_cash_flow": Decimal("0"),
+                        },
+                        {
+                            "trade_id": "expiry-close",
+                            "household_id": household_id,
+                            "account_id": "U2515365",
+                            "trade_time": datetime(2022, 1, 21, 16, 0, tzinfo=timezone.utc),
+                            "trade_date": date(2022, 1, 21),
+                            "event_type": "expire",  # inferred from notes='Ep'
+                            "side": "buy",
+                            "quantity": Decimal("1"),
+                            "net_cash_flow": Decimal("0"),
+                            "realized_pnl": Decimal("248"),
+                            "currency": "USD",
+                            "open_close_indicator": "C",
+                            "underlying_symbol": "MSFT",
+                            "right": "put",
+                            "strike": Decimal("315"),
+                            "expiry": date(2022, 1, 21),
+                            "multiplier": Decimal("100"),
+                            "assignment_cash_flow": Decimal("0"),
+                        },
+                    ]
+                )
+            return super().execute(statement, params)
+
+    session = FakeSessionExpiry()
+    result = compute_options_strategy_groups(session)  # type: ignore[arg-type]
+
+    assert result["group_count"] == 1
+    assert session.groups[0]["status"] == "expired"

--- a/apps/frontend/src/components/Options/__tests__/NetCashFlowVsRealizedChart.test.tsx
+++ b/apps/frontend/src/components/Options/__tests__/NetCashFlowVsRealizedChart.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import Decimal from 'decimal.js';
-import { describe, expect, it } from 'vitest';
+import { createChart } from 'lightweight-charts';
+import { describe, expect, it, vi } from 'vitest';
 import NetCashFlowVsRealizedChart, { buildOptionsChartSeries } from '../net-cash-flow-vs-realized-chart';
 import type { MonthlyMetric } from '@/types/options';
 
 const months: MonthlyMetric[] = [
-  { accountId: 'DU1', periodStart: '2026-01-01', periodEnd: '2026-01-31', cashFlow: '3000', realizedPnl: '0', cumulativeCashFlow: '3000', cumulativeRealizedPnl: '0', varianceGap: '3000', cumulativeVarianceGap: '3000', tradeCount: 1, rollCount: 0, rollPositiveCount: 0, rollNegativeCount: 0, rollNeutralCount: 0, rollEfficiencyPct: null, lastComputedAt: '2026-01-31T00:00:00Z' },
+  { accountId: 'DU1', periodStart: '2026-01-01', periodEnd: '2026-01-31', cashFlow: '3000', realizedPnl: '0', cumulativeCashFlow: '3000', cumulativeRealizedPnl: '0', varianceGap: '3000', cumulativeVarianceGap: '3000', tradeCount: 1, rollCount: 0, rollPositiveCount: 0, rollNegativeCount: 1, rollNeutralCount: 0, rollEfficiencyPct: null, lastComputedAt: '2026-01-31T00:00:00Z' },
   { accountId: 'DU1', periodStart: '2026-02-01', periodEnd: '2026-02-28', cashFlow: '200', realizedPnl: '-1000', cumulativeCashFlow: '3200', cumulativeRealizedPnl: '-1000', varianceGap: '1200', cumulativeVarianceGap: '4200', tradeCount: 2, rollCount: 1, rollPositiveCount: 0, rollNegativeCount: 1, rollNeutralCount: 0, rollEfficiencyPct: '0', lastComputedAt: '2026-02-28T00:00:00Z' },
   { accountId: 'DU1', periodStart: '2026-03-01', periodEnd: '2026-03-31', cashFlow: '-500', realizedPnl: '2000', cumulativeCashFlow: '2700', cumulativeRealizedPnl: '1000', varianceGap: '-2500', cumulativeVarianceGap: '1700', tradeCount: 1, rollCount: 0, rollPositiveCount: 0, rollNegativeCount: 0, rollNeutralCount: 0, rollEfficiencyPct: null, lastComputedAt: '2026-03-31T00:00:00Z' },
 ];
@@ -23,5 +24,31 @@ describe('NetCashFlowVsRealizedChart', () => {
     await waitFor(() => expect(screen.getByTestId('net-cash-flow-chart')).toBeInTheDocument());
     expect(screen.getByText(/Net Cash Flow vs Realized P&L/i)).toBeInTheDocument();
     expect(screen.getByTestId('options-chart-tooltip')).toHaveTextContent('Variance gap');
+  });
+
+  it('creates dual Y-axes: left for cash flow, right for cumulative P&L', async () => {
+    render(<NetCashFlowVsRealizedChart months={months} />);
+
+    await waitFor(() => expect(screen.getByTestId('net-cash-flow-chart')).toBeInTheDocument());
+
+    const calls = vi.mocked(createChart).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const chartOptions = calls[calls.length - 1][1] as {
+      leftPriceScale?: { visible?: boolean };
+      rightPriceScale?: { borderColor?: string };
+    };
+    // Left axis must be explicitly enabled for the cash-flow histogram
+    expect(chartOptions?.leftPriceScale?.visible).toBe(true);
+    // Right axis must be configured for the cumulative P&L line (blue border)
+    expect(chartOptions?.rightPriceScale?.borderColor).toBe('#60a5fa');
+  });
+
+  it('tooltip labels axis direction for each series', async () => {
+    render(<NetCashFlowVsRealizedChart months={months} />);
+
+    await waitFor(() => expect(screen.getByTestId('options-chart-tooltip')).toBeInTheDocument());
+    const tooltip = screen.getByTestId('options-chart-tooltip');
+    expect(tooltip).toHaveTextContent('Cash Flow (←)');
+    expect(tooltip).toHaveTextContent('Cumulative P&L (→)');
   });
 });

--- a/apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx
+++ b/apps/frontend/src/components/Options/net-cash-flow-vs-realized-chart.tsx
@@ -86,6 +86,9 @@ export default function NetCashFlowVsRealizedChart({ months }: Props) {
   const computed = useMemo(() => buildOptionsChartSeries(months), [months]);
   const [hovered, setHovered] = useState<OptionsChartComputedPoint | null>(null);
 
+  const currencyFormatter = (price: number): string =>
+    new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(price);
+
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -93,24 +96,38 @@ export default function NetCashFlowVsRealizedChart({ months }: Props) {
       height: 360,
       layout: { background: { type: ColorType.Solid, color: '#020617' }, textColor: '#cbd5e1' },
       grid: { vertLines: { color: '#1e293b' }, horzLines: { color: '#1e293b' } },
-      rightPriceScale: { borderColor: '#334155' },
+      // Left axis: monthly cash flow bars (emerald border matches bar colour)
+      leftPriceScale: {
+        visible: true,
+        borderColor: '#22c55e',
+        scaleMargins: { top: 0.1, bottom: 0.1 },
+      },
+      // Right axis: cumulative P&L and tax estimate (blue border matches line colour)
+      rightPriceScale: {
+        borderColor: '#60a5fa',
+        scaleMargins: { top: 0.1, bottom: 0.1 },
+      },
       timeScale: { borderColor: '#334155' },
     });
 
     const cashFlow = chart.addSeries(HistogramSeries, {
-      priceFormat: { type: 'price', precision: 0, minMove: 1 },
-      priceScaleId: 'right',
+      priceFormat: { type: 'custom', formatter: currencyFormatter, minMove: 1 },
+      // Left axis — monthly cash-flow values are orders of magnitude smaller than
+      // the cumulative P&L line, so they need their own independent scale.
+      priceScaleId: 'left',
     });
     const realized = chart.addSeries(LineSeries, {
       color: '#60a5fa',
       lineWidth: 3,
-      priceFormat: { type: 'price', precision: 0, minMove: 1 },
+      priceFormat: { type: 'custom', formatter: currencyFormatter, minMove: 1 },
+      priceScaleId: 'right',
     });
     const tax = chart.addSeries(LineSeries, {
       color: '#94a3b8',
       lineWidth: 2,
       lineStyle: LineStyle.Dotted,
-      priceFormat: { type: 'price', precision: 0, minMove: 1 },
+      priceFormat: { type: 'custom', formatter: currencyFormatter, minMove: 1 },
+      priceScaleId: 'right',
     });
 
     chartRef.current = chart;
@@ -185,17 +202,20 @@ export default function NetCashFlowVsRealizedChart({ months }: Props) {
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
           {([
-            ['cashFlow', 'Monthly cash flow', 'bg-emerald-500'],
-            ['realized', 'Cumulative realized P&L', 'bg-blue-400'],
-            ['tax', '25% tax estimate', 'bg-slate-400'],
-          ] as const).map(([key, label, swatch]) => (
+            ['cashFlow', 'Monthly cash flow', 'bg-emerald-500', '← left axis'],
+            ['realized', 'Cumulative realized P&L', 'bg-blue-400', 'right axis →'],
+            ['tax', '25% tax estimate', 'bg-slate-400', 'right axis →'],
+          ] as const).map(([key, label, swatch, axisHint]) => (
             <button
               key={key}
               type="button"
+              aria-label={`${visibility[key] ? 'Hide' : 'Show'} ${label} (${axisHint})`}
               onClick={() => setVisibility((current) => ({ ...current, [key]: !current[key] }))}
               className={`rounded-full border px-3 py-1.5 ${visibility[key] ? 'border-slate-500 text-slate-100' : 'border-slate-800 text-slate-500'}`}
             >
-              <span className={`mr-2 inline-block h-2 w-2 rounded-full ${swatch}`} />{label}
+              <span className={`mr-2 inline-block h-2 w-2 rounded-full ${swatch}`} />
+              {label}
+              <span className="ml-1.5 opacity-50">{axisHint}</span>
             </button>
           ))}
         </div>
@@ -206,8 +226,14 @@ export default function NetCashFlowVsRealizedChart({ months }: Props) {
         {tooltip && (
           <div className="pointer-events-none absolute left-4 top-4 rounded-2xl border border-slate-700 bg-slate-950/95 p-3 text-xs shadow-xl" data-testid="options-chart-tooltip">
             <p className="font-semibold text-slate-100">{monthLabel(tooltip.time)}</p>
-            <p className="mt-1 text-emerald-300">Cash flow: {formatSignedUsd(tooltip.cashFlow)}</p>
-            <p className="text-blue-300">Realized P&amp;L: {formatSignedUsd(tooltip.cumulativeRealizedPnl)}</p>
+            <p className="mt-1 text-emerald-300">
+              <span className="text-slate-400">Cash Flow (←):</span>{' '}
+              {formatSignedUsd(tooltip.cashFlow)}
+            </p>
+            <p className="text-blue-300">
+              <span className="text-slate-400">Cumulative P&amp;L (→):</span>{' '}
+              {formatSignedUsd(tooltip.cumulativeRealizedPnl)}
+            </p>
             <p className="text-amber-200">Variance gap: {formatSignedUsd(tooltip.varianceGap)}</p>
           </div>
         )}


### PR DESCRIPTION
## Problem

The Trade Lifecycle Timeline shows every position as "open" and the Roll Efficiency Donut shows zero rolls. Root cause: the 2022–2025 IBKR backfill Flex XML omitted `openCloseIndicator` from the report template.

- `flex_parser.py` → `_event_type_from_open_close(None)` returned `"adjustment"` fallback  
- Strategy grouper's `_is_open()` / `_is_close()` both fail for `"adjustment"` / null OCI  
- All 3,562 backfill trades became singleton **ungrouped/open** groups  
- `options_roll_events` is empty (0 rows)  

## Fix

**Priority chain in `_event_type_from_trade_attrs()` (flex_parser.py):**
1. `openCloseIndicator` present → canonical
2. `notes = Ep` → `expire`
3. `notes = Ex` → `exercise`
4. `notes = A` → `assign`
5. `fifoPnlRealized != 0` → `close` (realized PnL only occurs on closes)
6. default → `open`

Same logic applied as SQL CASE expressions in `options_grouping.py` so existing backfill rows are reclassified without re-syncing from IBKR.

## Files changed

- `flex_parser.py` — new `_event_type_from_trade_attrs()`, replaces `_event_type_from_open_close(None)` call
- `options_grouping.py` — CASE expressions in `_load_strategy_trades()` SQL
- `scripts/reclassify_options.py` — one-shot reclassification runner
- `tests/services/options/test_flex_parser.py` — 8 new inference tests
- `tests/worker/test_options_grouping.py` — 2 new backfill grouping tests

## Reclassification

After merging, run once:
```bash
cd apps/backend
uv run python scripts/reclassify_options.py --account U2515365
```

## Tests

25 tests pass, 0 failures.

Working as Hockney (Backend Dev)