### PR TITLE
chore(infra): backup workflow hardening + dedupe (#344-#349)

### DIFF
--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -164,7 +164,11 @@ jobs:
       #       "${{ steps.meta.outputs.filename }}" \
       #       "backups/${{ steps.meta.outputs.filename }}"
 
-  # ── Failure alert: open a GH issue ────────────────────────────────────────
+  # ── Failure alert: open a GH issue (deduped) ──────────────────────────────
+  # Only ONE open backup-failure issue at a time.  If prior open issues with
+  # the same title prefix exist, they are closed as "superseded" before a new
+  # one is created.  This prevents issue-spam when operators manually re-run
+  # a failing workflow multiple times while investigating.
   alert-on-failure:
     name: Open failure issue
     needs: backup
@@ -173,20 +177,59 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Create critical failure issue
+      - name: Deduplicate and create critical failure issue
         uses: actions/github-script@v9
         with:
           script: |
+            const TITLE_PREFIX = '🚨 Nightly backup FAILED';
+
+            // ── 1. Find any existing open backup-failure issues ──────────────
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo:  context.repo.repo,
+              state: 'open',
+              labels: 'squad:kujan',
+              per_page: 50,
+            });
+
+            const priorIssues = existing.data.filter(i =>
+              i.title.startsWith(TITLE_PREFIX)
+            );
+
+            // ── 2. Close each prior issue as "superseded" ────────────────────
+            const supersededRefs = [];
+            for (const issue of priorIssues) {
+              await github.rest.issues.createComment({
+                owner:    context.repo.owner,
+                repo:     context.repo.repo,
+                issue_number: issue.number,
+                body: `⛔ Superseded by a newer failure alert from run [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}). Closing to keep exactly one open backup-failure issue.`,
+              });
+              await github.rest.issues.update({
+                owner:    context.repo.owner,
+                repo:     context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+              supersededRefs.push(`#${issue.number}`);
+            }
+
+            // ── 3. Open a single fresh issue ─────────────────────────────────
+            const supersededNote = supersededRefs.length > 0
+              ? `\n> 🔁 Superseded and closed prior open issue(s): ${supersededRefs.join(', ')}\n`
+              : '';
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo:  context.repo.repo,
-              title: `🚨 Nightly backup FAILED — ${new Date().toISOString().split('T')[0]}`,
+              title: `${TITLE_PREFIX} — ${new Date().toISOString().split('T')[0]}`,
               body: [
                 '## Backup failure alert',
                 '',
                 `**Run:** [${context.runId}](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`,
                 `**Triggered at:** ${new Date().toUTCString()}`,
-                '',
+                supersededNote,
                 '### Action required',
                 '1. Review the failed workflow run linked above.',
                 '2. Verify `SUPABASE_PROD_DB_URL` and `AGE_PUBLIC_KEY` secrets are still valid.',

--- a/.squad/agents/kujan/history.md
+++ b/.squad/agents/kujan/history.md
@@ -11,6 +11,23 @@ DevOps/Platform engineer. Owns Supabase infrastructure, Docker/Aspire setup, CI/
 
 ---
 
+## 2026-05-11 — ✅ Nightly Backup Triage: #344–#349 (pg_dump v17 mismatch + issue-spam dedupe)
+
+**Scope:** Root-cause the 6× backup failure issues filed 2026-05-09 and harden the workflow.
+
+**Root cause:** Commit `870a253` (2026-05-05) added the PGDG APT repo but kept installing `postgresql-client-15`. Supabase runs PostgreSQL 17; `PG_DUMP` pointed to `/usr/lib/postgresql/17/bin/pg_dump` which wasn't installed, causing every nightly run to fail immediately. An operator manually triggered the workflow 6 times while investigating, and the `alert-on-failure` job had no deduplication guard, producing 6 identical `priority:critical` issues (#344–#349).
+
+**Executed:**
+- ✅ Confirmed root cause via log analysis (run 25609713276 shows `postgresql-client-15` install attempt with v17 binary path)
+- ✅ pg_dump fix already applied (commits `04d3558`, `fa6b75c`, `1e9e011`) — backup verified working at run [25654224589](https://github.com/cohenjo/trading-journal/actions/runs/25654224589) (`2026-05-11T06:35:26Z`)
+- ✅ Added deduplication to `alert-on-failure` job: closes prior open `🚨 Nightly backup FAILED` issues as "superseded" before opening a single fresh issue
+- ✅ Filed decisions inbox: `kujan-backup-triage-2026-05-11.md`
+- ✅ Closed issues #344–#349 with root-cause comment
+
+**PR:** `squad/backup-triage-344-349` — `chore(infra): backup workflow hardening + dedupe (#344-#349)`
+
+---
+
 ## 2026-05-10 — ✅ Flex Pipeline v2: Applied Migrations + Rebuilt Worker (Image 82fe82a9)
 
 **Scope:** Infrastructure work to apply Flex v2 schema migrations and deploy updated worker for live Flex sync.


### PR DESCRIPTION
## Summary
Adds issue deduplication to the nightly backup workflow's `alert-on-failure` job.

## Context
On 2026-05-09, 6 manual re-runs of a failing backup (pg_dump v15 vs Supabase Postgres v17 mismatch) spawned 6 identical `priority:critical` issues #344-#349. The root cause was already fixed on main in commits 04d3558, fa6b75c, 1e9e011 — verified by successful run [25654224589](https://github.com/cohenjo/trading-journal/actions/runs/25654224589).

This patch prevents future issue-spam by ensuring **at most one** open `🚨 Nightly backup FAILED` issue at any time.

## Change
`alert-on-failure` job now:
1. Searches open issues prefixed `🚨 Nightly backup FAILED`
2. Closes each as "superseded" with a comment linking the new run
3. Opens exactly ONE fresh issue

## Recommendations (post-merge follow-ups)
1. Upgrade Supabase tier to remove free-tier inactivity pause failure vector
2. Add external health check (healthchecks.io) for independent monitoring
3. Document pg_dump version policy: bump `postgresql-client-XY` when Supabase upgrades Postgres major version

Closes #344, #345, #346, #347, #348, #349 (already closed manually by Kujan during triage).
