### PR TITLE
chore(migrations): track ad-hoc applied migrations (#335 Steps 1-2)

### DIFF
--- a/.squad/agents/kujan/history.md
+++ b/.squad/agents/kujan/history.md
@@ -11,6 +11,39 @@ DevOps/Platform engineer. Owns Supabase infrastructure, Docker/Aspire setup, CI/
 
 ---
 
+## 2026-05-11 — ✅ Migration Drift Repair: Track Ad-Hoc Migrations (#335 Steps 1–2)
+
+**Scope:** Register 6 ad-hoc-applied migrations in `supabase_migrations.schema_migrations` so `supabase db push` no longer treats them as pending.
+
+**Background:** On 2026-05-10, Flex pipeline Phase 1 DDL was applied directly to prod outside the Supabase CLI migration flow. All schema objects exist in prod but the tracking table had no rows for these versions, causing `db push` to attempt re-runs (which would fail on the non-idempotent `ADD CONSTRAINT` in 000200).
+
+**Executed:**
+- ✅ Verified all 5 DDL migration objects exist in prod (columns, tables, indexes)
+- ✅ Verified 000600 (`bond_holdings_add_listing_exchange`) was already tracked — only 000100–000500 + backfill needed insertion
+- ✅ Dry-run `BEGIN/ROLLBACK` confirmed correct INSERT shape
+- ✅ Applied tracking INSERTs via `supabase_migrations.schema_migrations` with `ON CONFLICT (version) DO NOTHING`
+- ✅ Verification `SELECT` confirmed all 6 rows present
+
+**Versions tracked (tracking only — no DDL re-run):**
+| Version | Name |
+|---------|------|
+| 20260510000100 | extend_stock_positions_flex_fields |
+| 20260510000200 | flex_bond_holdings_snapshot |
+| 20260510000300 | dividend_payments |
+| 20260510000400 | dividend_accruals |
+| 20260510000500 | security_reference |
+| 20260511052500 | backfill_placeholder_account_households |
+
+**Artifacts:**
+- Runbook: `supabase/scripts/track-adhoc-migrations.sql`
+- Decisions inbox: `.squad/decisions/inbox/kujan-migration-tracking-2026-05-11.md`
+
+**PR:** `squad/335-migration-tracking` — `chore(migrations): track ad-hoc applied migrations (#335 Steps 1-2)`
+
+**Handoff:** Hockney can now safely run Step 5 (apply `20260501120000` insurance_policies cleanup). Steps 3+4 (RLS policies) also remain for Hockney.
+
+---
+
 ## 2026-05-11 — ✅ Nightly Backup Triage: #344–#349 (pg_dump v17 mismatch + issue-spam dedupe)
 
 **Scope:** Root-cause the 6× backup failure issues filed 2026-05-09 and harden the workflow.

--- a/.squad/decisions/inbox/kujan-migration-tracking-2026-05-11.md
+++ b/.squad/decisions/inbox/kujan-migration-tracking-2026-05-11.md
@@ -1,0 +1,38 @@
+# Decision: Migration Tracking Repair (Steps 1–2)
+**Author:** Kujan (DevOps/Platform)
+**Date:** 2026-05-11
+**Issue:** #335 — Audit + reconcile Supabase migration drift
+**Ref:** Hockney's audit `.squad/decisions/hockney-migration-drift-audit-2026-05-11.md`
+
+## Decision
+
+Executed Steps 1 and 2 of Hockney's reconciliation plan: inserted 6 tracking rows into
+`supabase_migrations.schema_migrations` for migrations that were applied ad-hoc to prod
+on 2026-05-10/11 but were missing from the tracking table.
+
+**Versions tracked (no DDL re-run):**
+| Version | Name |
+|---------|------|
+| 20260510000100 | extend_stock_positions_flex_fields |
+| 20260510000200 | flex_bond_holdings_snapshot |
+| 20260510000300 | dividend_payments |
+| 20260510000400 | dividend_accruals |
+| 20260510000500 | security_reference |
+| 20260511052500 | backfill_placeholder_account_households |
+
+## Rationale
+
+- All 5 DDL migrations were verified present in prod before inserting tracking rows
+- `ON CONFLICT (version) DO NOTHING` makes the script idempotent
+- Runbook saved to `supabase/scripts/track-adhoc-migrations.sql`
+- No DDL was re-executed; this is tracking-only
+
+## Status After
+
+`supabase db push` will no longer attempt to re-apply these 6 migrations.
+Hockney can now safely proceed to Step 5 (apply `20260501120000` insurance_policies cleanup).
+
+## Handoff
+
+- Steps 3+4 (RLS policies for dividend_payments, dividend_accruals, security_reference) → **Hockney**
+- Step 5 (insurance_policies wave2 cleanup) → **Hockney** (pre-conditions check required first)

--- a/supabase/scripts/track-adhoc-migrations.sql
+++ b/supabase/scripts/track-adhoc-migrations.sql
@@ -1,0 +1,83 @@
+-- ================================================================
+-- Runbook: track-adhoc-migrations.sql
+-- Issue:   #335 — Audit + reconcile Supabase migration drift
+-- Author:  Kujan (DevOps/Platform)
+-- Date:    2026-05-11
+-- ================================================================
+--
+-- BACKGROUND
+-- ----------
+-- On 2026-05-10 the Flex pipeline Phase 1 schema was applied directly
+-- to the production database (ad-hoc, outside the Supabase CLI migration
+-- flow) to meet deployment timing.  The DDL ran successfully and all
+-- schema objects exist in prod, but `supabase_migrations.schema_migrations`
+-- had no rows for these versions.
+--
+-- As a result, `supabase db push` treated them as pending and would
+-- attempt to re-apply the DDL — which would fail because the objects
+-- already exist (particularly the non-idempotent ADD CONSTRAINT in
+-- 000200).
+--
+-- Additionally, 20260511052500 (a data backfill) was applied separately
+-- and was also untracked.
+--
+-- This script registers all 6 migrations as applied WITHOUT re-running
+-- any DDL.  It is idempotent: ON CONFLICT (version) DO NOTHING.
+--
+-- SCHEMA OBJECTS VERIFIED IN PROD BEFORE THIS SCRIPT WAS RUN
+-- ----------------------------------------------------------
+-- 000100: stock_positions.listing_exchange column (+ 7 other flex cols + index)  ✅
+-- 000200: bond_holdings.cusip column (+ 17 other flex cols + index + constraint)  ✅
+-- 000300: dividend_payments table (+ indexes + RLS enabled)                       ✅
+-- 000400: dividend_accruals table  (+ indexes + RLS enabled)                      ✅
+-- 000500: security_reference table (+ indexes + RLS enabled)                      ✅
+-- 052500: trading_account_config backfill — zero NULL household_id rows in prod   ✅
+--
+-- ROLLBACK (no schema change — tracking only)
+-- -------------------------------------------
+-- DELETE FROM supabase_migrations.schema_migrations
+--   WHERE version IN (
+--     '20260510000100', '20260510000200', '20260510000300',
+--     '20260510000400', '20260510000500', '20260511052500'
+--   );
+-- ================================================================
+
+BEGIN;
+
+INSERT INTO supabase_migrations.schema_migrations (version, name, statements)
+VALUES
+  ('20260510000100', 'extend_stock_positions_flex_fields',
+   ARRAY['-- ad-hoc applied 2026-05-10; tracked retrospectively 2026-05-11']),
+
+  ('20260510000200', 'flex_bond_holdings_snapshot',
+   ARRAY['-- ad-hoc applied 2026-05-10; tracked retrospectively 2026-05-11']),
+
+  ('20260510000300', 'dividend_payments',
+   ARRAY['-- ad-hoc applied 2026-05-10; tracked retrospectively 2026-05-11']),
+
+  ('20260510000400', 'dividend_accruals',
+   ARRAY['-- ad-hoc applied 2026-05-10; tracked retrospectively 2026-05-11']),
+
+  ('20260510000500', 'security_reference',
+   ARRAY['-- ad-hoc applied 2026-05-10; tracked retrospectively 2026-05-11']),
+
+  ('20260511052500', 'backfill_placeholder_account_households',
+   ARRAY['-- ad-hoc applied 2026-05-11; tracked retrospectively 2026-05-11'])
+
+ON CONFLICT (version) DO NOTHING;
+
+COMMIT;
+
+-- ================================================================
+-- VERIFICATION QUERY (run after to confirm)
+-- ================================================================
+-- SELECT version, name
+--   FROM supabase_migrations.schema_migrations
+--  WHERE version IN (
+--    '20260510000100', '20260510000200', '20260510000300',
+--    '20260510000400', '20260510000500', '20260511052500'
+--  )
+--  ORDER BY version;
+--
+-- Expected: 6 rows returned.
+-- ================================================================


### PR DESCRIPTION
## Summary

Closes #335 (Steps 1-2)
Working as **Kujan** (DevOps/Platform)

Implements Steps 1 and 2 from Hockney's audit: [.squad/decisions/hockney-migration-drift-audit-2026-05-11.md](../blob/main/.squad/decisions/hockney-migration-drift-audit-2026-05-11.md)

---

## Problem

5 Flex pipeline Phase 1 migrations were applied directly to prod on 2026-05-10 (ad-hoc, outside Supabase CLI). The schema objects all exist in prod, but `supabase_migrations.schema_migrations` had no tracking rows — so `supabase db push` would attempt to re-apply DDL that is already present, failing on the non-idempotent `ADD CONSTRAINT` in 000200.

Additionally, the 2026-05-11 backfill migration (000052500) was also untracked.

---

## What this PR does

**NO DDL changes.** Tracking-only.

Inserts 6 rows into `supabase_migrations.schema_migrations` to register these migrations as applied:

| Version | Name | Schema in prod? |
|---------|------|----------------|
| 20260510000100 | extend_stock_positions_flex_fields | ✅ all 8 columns + index |
| 20260510000200 | flex_bond_holdings_snapshot | ✅ all 19 columns + index + constraint |
| 20260510000300 | dividend_payments | ✅ table + indexes + RLS |
| 20260510000400 | dividend_accruals | ✅ table + indexes + RLS |
| 20260510000500 | security_reference | ✅ table + indexes + RLS |
| 20260511052500 | backfill_placeholder_account_households | ✅ zero NULL household_id rows |

Insertion used `ON CONFLICT (version) DO NOTHING` for idempotency.

---

## Verification

```sql
SELECT version, name FROM supabase_migrations.schema_migrations
WHERE version IN (
  '20260510000100','20260510000200','20260510000300',
  '20260510000400','20260510000500','20260511052500'
)
ORDER BY version;
```

Result (✅ all 6 rows returned):
```
 version        | name
----------------+----------------------------------------------
 20260510000100 | extend_stock_positions_flex_fields
 20260510000200 | flex_bond_holdings_snapshot
 20260510000300 | dividend_payments
 20260510000400 | dividend_accruals
 20260510000500 | security_reference
 20260511052500 | backfill_placeholder_account_households
```

---

## Files changed

- `supabase/scripts/track-adhoc-migrations.sql` — idempotent runbook with full context
- `.squad/agents/kujan/history.md` — updated history entry
- `.squad/decisions/inbox/kujan-migration-tracking-2026-05-11.md` — decision note for Scribe

---

## Handoff

**Hockney can now safely run Step 5** (apply `20260501120000_align_insurance_policies_household_id`).

Steps 3+4 (RLS policies for `dividend_payments`, `dividend_accruals`, `security_reference`) remain for Hockney.