### PR TITLE
fix(a11y, tests): label htmlFor + LadderPage coupon test alignment (#372, #376)

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -1,4 +1,34 @@
+## 2026-05-11 — #372 & #376 Batch Frontend Fixes
+
+**Issues:** #372 (label htmlFor accessibility), #376 (LadderPage coupon test alignment)
+
+### #372 — Label htmlFor accessibility on TradingAccountSettings
+
+**Problem:** PR #371 LURVG found that `getByLabel('Account Type')` timed out in Playwright tests because the form label had no `htmlFor` attribute, preventing screen readers and test tools from associating the label with its form control.
+
+**Fix:** Added `htmlFor`/`id` pairs to all 9 form labels in `TradingAccountSettings.tsx`:
+- `account-name`, `account-type`, `linked-account` (always shown)
+- `host`, `port`, `client-id` (IBKR-specific)
+- `app-key`, `app-secret`, `account-hash` (Schwab/LeumiIRA)
+
+**Impact:** Improves accessibility compliance and enables reliable Playwright label-based queries.
+
+### #376 — LadderPage coupon test alignment
+
+**Problem:** PR #373 introduced `displayCouponRate()` utility with default `decimals: 3`. Production renders 3-decimal coupons (e.g., "4.250%"), but the LadderPage test expected 2 decimals ("4.25%"), causing test failure (518/519 → 519/519).
+
+**Fix:** Updated test expectation in `LadderPage.test.tsx` line 142: `"4.25%"` → `"4.250%"` to match production behavior.
+
+**Rationale:** No need to modify `displayCouponRate` defaults (used elsewhere correctly); test alignment is the right fix.
+
+**Tests:** All 519 tests pass ✅
+
+**Commit:** `2ee7637` on `squad/372-376-fenster-batch` → PR #378.
+
+---
+
 ## 2026-05-12 — #358 Extract displayCouponRate() utility
+
 
 **Issue:** #358 "Bonds: extract displayCouponRate() utility to remove Bug-2 footgun"
 

--- a/apps/frontend/src/app/ladder/__tests__/LadderPage.test.tsx
+++ b/apps/frontend/src/app/ladder/__tests__/LadderPage.test.tsx
@@ -138,8 +138,8 @@ describe('LadderPage — Bond Holdings table (#356 / #364)', () => {
 
     render(<LadderPageWrapper />);
     const couponCell = await screen.findByTestId('coupon-b1');
-    // Should show "4.25%" not "425.00%"
-    expect(couponCell.textContent).toBe('4.25%');
+    // Should show "4.250%" (3 decimals per displayCouponRate utility)
+    expect(couponCell.textContent).toBe('4.250%');
   });
 
   it('shows bond-holdings-empty when IBKR has rungs but no bonds', async () => {

--- a/apps/frontend/src/components/trading/TradingAccountSettings.tsx
+++ b/apps/frontend/src/components/trading/TradingAccountSettings.tsx
@@ -180,8 +180,9 @@ export default function TradingAccountSettings() {
                 <form onSubmit={handleSave} className="space-y-6">
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                         <div className="md:col-span-2">
-                            <label className="block text-sm font-medium text-slate-400 mb-2">Account Name</label>
+                            <label htmlFor="account-name" className="block text-sm font-medium text-slate-400 mb-2">Account Name</label>
                             <input
+                                id="account-name"
                                 type="text"
                                 title="Account Name"
                                 placeholder="e.g. Schwab Main"
@@ -192,8 +193,9 @@ export default function TradingAccountSettings() {
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-slate-400 mb-2">Account Type</label>
+                            <label htmlFor="account-type" className="block text-sm font-medium text-slate-400 mb-2">Account Type</label>
                             <select
+                                id="account-type"
                                 title="Account Type"
                                 value={editingConfig.account_type ?? "ibkr"}
                                 onChange={(e) => setEditingConfig({ ...editingConfig, account_type: e.target.value as TradingAccountConfig['account_type'] })}
@@ -206,8 +208,9 @@ export default function TradingAccountSettings() {
                         </div>
 
                         <div>
-                            <label className="block text-sm font-medium text-slate-400 mb-2">Link to Internal Account</label>
+                            <label htmlFor="linked-account" className="block text-sm font-medium text-slate-400 mb-2">Link to Internal Account</label>
                             <select
+                                id="linked-account"
                                 title="Select internal account to link"
                                 value={editingConfig.linked_account_id ?? ""}
                                 onChange={(e) => setEditingConfig({ ...editingConfig, linked_account_id: e.target.value })}
@@ -223,8 +226,9 @@ export default function TradingAccountSettings() {
                         {isIBKR ? (
                             <>
                                 <div>
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">Host</label>
+                                    <label htmlFor="host" className="block text-sm font-medium text-slate-400 mb-2">Host</label>
                                     <input
+                                        id="host"
                                         type="text"
                                         title="Host"
                                         placeholder="127.0.0.1"
@@ -234,8 +238,9 @@ export default function TradingAccountSettings() {
                                     />
                                 </div>
                                 <div>
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">Port</label>
+                                    <label htmlFor="port" className="block text-sm font-medium text-slate-400 mb-2">Port</label>
                                     <input
+                                        id="port"
                                         type="number"
                                         title="Port"
                                         placeholder="4001"
@@ -245,8 +250,9 @@ export default function TradingAccountSettings() {
                                     />
                                 </div>
                                 <div>
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">Client ID</label>
+                                    <label htmlFor="client-id" className="block text-sm font-medium text-slate-400 mb-2">Client ID</label>
                                     <input
+                                        id="client-id"
                                         type="number"
                                         title="Client ID"
                                         placeholder="1"
@@ -259,8 +265,9 @@ export default function TradingAccountSettings() {
                         ) : (
                             <>
                                 <div className="md:col-span-2">
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">App Key</label>
+                                    <label htmlFor="app-key" className="block text-sm font-medium text-slate-400 mb-2">App Key</label>
                                     <input
+                                        id="app-key"
                                         type="text"
                                         value={editingConfig.app_key || ""}
                                         onChange={(e) => setEditingConfig({ ...editingConfig, app_key: e.target.value })}
@@ -269,8 +276,9 @@ export default function TradingAccountSettings() {
                                     />
                                 </div>
                                 <div className="md:col-span-2">
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">App Secret</label>
+                                    <label htmlFor="app-secret" className="block text-sm font-medium text-slate-400 mb-2">App Secret</label>
                                     <input
+                                        id="app-secret"
                                         type="password"
                                         value={editingConfig.app_secret || ""}
                                         onChange={(e) => setEditingConfig({ ...editingConfig, app_secret: e.target.value })}
@@ -279,8 +287,9 @@ export default function TradingAccountSettings() {
                                     />
                                 </div>
                                 <div className="md:col-span-2">
-                                    <label className="block text-sm font-medium text-slate-400 mb-2">Account Hash</label>
+                                    <label htmlFor="account-hash" className="block text-sm font-medium text-slate-400 mb-2">Account Hash</label>
                                     <input
+                                        id="account-hash"
                                         type="text"
                                         value={editingConfig.account_hash || ""}
                                         onChange={(e) => setEditingConfig({ ...editingConfig, account_hash: e.target.value })}


### PR DESCRIPTION
## Summary

Batch two small frontend fixes addressing accessibility and test alignment issues.

### Task A: Label htmlFor accessibility (#372)

Added `htmlFor` attributes to all label elements and matching `id` attributes to form inputs in `TradingAccountSettings`:
- Account Name (`account-name`)
- Account Type (`account-type`)
- Link to Internal Account (`linked-account`)
- Host, Port, Client ID (IBKR-specific form)
- App Key, App Secret, Account Hash (Schwab/LeumiIRA form)

This fixes the accessibility issue found in PR #371 where `getByLabel('Account Type')` timed out because the label wasn't associated with its form control. Screen readers and Playwright can now properly identify the label-input associations.

### Task B: LadderPage coupon test alignment (#376)

Updated the test expectation in `LadderPage.test.tsx` from `'4.25%'` to `'4.250%'` to match the new `displayCouponRate` utility (PR #373) which defaults to 3 decimal places. Production is already rendering 3 decimals; this aligns the test with the implementation.

## Test Results
- Before: 518/519 tests passing (LadderPage coupon test failing)
- After: **519/519 tests passing** ✅

## Files Changed
- `apps/frontend/src/components/trading/TradingAccountSettings.tsx` — Added htmlFor/id pairs
- `apps/frontend/src/app/ladder/__tests__/LadderPage.test.tsx` — Updated test expectation (4.25% → 4.250%)

## Notes
- Working as **Fenster** (Frontend Dev)
- No changes to `displayCouponRate` utility or other production code
- All tests pass; no regressions detected
- This PR is a good fit for accessibility review if desired

Closes #372
Closes #376