### PR TITLE
fix(trading): capture cost basis + unrealized P&L on import; fix Leumi ticker contamination

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -726,3 +726,26 @@ Rewrote `importManualPositionsCsv` to skip HTTP entirely — parse CSV text in t
 - Schwab CSV has a preamble row with the as-of date in `YYYY/MM/DD` — skip rows 0–1 before the real header.
 - `isSchwabCsv()` content-sniff (first 256 bytes) is more reliable than file extension for broker CSV routing.
 - New DB columns should always have a migration file even when added via `execute_sql` directly.
+
+---
+
+## 2026-05-11 — Parser fixes: cost basis + unrealized P&L + Leumi ticker contamination (PR squad/parser-fixes-cost-basis-leumi-ticker)
+
+**Scope:** Three targeted parser/schema fixes flagged by Jony after using the import flow built in PR #394.
+
+**Changes:**
+1. **`apps/frontend/src/lib/trading/leumi-xls-parser.ts`** — Added `unrealized_pnl` field to `ParsedHolding` interface; fixed `tase_id` extraction to strip Hebrew from col 0; reads col 10 (`רווח ב ₪`) → `unrealized_pnl`; `holdingsToCsv()` emits `unrealized_pnl` column.
+2. **`apps/frontend/src/lib/trading/schwab-csv-parser.ts`** — Maps `Gain $ (Gain/Loss $)` column → `unrealized_pnl` (USD).
+3. **`apps/frontend/src/app/trading/actions.ts`** — Parses `unrealized_pnl` from enriched CSV and writes it to `stock_positions` on import.
+4. **Tests:** 619 → 625 (+6). All green.
+
+**Schema:** No migration needed — `unrealized_pnl` and `cost_basis_total` columns already existed in `stock_positions`.
+
+**Tests:** 619 → 625/625 (+6). Build: ✅ green. LURVG: 🟡 recommended — Redfoot should upload actual Leumi IRA export to validate ticker fix and unrealized_pnl population end-to-end.
+
+## Learnings
+
+- **Leumi ticker contamination root cause:** In the real Leumi SpreadsheetML export, col 0 (`מספר נייר`) contains `"PAPERNUM Hebrew description"` as a combined string (not just the number). The hand-crafted fixture had clean numeric-only cells. Fix: take only the leading whitespace-delimited token from col 0 as `tase_id`. Regression test uses synthetic XML with contaminated col 0.
+- **Fixture fidelity:** Hand-crafted test fixtures can silently diverge from real broker export formats. Always validate parser against a real file (LURVG) before closing a parser PR. If LURVG finds a schema mismatch, update the fixture to match real-world output.
+- **Column coverage on parsers:** When adding a new column to a parser, also check: (1) `ParsedHolding` interface, (2) `holdingsToCsv()` CSV header + row, (3) `importManualPositionsCsv()` column index + insert object. All three must be updated together.
+- **Schema pre-check:** Always query `information_schema.columns` before applying a migration — `unrealized_pnl` and `cost_basis_total` were already in the schema from a previous migration, saving unnecessary DDL.

--- a/.squad/skills/ticker-normalization/SKILL.md
+++ b/.squad/skills/ticker-normalization/SKILL.md
@@ -1,0 +1,91 @@
+# Skill: Ticker Normalization Across Multi-Currency Broker Exports
+
+## Summary
+
+Reusable pattern for cleanly extracting canonical ticker symbols from broker
+export files that may embed additional metadata (description, Hebrew name,
+exchange suffix) in the same cell as the identifier.
+
+**Established by:** Hockney (Backend Dev), 2026-05-11.
+
+---
+
+## Problem: Combined Identifier + Name Cells
+
+Some broker exports (notably Leumi IRA SpreadsheetML) place both the security
+identifier and the human-readable name in a **single cell**, separated by
+whitespace. Example:
+
+```
+col 0 (מספר נייר): "1081843 מיטב השקעות"
+```
+
+If the parser uses the whole cell as the ticker/ID, it leaks the description
+into the `symbol` field — breaking symbol lookup, DB deduplication, and UI
+display.
+
+**Rule:** Always extract **only the leading non-whitespace token** from the
+identifier cell:
+
+```typescript
+const id = (rawCell?.trim() ?? '').split(/\s+/)[0];
+```
+
+This is safe for clean numeric cells AND contaminated combined cells.
+
+---
+
+## Pattern: Exchange + Symbol Derivation (Leumi TASE)
+
+For TASE (Tel Aviv Stock Exchange) paper numbers, the `deriveExchange()`
+function maps `tasePaperId → { symbol, exchange, currency }`:
+
+| Paper number format         | Exchange | Symbol          | Currency |
+|-----------------------------|----------|-----------------|----------|
+| 8-digit starting with `6`  | US / LSE | Extracted from `(…) TICKER [LN]` | USD / GBP |
+| All others                  | TASE     | The paper number itself | ILA      |
+
+For the "6-prefix" foreign securities, the symbol is extracted from the **name
+cell** (col 1), not from col 0. The pattern `\)\s+(.+)$` matches everything
+after the last `)` in the name.
+
+```typescript
+// "(JPMORGAN EQUITY PREMIUM INCOME ETF) JEPI" → "JEPI"
+const parenMatch = desc.match(/\)\s+(.+)$/);
+const tickerPart = parenMatch?.[1].trim();
+const lnMatch = tickerPart.match(/^(.+?)\s+LN$/);
+// LN suffix → LSE; no suffix → US
+```
+
+---
+
+## Currency Conventions
+
+| Exchange | Price unit | DB currency | Notes |
+|----------|-----------|-------------|-------|
+| TASE     | ILA (agorot) | `ILA` | 1 ILS = 100 ILA |
+| US       | USD | `USD` | |
+| LSE      | GBP | `GBP` | |
+| ILS-denominated values (market value, P&L) | ILS | Implicit in column name | Store as `market_value_local`, `unrealized_pnl` |
+
+**Do not** store agorot prices as ILS — they differ by 100×.
+
+---
+
+## Fixture Fidelity Checklist
+
+When creating a test fixture for a broker parser:
+
+- [ ] Use the actual broker file (redacted), not a hand-crafted approximation
+- [ ] Verify combined-cell format (id + name in same cell?)
+- [ ] Verify all numeric columns are present (mark_price, market_value, unrealized_pnl, …)
+- [ ] Preserve Hebrew strings verbatim for encoding regression tests
+- [ ] Run LURVG with a real upload before closing the parser PR
+
+---
+
+## Files
+
+- `apps/frontend/src/lib/trading/leumi-xls-parser.ts` — `deriveExchange()`, `parseLeumiIraXmlText()`
+- `apps/frontend/src/lib/trading/leumi-xls-parser.test.ts` — ticker contamination regression suite
+- Related: `.squad/skills/broker-import-validation/SKILL.md`

--- a/apps/frontend/src/app/trading/actions.ts
+++ b/apps/frontend/src/app/trading/actions.ts
@@ -622,7 +622,7 @@ export async function updateStockPosition(
  *
  * Expected CSV header (enriched format produced by holdingsToCsv / parseSchwabCsv):
  *   ticker,quantity,average_cost,currency,as_of_date,description,mark_price,
- *   market_value,market_value_local,dividend_yield,cost_basis_total
+ *   market_value,market_value_local,dividend_yield,cost_basis_total,unrealized_pnl
  *
  * RLS policy is satisfied by the user-scoped createClient() — the calling user
  * must be a household writer for the target account's household_id.
@@ -681,6 +681,7 @@ export async function importManualPositionsCsv(
     const idxMktValLocal = col('market_value_local');
     const idxDivYld = col('dividend_yield');
     const idxCostBasis = col('cost_basis_total');
+    const idxUnrealizedPnl = col('unrealized_pnl');
 
     if (idxTicker === -1 || idxQty === -1) {
       return { ok: false, error: 'CSV is missing required columns (ticker, quantity)' };
@@ -749,6 +750,7 @@ export async function importManualPositionsCsv(
       const market_value_local = idxMktValLocal !== -1 ? parseOptionalNumber(parseField(fields, idxMktValLocal)) : null;
       const dividend_yield = idxDivYld !== -1 ? parseOptionalNumber(parseField(fields, idxDivYld)) : null;
       const cost_basis_total = idxCostBasis !== -1 ? parseOptionalNumber(parseField(fields, idxCostBasis)) : null;
+      const unrealized_pnl = idxUnrealizedPnl !== -1 ? parseOptionalNumber(parseField(fields, idxUnrealizedPnl)) : null;
 
       return {
         ticker,
@@ -762,6 +764,7 @@ export async function importManualPositionsCsv(
         market_value_local,
         dividend_yield,
         cost_basis_total,
+        unrealized_pnl,
         account_id: accountId,
         household_id: householdId,
         source: 'manual' as const,

--- a/apps/frontend/src/lib/trading/leumi-xls-parser.test.ts
+++ b/apps/frontend/src/lib/trading/leumi-xls-parser.test.ts
@@ -355,7 +355,7 @@ describe('holdingsToCsv', () => {
   it('produces CSV with correct header row', () => {
     const { csv } = holdingsToCsv(holdings);
     const lines = csv.split('\n');
-    expect(lines[0]).toBe('ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total');
+    expect(lines[0]).toBe('ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total,unrealized_pnl');
   });
 
   it('includes mappable holdings (US, LSE, TASE) in CSV', () => {
@@ -402,7 +402,7 @@ describe('holdingsToCsv', () => {
 
   it('produces only header for empty input', () => {
     const { csv, unmappable } = holdingsToCsv([]);
-    expect(csv).toBe('ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total');
+    expect(csv).toBe('ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total,unrealized_pnl');
     expect(unmappable).toHaveLength(0);
   });
 
@@ -540,5 +540,90 @@ describe('parseLeumiIraXmlText — enriched fields', () => {
     const qqqi = holdings.find(h => h.symbol === 'QQQI');
     // The Hebrew inside parens
     expect(qqqi!.description).toContain('ניאוס');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseLeumiIraXmlText — unrealized P&L extraction (Fix 3)
+// ---------------------------------------------------------------------------
+
+describe('parseLeumiIraXmlText — unrealized_pnl', () => {
+  const fixturePath = join(__dirname, '__tests__', 'fixtures', 'leumi-ira-sample.xls');
+  const fixtureXml = readFileSync(fixturePath, 'utf-8');
+
+  it('extracts unrealized_pnl (רווח ב ₪) for TASE holding לאומי', () => {
+    const holdings = parseLeumiIraXmlText(fixtureXml);
+    const leumi = holdings.find(h => h.tase_id === '604611');
+    expect(leumi!.unrealized_pnl).toBeCloseTo(40627.90, 1);
+  });
+
+  it('extracts unrealized_pnl for TASE holding ניו-מד', () => {
+    const holdings = parseLeumiIraXmlText(fixtureXml);
+    const newmed = holdings.find(h => h.tase_id === '475020');
+    expect(newmed!.unrealized_pnl).toBeCloseTo(11462.16, 1);
+  });
+
+  it('extracts unrealized_pnl for US holding JPXN (ILS equivalent)', () => {
+    const holdings = parseLeumiIraXmlText(fixtureXml);
+    const jpxn = holdings.find(h => h.symbol === 'JPXN');
+    expect(jpxn!.unrealized_pnl).toBeCloseTo(97.68, 1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Ticker contamination regression (Fix 2)
+// ---------------------------------------------------------------------------
+
+describe('parseLeumiIraXmlText — ticker contamination regression', () => {
+  it('strips Hebrew description from tase_id when paper number cell contains combined text', () => {
+    // Simulates a real Leumi export where col 0 = "1081843 מיטב השקעות" (number + name concatenated)
+    const xml = `
+      <Row><Cell><Data ss:Type="String">title</Data></Cell></Row>
+      <Row><Cell><Data ss:Type="String">תאריך:</Data></Cell><Cell><Data ss:Type="String">11.05.26</Data></Cell></Row>
+      <Row><Cell><Data ss:Type="String">summary1</Data></Cell></Row>
+      <Row><Cell><Data ss:Type="String">summary2</Data></Cell></Row>
+      <Row><Cell><Data ss:Type="String">מספר נייר</Data></Cell></Row>
+      <Row>
+        <Cell><Data ss:Type="String">1081843 מיטב השקעות</Data></Cell>
+        <Cell><Data ss:Type="String">מיטב השקעות</Data></Cell>
+        <Cell><Data ss:Type="String">לא קיים</Data></Cell>
+        <Cell><Data ss:Type="String">לא קיים</Data></Cell>
+        <Cell><Data ss:Type="Number">1000.00</Data></Cell>
+        <Cell><Data ss:Type="Number">500.00</Data></Cell>
+        <Cell><Data ss:Type="Number">1200.00</Data></Cell>
+        <Cell><Data ss:Type="Number">60000.00</Data></Cell>
+        <Cell><Data ss:Type="Number">0.01</Data></Cell>
+        <Cell><Data ss:Type="Number">0.20</Data></Cell>
+        <Cell><Data ss:Type="Number">10000.00</Data></Cell>
+      </Row>
+    `;
+    const holdings = parseLeumiIraXmlText(xml);
+    expect(holdings).toHaveLength(1);
+    // Symbol must be ONLY the numeric paper number — NOT "1081843 מיטב השקעות"
+    expect(holdings[0].symbol).toBe('1081843');
+    expect(holdings[0].tase_id).toBe('1081843');
+    // Description is correctly taken from col 1
+    expect(holdings[0].description).toBe('מיטב השקעות');
+    // unrealized_pnl from col 10
+    expect(holdings[0].unrealized_pnl).toBeCloseTo(10000.00, 1);
+  });
+
+  it('clean numeric paper number in col 0 still works correctly', () => {
+    const holdings = parseLeumiIraXmlText(`
+      <Row><Cell><Data>title</Data></Cell></Row>
+      <Row><Cell><Data>תאריך:</Data></Cell><Cell><Data>11.05.26</Data></Cell></Row>
+      <Row><Cell><Data>s</Data></Cell></Row>
+      <Row><Cell><Data>s</Data></Cell></Row>
+      <Row><Cell><Data>header</Data></Cell></Row>
+      <Row>
+        <Cell><Data ss:Type="Number">1081843</Data></Cell>
+        <Cell><Data ss:Type="String">מיטב השקעות</Data></Cell>
+        <Cell><Data>לא קיים</Data></Cell>
+        <Cell><Data>לא קיים</Data></Cell>
+        <Cell><Data ss:Type="Number">1000.00</Data></Cell>
+        <Cell><Data ss:Type="Number">500.00</Data></Cell>
+      </Row>
+    `);
+    expect(holdings[0].symbol).toBe('1081843');
   });
 });

--- a/apps/frontend/src/lib/trading/leumi-xls-parser.ts
+++ b/apps/frontend/src/lib/trading/leumi-xls-parser.ts
@@ -83,6 +83,11 @@ export interface ParsedHolding {
   market_value?: number | null;
   /** Total cost basis (Schwab: Cost Basis column). */
   cost_basis_total?: number | null;
+  /**
+   * Unrealized P&L in the holding's native currency.
+   * For Leumi: רווח ב ₪ (ILS). For Schwab: Gain $ (Gain/Loss $, USD).
+   */
+  unrealized_pnl?: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -251,13 +256,17 @@ export function parseLeumiIraXmlText(xmlText: string): ParsedHolding[] {
     // Minimum: tase_id (col 0), description (col 1), avg_cost (col 4), qty (col 5)
     if (row.length < 6) continue;
 
-    const tase_id = row[0]?.trim() ?? '';
+    // Col 0 may contain "PAPERNUM Hebrew description" in some Leumi exports.
+    // Extract ONLY the leading non-whitespace token as the canonical paper number.
+    const tase_id = (row[0]?.trim() ?? '').split(/\s+/)[0];
     const raw_description = row[1]?.trim() ?? '';
     const avg_cost_raw = row[4]?.trim() ?? '';
     const qty_raw = row[5]?.trim() ?? '';
     // Col 6: שער אחרון (last price); Col 7: שווי אחזקה ב ₪ (holding value in ILS)
+    // Col 10: רווח ב ₪ (unrealized P&L in ILS)
     const mark_price_raw = row[6]?.trim() ?? '';
     const market_value_local_raw = row[7]?.trim() ?? '';
+    const unrealized_pnl_raw = row[10]?.trim() ?? '';
 
     if (!tase_id || !raw_description) continue;
 
@@ -272,6 +281,9 @@ export function parseLeumiIraXmlText(xmlText: string): ParsedHolding[] {
 
     const market_value_local_val = parseNumber(market_value_local_raw);
     const market_value_local = isNaN(market_value_local_val) ? null : market_value_local_val;
+
+    const unrealized_pnl_val = parseNumber(unrealized_pnl_raw);
+    const unrealized_pnl = isNaN(unrealized_pnl_val) ? null : unrealized_pnl_val;
 
     const { symbol, exchange, currency } = deriveExchange(raw_description, tase_id);
     const description = extractDescription(raw_description, tase_id);
@@ -291,6 +303,7 @@ export function parseLeumiIraXmlText(xmlText: string): ParsedHolding[] {
       dividend_yield: null,
       market_value: null,
       cost_basis_total: null,
+      unrealized_pnl,
     });
   }
 
@@ -313,7 +326,7 @@ export function holdingsToCsv(holdings: ParsedHolding[]): {
   csv: string;
   unmappable: ParsedHolding[];
 } {
-  const header = 'ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total';
+  const header = 'ticker,quantity,average_cost,currency,as_of_date,description,mark_price,market_value,market_value_local,dividend_yield,cost_basis_total,unrealized_pnl';
   const mappable: ParsedHolding[] = [];
   const unmappable: ParsedHolding[] = [];
 
@@ -333,7 +346,8 @@ export function holdingsToCsv(holdings: ParsedHolding[]): {
     const mktValLocal = (h.market_value_local ?? null) !== null ? String(h.market_value_local) : '';
     const divYld = (h.dividend_yield ?? null) !== null ? String(h.dividend_yield) : '';
     const costBasisTotal = (h.cost_basis_total ?? null) !== null ? String(h.cost_basis_total) : '';
-    return `${h.symbol},${h.quantity},${avg},${h.currency},${h.as_of_date},${desc},${markPr},${mktVal},${mktValLocal},${divYld},${costBasisTotal}`;
+    const unrealizedPnl = (h.unrealized_pnl ?? null) !== null ? String(h.unrealized_pnl) : '';
+    return `${h.symbol},${h.quantity},${avg},${h.currency},${h.as_of_date},${desc},${markPr},${mktVal},${mktValLocal},${divYld},${costBasisTotal},${unrealizedPnl}`;
   });
 
   return { csv: [header, ...rows].join('\n'), unmappable };

--- a/apps/frontend/src/lib/trading/schwab-csv-parser.test.ts
+++ b/apps/frontend/src/lib/trading/schwab-csv-parser.test.ts
@@ -116,6 +116,19 @@ describe('parseSchwabCsv — fixture', () => {
     expect(positions[2].cost_basis_total).toBeCloseTo(8321.65);
   });
 
+  it('parses unrealized_pnl (Gain $) from $-prefixed string (positive, negative, small)', () => {
+    // ABR: -$1,177.00
+    expect(positions[0].unrealized_pnl).toBeCloseTo(-1177.0);
+    // ADC: $1,331.50
+    expect(positions[1].unrealized_pnl).toBeCloseTo(1331.5);
+    // JEPQ: $928.53
+    expect(positions[2].unrealized_pnl).toBeCloseTo(928.53);
+    // WMT: $25,601.33
+    expect(positions[3].unrealized_pnl).toBeCloseTo(25601.33);
+    // SGOV: -$7.99
+    expect(positions[4].unrealized_pnl).toBeCloseTo(-7.99);
+  });
+
   it('sets exchange to US for all positions', () => {
     positions.forEach(p => expect(p.exchange).toBe('US'));
   });

--- a/apps/frontend/src/lib/trading/schwab-csv-parser.ts
+++ b/apps/frontend/src/lib/trading/schwab-csv-parser.ts
@@ -166,6 +166,7 @@ export function parseSchwabCsv(text: string): ParsedHolding[] {
   const idxPrice  = col('price');
   const idxMktVal = col('mkt val');
   const idxCostBasis = col('cost basis');
+  const idxGainDollar = col('gain $');
   const idxDivYld = col('div yld');
 
   if (idxSymbol < 0 || idxQty < 0) return [];
@@ -188,6 +189,7 @@ export function parseSchwabCsv(text: string): ParsedHolding[] {
     const mark_price = idxPrice >= 0 ? parseNum((fields[idxPrice] ?? '')) : null;
     const market_value = idxMktVal >= 0 ? parseCurrency((fields[idxMktVal] ?? '')) : null;
     const cost_basis_total = idxCostBasis >= 0 ? parseCurrency((fields[idxCostBasis] ?? '')) : null;
+    const unrealized_pnl = idxGainDollar >= 0 ? parseCurrency((fields[idxGainDollar] ?? '')) : null;
     const dividend_yield = idxDivYld >= 0 ? parsePct((fields[idxDivYld] ?? '')) : null;
 
     holdings.push({
@@ -205,6 +207,7 @@ export function parseSchwabCsv(text: string): ParsedHolding[] {
       market_value_local: null,   // USD-only account, no local-currency value
       dividend_yield,
       cost_basis_total,
+      unrealized_pnl,
     });
   }
 


### PR DESCRIPTION
Working as Hockney (Backend Dev)

Three targeted parser fixes flagged by Jony after using the import features from PR #394.

## Fix 1 — Schwab CSV: wire `Gain $` → `unrealized_pnl`

The `Gain $ (Gain/Loss $)` column was already in the Schwab CSV but never mapped. Added `col('gain $')` lookup and `parseCurrency()` extraction.

**Before/after (3 sample rows):**
| Symbol | Gain $ raw | unrealized_pnl before | unrealized_pnl after |
|--------|------------|----------------------|----------------------|
| ABR | -$1,177.00 | null | -1177.00 |
| ADC | $1,331.50 | null | 1331.50 |
| JEPQ | $928.53 | null | 928.53 |

## Fix 2 — Leumi IRA XLS: strip Hebrew from symbol field

**Root cause:** In the real Leumi SpreadsheetML export, col 0 contains `"1081843 מיטב השקעות"` (paper number + Hebrew name combined). The parser used the whole cell as `tase_id`, propagating verbatim into `symbol` via `deriveExchange()`.

**Fix:** `const tase_id = (row[0]?.trim() ?? '').split(/\s+/)[0];` — take only the leading token.

| Col 0 value | symbol before | symbol after |
|-------------|--------------|--------------|
| `"1081843 מיטב השקעות"` | `"1081843 מיטב השקעות"` | `"1081843"` |

## Fix 3 — Leumi IRA XLS: extract unrealized P&L from col 10

Col 10 (`רווח ב ₪`) was in the fixture data but parser stopped at col 7. Extended to col 10 → `unrealized_pnl` (ILS).

| tase_id | רווח ב ₪ | unrealized_pnl before | unrealized_pnl after |
|---------|---------|----------------------|----------------------|
| 604611 (לאומי) | 40627.90 | null | 40627.90 |
| 475020 (ניו-מד) | 11462.16 | null | 11462.16 |
| 60457875 (JPXN) | 97.68 | null | 97.68 |

## Schema migration

**None required.** Both `unrealized_pnl` and `cost_basis_total` already exist in `stock_positions`. `importManualPositionsCsv()` updated to parse and write `unrealized_pnl`.

## Tests

619 → 625 (+6). All green. Build green.

## LURVG: 🟡 recommended

Redfoot should upload actual Leumi IRA XLS to staging and assert: (1) symbol is numeric-only for TASE holdings, (2) unrealized_pnl non-null for ILS rows, (3) Schwab CSV unrealized_pnl populates.

⚠️ This task was flagged as 'needs review' — please have a squad member review before merging.