### PR TITLE
fix(ci): make supabase_realtime publication references idempotent (closes #397)

### DIFF
--- a/supabase/migrations/20260509180919_add_stock_positions.sql
+++ b/supabase/migrations/20260509180919_add_stock_positions.sql
@@ -121,5 +121,11 @@ create policy stock_positions_delete on public.stock_positions
   for delete to authenticated
   using (household_id is not null and public.is_household_writer(household_id));
 
--- Add to realtime publication
-alter publication supabase_realtime add table public.stock_positions;
+-- Add to realtime publication (idempotent: handles missing publication on shadow/CI DBs)
+do $$
+begin
+  alter publication supabase_realtime add table public.stock_positions;
+exception
+  when duplicate_object then null;
+  when undefined_object then null;
+end $$;


### PR DESCRIPTION
## Summary

Working as **Hockney** (Backend Dev)

Closes #397

## Root Cause

The `dry-run-on-shadow` CI job provisions a bare Postgres 15 container. Supabase auto-creates the `supabase_realtime` publication on real projects, but this publication doesn't exist in the shadow DB. Migration `20260509180919_add_stock_positions.sql` used a bare `ALTER PUBLICATION supabase_realtime ADD TABLE ...` which fails with:

```
ERROR: publication "supabase_realtime" does not exist
```

## Fix

Wrapped the bare `ALTER PUBLICATION` in a DO block matching the established pattern used in **all other migrations** in the repo:

```sql
do $$
begin
  alter publication supabase_realtime add table public.stock_positions;
exception
  when duplicate_object then null;
  when undefined_object then null;
end $$;
```

- **`undefined_object`** (SQLSTATE 42704) — catches the missing publication on shadow/CI DB
- **`duplicate_object`** — catches re-runs where table is already in the publication
- **Safe on prod** — Supabase has the publication; the ALTER succeeds normally

## Files Changed

- `supabase/migrations/20260509180919_add_stock_positions.sql` lines 124–132 (was line 125)

## Pre-fix CI status: ❌ FAIL
## Post-fix CI status: ⏳ Running