### PR TITLE
test(e2e): fix accounts-phase2 spec testids (closes #404)

### DIFF
--- a/apps/frontend/e2e/flows/accounts-phase2.spec.ts
+++ b/apps/frontend/e2e/flows/accounts-phase2.spec.ts
@@ -24,13 +24,13 @@ test.describe('Phase 2 — accounts tab / header @auth', () => {
       await page.goto('/trading/accounts', { waitUntil: 'networkidle', timeout: 20_000 });
 
       // All three tabs visible with correct display labels
-      await expect(page.getByTestId('tab-ibkr')).toBeVisible();
-      await expect(page.getByTestId('tab-schwab')).toBeVisible();
-      await expect(page.getByTestId('tab-ira')).toBeVisible();
+      await expect(page.getByTestId('account-tab-ibkr')).toBeVisible();
+      await expect(page.getByTestId('account-tab-schwab')).toBeVisible();
+      await expect(page.getByTestId('account-tab-ira')).toBeVisible();
 
-      await expect(page.getByTestId('tab-ibkr')).toHaveText('InteractiveBrokers');
-      await expect(page.getByTestId('tab-schwab')).toHaveText('Schwab');
-      await expect(page.getByTestId('tab-ira')).toHaveText('LeumiIRA');
+      await expect(page.getByTestId('account-tab-ibkr')).toHaveText('InteractiveBrokers');
+      await expect(page.getByTestId('account-tab-schwab')).toHaveText('Schwab');
+      await expect(page.getByTestId('account-tab-ira')).toHaveText('LeumiIRA');
     } finally {
       await cleanupHouseholdData(householdId);
     }
@@ -42,7 +42,8 @@ test.describe('Phase 2 — accounts tab / header @auth', () => {
     try {
       await page.goto('/trading/accounts', { waitUntil: 'networkidle', timeout: 20_000 });
 
-      // IBKR is the default active tab — refresh-button must be visible
+      // Click IBKR tab explicitly before asserting — active tab determines which AccountHeader renders
+      await page.getByTestId('account-tab-ibkr').click();
       await expect(page.getByTestId('refresh-button')).toBeVisible({ timeout: 10_000 });
       await expect(page.getByTestId('add-position-button')).not.toBeVisible();
     } finally {
@@ -58,7 +59,7 @@ test.describe('Phase 2 — accounts tab / header @auth', () => {
       await page.goto('/trading/accounts', { waitUntil: 'networkidle', timeout: 20_000 });
 
       // Switch to Schwab tab
-      await page.getByTestId('tab-schwab').click();
+      await page.getByTestId('account-tab-schwab').click();
 
       await expect(page.getByTestId('add-position-button')).toBeVisible({ timeout: 10_000 });
       await expect(page.getByTestId('refresh-button')).not.toBeVisible();
@@ -74,7 +75,7 @@ test.describe('Phase 2 — accounts tab / header @auth', () => {
     try {
       await page.goto('/trading/accounts', { waitUntil: 'networkidle', timeout: 20_000 });
 
-      await page.getByTestId('tab-ira').click();
+      await page.getByTestId('account-tab-ira').click();
 
       await expect(page.getByTestId('add-position-button')).toBeVisible({ timeout: 10_000 });
       await expect(page.getByTestId('refresh-button')).not.toBeVisible();


### PR DESCRIPTION
## Summary

Working as **Redfoot** (Tester).

Closes #404

### Root cause
`accounts-phase2.spec.ts` was written with stale `data-testid` selectors (`tab-ibkr`, `tab-schwab`, `tab-ira`) that never matched the production UI. The page implementation uses `account-tab-{ibkr,schwab,ira}` — the same prefix established in PRs #354/#355 and validated in PR #402's fix for `trading-accounts.spec.ts`.

### Changes
- `apps/frontend/e2e/flows/accounts-phase2.spec.ts` (lines 27–33, 46, 61, 77):
  - `getByTestId('tab-ibkr')` → `getByTestId('account-tab-ibkr')`
  - `getByTestId('tab-schwab')` → `getByTestId('account-tab-schwab')`
  - `getByTestId('tab-ira')` → `getByTestId('account-tab-ira')`
  - Added explicit `account-tab-ibkr.click()` before IBKR assertions so the active tab is deterministic (mirrors pattern in `trading-accounts.spec.ts`)

### No production code changed — spec selectors only.