### PR TITLE
fix(accounts): Leumi IRA market_value 100x correction — ILA→ILS agorot conversion (closes #407)

### DIFF
--- a/apps/backend/app/worker/yahoo_refresh.py
+++ b/apps/backend/app/worker/yahoo_refresh.py
@@ -354,7 +354,13 @@ def refresh_stock_positions() -> dict[str, Any]:
 
             mark_price: Decimal = data["mark_price"]
             dividend_yield: Decimal | None = data["dividend_yield"]
-            market_value = (quantity * mark_price).quantize(Decimal("0.01"))
+            # TASE mark_price is in ILA (agorot = 1/100 ILS).
+            # Divide by 100 so market_value is stored in ILS, matching the
+            # broker XLS "שווי אחזקה ב ₪" column and all non-TASE positions.
+            if is_tase:
+                market_value = (quantity * mark_price / Decimal("100")).quantize(Decimal("0.01"))
+            else:
+                market_value = (quantity * mark_price).quantize(Decimal("0.01"))
 
             try:
                 _upsert_position_price(

--- a/apps/backend/tests/test_yahoo_refresh.py
+++ b/apps/backend/tests/test_yahoo_refresh.py
@@ -398,6 +398,95 @@ class TestTaseCurrencyNormalization:
         assert "ILA" in update_sql, f"Expected ILA in UPDATE SQL, got: {update_sql}"
         assert "ILS" not in update_sql, f"Must not write ILS in UPDATE SQL, got: {update_sql}"
 
+    def test_tase_market_value_is_in_ils_not_agorot(self) -> None:
+        """TASE market_value must be stored in ILS (mark_price / 100).
+
+        Example: 1000 shares of LUMI.TA at 7550 agorot → market_value = 75,500 ILS,
+        NOT 7,550,000 agorot. The fix divides by 100 when is_tase=True.
+        """
+        mock_session = MagicMock()
+
+        # 1000 shares × 7550 agorot / 100 = 75,500 ILS
+        quantity = Decimal("1000")
+        mark_price_ila = Decimal("7550")
+        expected_market_value_ils = Decimal("75500.00")
+
+        # Import the function under test after patching
+        from app.worker.yahoo_refresh import refresh_stock_positions  # noqa: PLC0415
+
+        tase_pos = _pos(ticker="604611", currency="ILA", listing_exchange=None, quantity=1000.0)
+        mock_yf = _make_yfinance_mock(close=float(mark_price_ila), div_yield=0.04)
+        tase_map = {"604611": "LUMI.TA"}
+
+        captured_params: list[dict] = []
+
+        def capture_execute(stmt, params=None):
+            if params and "market_value" in params:
+                captured_params.append(dict(params))
+            mock_result = MagicMock()
+            mock_result.all.return_value = []
+            return mock_result
+
+        mock_sess = MagicMock()
+        mock_sess.__enter__ = MagicMock(return_value=mock_sess)
+        mock_sess.__exit__ = MagicMock(return_value=False)
+        mock_sess.execute.side_effect = capture_execute
+
+        with (
+            patch("app.worker.yahoo_refresh.Session", return_value=mock_sess),
+            patch("app.worker.yahoo_refresh._load_tase_map", return_value=tase_map),
+            patch("app.worker.yahoo_refresh._fetch_active_positions", return_value=[tase_pos]),
+            patch("yfinance.Ticker", return_value=mock_yf),
+            patch("app.worker.yahoo_refresh.time.sleep"),
+        ):
+            result = refresh_stock_positions()
+
+        assert result["refreshed"] == 1
+        assert captured_params, "Expected upsert params to be captured"
+        stored_market_value = Decimal(captured_params[0]["market_value"])
+        assert stored_market_value == expected_market_value_ils, (
+            f"TASE market_value must be in ILS ({expected_market_value_ils}), "
+            f"got {stored_market_value} (100x too high = agorot not converted)"
+        )
+
+    def test_non_tase_market_value_not_divided(self) -> None:
+        """Non-TASE market_value must use quantity * mark_price directly (no /100)."""
+        mock_session = MagicMock()
+
+        # 10 shares of AAPL at 150 USD → market_value = 1500 USD
+        captured_params: list[dict] = []
+
+        def capture_execute(stmt, params=None):
+            if params and "market_value" in params:
+                captured_params.append(dict(params))
+            mock_result = MagicMock()
+            mock_result.all.return_value = []
+            return mock_result
+
+        mock_sess = MagicMock()
+        mock_sess.__enter__ = MagicMock(return_value=mock_sess)
+        mock_sess.__exit__ = MagicMock(return_value=False)
+        mock_sess.execute.side_effect = capture_execute
+
+        usd_pos = _pos(ticker="AAPL", currency="USD", listing_exchange="NASDAQ", quantity=10.0)
+        mock_yf = _make_yfinance_mock(close=150.0, div_yield=0.005)
+
+        with (
+            patch("app.worker.yahoo_refresh.Session", return_value=mock_sess),
+            patch("app.worker.yahoo_refresh._load_tase_map", return_value={}),
+            patch("app.worker.yahoo_refresh._fetch_active_positions", return_value=[usd_pos]),
+            patch("yfinance.Ticker", return_value=mock_yf),
+            patch("app.worker.yahoo_refresh.time.sleep"),
+        ):
+            result = refresh_stock_positions()
+
+        assert result["refreshed"] == 1
+        assert captured_params, "Expected upsert params to be captured"
+        stored_market_value = Decimal(captured_params[0]["market_value"])
+        assert stored_market_value == Decimal("1500.00"), (
+            f"USD market_value must be quantity × mark_price = 1500, got {stored_market_value}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Schedule registration test


### PR DESCRIPTION
Working as Hockney (Backend Dev)

## Problem

`/trading/accounts?account=ira` showed Leumi IRA totals ~100x too high.
Expected: ~1,340,000 ILS; Actual: ~134,000,000 ILS.

## Root cause

`yahoo_refresh.py` computed `market_value = quantity × mark_price` without dividing by 100 for TASE positions. Yahoo Finance returns TASE prices in ILA (agorot = 1/100 ILS). The worker then wrote the agorot-denominated `market_value` to both `market_value` and `market_value_local`, causing 100x inflation.

**Example (Bank Leumi / LUMI.TA):**
- Before: 1010 shares × 7550 agorot = 7,625,500 (stored as ILS — wrong)
- After: 1010 × 7550 / 100 = 76,255 ILS (correct)

## Fix

One-line change in `yahoo_refresh.py`:
```python
# When is_tase=True: divide by 100 to convert ILA → ILS
if is_tase:
    market_value = (quantity * mark_price / Decimal("100")).quantize(Decimal("0.01"))
else:
    market_value = (quantity * mark_price).quantize(Decimal("0.01"))
```

Decision: **Option A** — store `market_value` / `market_value_local` in ILS; keep `mark_price` in ILA (native Yahoo/broker unit). UI displays as-is, no conversion needed.

## Tests

+2 new assertions in `TestTaseCurrencyNormalization`:
- `test_tase_market_value_is_in_ils_not_agorot` — verifies 1000 × 7550 / 100 = 75,500 ILS
- `test_non_tase_market_value_not_divided` — regression: 10 × 150 = 1,500 USD unchanged

All 621 backend tests pass (3 integration skipped in CI).

## DB verification (pre-fix)

```sql
SELECT ticker, currency, quantity, mark_price, market_value
FROM stock_positions
WHERE account_id IN (SELECT id FROM trading_account_config WHERE lower(name) ILIKE '%ira%')
ORDER BY market_value DESC NULLS LAST LIMIT 5;
```

Pre-fix: LUMI.TA had `market_value=7,625,500` — 100x too high.
Post-fix (after next worker run): expected `~76,255` ILS.

## Worker re-run

After merge, trigger the Yahoo worker `--run-once` to recompute all TASE `market_value` fields. IRA account total should converge to ~1.3M–1.4M ILS.

## Scope

- No schema migrations needed (columns pre-exist)
- No frontend changes needed (UI reads `market_value` directly — correct after fix)
- Does NOT touch `description`, `cost_basis_total`, `unrealized_pnl` (broker-snapshot-only per worker contract)

Closes #407