### PR TITLE
fix(dividends): surface all positions via dividend_yield fallback; add est. badge

### DIFF
--- a/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
+++ b/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
@@ -512,6 +512,99 @@ describe('getDividendPositions', () => {
     expect(result[0].ttm_dividend_total).toBe(44.76);
   });
 
+  it('[regression] surfaces schwab positions with dividend_yield fallback when no payment history exists', async () => {
+    // Simulates Schwab Joint Tenant account: CSV-imported positions have
+    // dividend_yield in stock_positions but NO entries in dividend_payments.
+    // Previously these were silently filtered out; now they surface with source='csv'.
+    mockAuth();
+
+    const schwabPos = {
+      ...IBKR_POS_JEPI,
+      id: 'pos-jepq',
+      account_id: 71,
+      ticker: 'JEPQ',
+      description: 'JPMorgan Nasdaq Equity Premium Income ETF',
+      quantity: 155,
+      mark_price: 59.705,
+      source: 'manual' as const,
+    };
+
+    setupMocks(
+      {
+        household_members: () =>
+          Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+        trading_account_config: () =>
+          Promise.resolve({ data: [{ id: 71, account_id: null }], error: null }),
+        dividend_payments: () => Promise.resolve({ data: [], error: null }),
+        dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+        // dividend_yield stored as a percentage (10.43 = 10.43%) — Yahoo Finance format
+        stock_positions: () =>
+          Promise.resolve({
+            data: [{ ticker: 'JEPQ', dividend_yield: '10.43' }],
+            error: null,
+          }),
+      },
+    );
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([schwabPos]);
+
+    const result = await getDividendPositions('schwab');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('JEPQ');
+    expect(row.source).toBe('csv');
+    // TTM metrics are null (no payment history)
+    expect(row.ttm_dividend_total).toBeNull();
+    expect(row.ttm_div_per_share).toBeNull();
+    // Forward estimate: 59.705 × (10.43/100) = 6.227... → rounded = 6.23 per share
+    // forward_dividend_annual = 6.23 × 155 = 965.65
+    expect(row.forward_div_per_share).toBe(6.23);
+    expect(row.forward_dividend_annual).toBe(965.65);
+  });
+
+  it('[regression] yield fallback uses decimal format correctly (yield ≤ 1)', async () => {
+    // dividend_yield stored as decimal fraction (0.056236 = 5.6236%)
+    mockAuth();
+
+    const pos = {
+      ...IBKR_POS_JEPI,
+      ticker: 'BNS',
+      description: 'Bank of Nova Scotia',
+      quantity: 150,
+      mark_price: 76.99,
+      source: 'manual' as const,
+    };
+
+    setupMocks(
+      {
+        household_members: () =>
+          Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+        trading_account_config: () =>
+          Promise.resolve({ data: [{ id: 71, account_id: null }], error: null }),
+        dividend_payments: () => Promise.resolve({ data: [], error: null }),
+        dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+        stock_positions: () =>
+          Promise.resolve({
+            data: [{ ticker: 'BNS', dividend_yield: '0.056236' }],
+            error: null,
+          }),
+      },
+    );
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([pos]);
+
+    const result = await getDividendPositions('schwab');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.source).toBe('csv');
+    // 0.056236 ≤ 1 → used as-is: 76.99 × 0.056236 = 4.33... → 4.33/share
+    // forward_dividend_annual = 4.33 × 150 = 649.50
+    expect(row.forward_div_per_share).toBe(4.33);
+    expect(row.forward_dividend_annual).toBe(649.5);
+  });
+
   it('[regression] surfaces positions via accruals when payments table is empty (RLS gate regression)', async () => {
     // Simulates early production state where dividend_payments was empty.
     // Even when payments come back empty, accruals-only code path must still surface positions.

--- a/apps/frontend/src/app/dividends/actions.ts
+++ b/apps/frontend/src/app/dividends/actions.ts
@@ -940,6 +940,11 @@ type AccrualRow = {
   ex_date: string;
 };
 
+type YieldRow = {
+  ticker: string;
+  dividend_yield: string | number | null;
+};
+
 /**
  * Returns dividend-enriched positions for one account tab.
  *
@@ -1006,7 +1011,11 @@ export async function getDividendPositions(
   // 20260511102251) scope reads to the authenticated user's household via
   // trading_account_config.account_id → is_household_member(). Standard client
   // is correct here; admin client workaround from #368 is no longer needed.
-  const [paymentsResult, accrualsResult] = await Promise.all([
+  //
+  // yieldDataResult fetches dividend_yield from stock_positions so that
+  // Schwab/IRA positions with no payment history (CSV-imported, no Flex export)
+  // are still surfaced via the Yahoo-enriched yield stored on each row.
+  const [paymentsResult, accrualsResult, yieldDataResult] = await Promise.all([
     supabase
       .from('dividend_payments')
       .select('symbol, amount, ex_date, report_date, type')
@@ -1019,6 +1028,11 @@ export async function getDividendPositions(
       .select('symbol, gross_rate, ex_date')
       .in('symbol', tickers)
       .order('ex_date', { ascending: false }),
+    supabase
+      .from('stock_positions')
+      .select('ticker, dividend_yield')
+      .eq('account_id', config.id)
+      .not('dividend_yield', 'is', null),
   ]);
 
   // Build per-ticker maps from payment rows.
@@ -1062,6 +1076,17 @@ export async function getDividendPositions(
     }
   }
 
+  // Yield fallback from stock_positions (Yahoo-enriched / Schwab CSV-imported).
+  // Values > 1 are stored as a percentage (e.g. 10.43 → 10.43%); values ≤ 1 are
+  // already a decimal fraction (e.g. 0.0520 → 5.20%).  Normalise to [0,1].
+  const yieldByTicker = new Map<string, number>();
+  for (const row of ((yieldDataResult.data ?? []) as YieldRow[])) {
+    const raw = Number(row.dividend_yield ?? 0);
+    if (raw > 0) {
+      yieldByTicker.set(row.ticker as string, raw > 1 ? raw / 100 : raw);
+    }
+  }
+
   const result: DividendPosition[] = [];
 
   for (const pos of positions) {
@@ -1071,9 +1096,12 @@ export async function getDividendPositions(
 
     const hasTTM = ttmTotal !== undefined && ttmTotal > 0;
     const hasAccrual = accrual !== undefined && accrual.gross_rate > 0;
+    // Yield fallback: use stock_positions.dividend_yield when no payment history
+    const yieldFraction = yieldByTicker.get(ticker) ?? 0;
+    const hasYield = yieldFraction > 0;
 
-    // Filter to dividend-bearing only
-    if (!hasTTM && !hasAccrual) continue;
+    // Include position only when at least one dividend signal is present
+    if (!hasTTM && !hasAccrual && !hasYield) continue;
 
     const qty = pos.quantity;
     const price = pos.mark_price;
@@ -1092,12 +1120,16 @@ export async function getDividendPositions(
         ? roundDecimal((ttmDivPerShare / price) * 100, 4)
         : null;
 
-    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised)
+    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised);
+    // fall back to stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
     let forwardDivPerShare: number | null = null;
     if (hasAccrual) {
       forwardDivPerShare = roundCurrency(accrual!.gross_rate * ppy);
-    } else if (ttmDivPerShare !== null) {
+    } else if (hasTTM && ttmDivPerShare !== null) {
       forwardDivPerShare = ttmDivPerShare;
+    } else if (hasYield && price !== null && price > 0) {
+      // Estimate: annualised dividend per share = price × yield fraction
+      forwardDivPerShare = roundCurrency(price * yieldFraction);
     }
 
     const forwardDividendAnnual =
@@ -1129,7 +1161,7 @@ export async function getDividendPositions(
       forward_yield_pct: forwardYieldPct,
       last_payment_date: lastPayDateByTicker.get(ticker) ?? null,
       payment_frequency: freq,
-      source: (hasTTM || hasAccrual) ? 'flex' : null,
+      source: (hasTTM || hasAccrual) ? 'flex' : (hasYield ? 'csv' : null),
     });
   }
 

--- a/apps/frontend/src/components/Dividends/DividendPositionsTable.tsx
+++ b/apps/frontend/src/components/Dividends/DividendPositionsTable.tsx
@@ -96,6 +96,14 @@ export default function DividendPositionsTable({ rows }: Props) {
               <td className="px-3 py-2 text-right">{fmtPct(row.forward_yield_pct)}</td>
               <td className="px-3 py-2 text-right font-medium text-green-400">
                 {fmtMoney(row.forward_dividend_annual)}
+                {row.source === 'csv' && (
+                  <span
+                    className="ml-1 inline-block rounded-full bg-amber-900/60 px-1.5 py-0.5 text-[10px] font-normal text-amber-300 align-middle"
+                    title="Estimated from dividend yield — actual payments not yet recorded. Refreshes after market close via Yahoo Finance."
+                  >
+                    est.
+                  </span>
+                )}
               </td>
               <td className="px-3 py-2 whitespace-nowrap">
                 {fmtFrequency(row.payment_frequency)}


### PR DESCRIPTION
## Working as Fenster (Frontend Dev)

Closes #406

## Problem

The `/dividends` page showed only ~3 Schwab positions (~$430/yr expected annual) instead of ~21 (~$9,200/yr). 


**DB diagnostic** (2026-05-11):
```
account 71 (schwab): 30 positions, 21 with dividend_yield > 0, ALL filtered out except 3
account 72 (ira):    21 positions, 21 with dividend_yield > 0, all filtered out  
account 1  (ibkr):  270 positions, 239 with dividend_yield > 0, mostly visible via payments
```

## Fix

1. **`getDividendPositions()`** — adds a third parallel fetch: `stock_positions.dividend_yield` for the account. Yields > 1 are treated as percentages (e.g. `10.43` → 10.43%), ≤ 1 as decimal fractions (e.g. `0.056236` → 5.62%). Positions qualifying only via yield get `source = 'csv'` and forward metrics estimated as `mark_price × normalised_yield × quantity`.

2. **`DividendPositionsTable`** — adds an amber **est.** pill on the Fwd Annual$ column for `source='csv'` rows, with tooltip: *"Estimated from dividend yield — actual payments not yet recorded. Refreshes after market close via Yahoo Finance."*

3. **Tests** — 2 new regression tests covering:
   - Percentage-stored yield (10.43 = 10.43%, JEPQ scenario)
   - Decimal-stored yield (0.056236 = 5.62%, BNS scenario)

## Coordination with Hockney

Hockney's PR #407 (agorot/ILS unit fix for Leumi IRA mark_price) addresses a related but separate display issue on TASE positions. The `est.` badge will also apply to IRA positions until the Yahoo worker back-fills dividend_payments for those tickers.

## What doesn't change

- Parser logic — untouched (Hockney's lane)  
- Yahoo worker — untouched (Hockney's lane)
- `dividend_yield` data shape in DB — untouched
- Totals: still sum `forward_dividend_annual` only (null-safe, so est. and exact rows both contribute)

## Test results

```
Test Files  56 passed (56)
     Tests  627 passed (627)  ← +2 new regression tests
```