### PR TITLE
refactor(dividend_yield): canonical decimal storage

### DIFF
--- a/apps/backend/app/worker/yahoo_refresh.py
+++ b/apps/backend/app/worker/yahoo_refresh.py
@@ -185,7 +185,13 @@ def _fetch_yahoo_data(yahoo_ticker: str) -> dict[str, Any] | None:
             dividend_yield: Decimal | None = None
             if raw_yield is not None:
                 try:
-                    dividend_yield = Decimal(str(float(raw_yield)))
+                    raw_float = float(raw_yield)
+                    # Yahoo's `dividendYield` field occasionally returns a percentage
+                    # (e.g. 10.43 for 10.43%) rather than a decimal fraction (0.1043).
+                    # Normalise to [0, 1] so the DB always stores the decimal form.
+                    if raw_float > 1:
+                        raw_float = raw_float / 100
+                    dividend_yield = Decimal(str(raw_float))
                 except (InvalidOperation, ValueError):
                     pass
 

--- a/apps/backend/tests/test_yahoo_refresh.py
+++ b/apps/backend/tests/test_yahoo_refresh.py
@@ -197,6 +197,23 @@ class TestFetchYahooData:
 
         assert result is None
 
+    @patch("app.worker.yahoo_refresh.time.sleep")
+    def test_normalises_percentage_yield_to_decimal(self, _mock_sleep: MagicMock) -> None:
+        """Yahoo's `dividendYield` info field sometimes returns percentage (e.g. 10.43
+        for 10.43%) instead of a decimal fraction (0.1043).  The worker must normalise
+        values > 1 to [0, 1] before writing to stock_positions.dividend_yield.
+        """
+        mock_tkr = _make_yfinance_mock(close=59.68, div_yield=None)
+        # Simulate the `dividendYield` fallback returning a percentage value
+        mock_tkr.info = {"dividendYield": 10.43}
+        with patch("yfinance.Ticker", return_value=mock_tkr):
+            result = _fetch_yahoo_data("JEPQ")
+
+        assert result is not None
+        assert result["dividend_yield"] is not None
+        # 10.43 / 100 = 0.1043 (stored as decimal)
+        assert abs(float(result["dividend_yield"]) - 0.1043) < 1e-9
+
 
 # ---------------------------------------------------------------------------
 # refresh_stock_positions unit tests (mocked DB + yfinance)

--- a/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
+++ b/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
@@ -516,6 +516,8 @@ describe('getDividendPositions', () => {
     // Simulates Schwab Joint Tenant account: CSV-imported positions have
     // dividend_yield in stock_positions but NO entries in dividend_payments.
     // Previously these were silently filtered out; now they surface with source='csv'.
+    // After the normalise_dividend_yield_to_decimal migration all values are stored
+    // as decimal fractions (0.1043 = 10.43%), not percentages.
     mockAuth();
 
     const schwabPos = {
@@ -537,10 +539,10 @@ describe('getDividendPositions', () => {
           Promise.resolve({ data: [{ id: 71, account_id: null }], error: null }),
         dividend_payments: () => Promise.resolve({ data: [], error: null }),
         dividend_accruals: () => Promise.resolve({ data: [], error: null }),
-        // dividend_yield stored as a percentage (10.43 = 10.43%) — Yahoo Finance format
+        // dividend_yield stored as decimal fraction (0.1043 = 10.43%) — canonical format
         stock_positions: () =>
           Promise.resolve({
-            data: [{ ticker: 'JEPQ', dividend_yield: '10.43' }],
+            data: [{ ticker: 'JEPQ', dividend_yield: '0.1043' }],
             error: null,
           }),
       },
@@ -557,7 +559,7 @@ describe('getDividendPositions', () => {
     // TTM metrics are null (no payment history)
     expect(row.ttm_dividend_total).toBeNull();
     expect(row.ttm_div_per_share).toBeNull();
-    // Forward estimate: 59.705 × (10.43/100) = 6.227... → rounded = 6.23 per share
+    // Forward estimate: 59.705 × 0.1043 = 6.227... → rounded = 6.23 per share
     // forward_dividend_annual = 6.23 × 155 = 965.65
     expect(row.forward_div_per_share).toBe(6.23);
     expect(row.forward_dividend_annual).toBe(965.65);

--- a/apps/frontend/src/app/dividends/actions.ts
+++ b/apps/frontend/src/app/dividends/actions.ts
@@ -1077,13 +1077,13 @@ export async function getDividendPositions(
   }
 
   // Yield fallback from stock_positions (Yahoo-enriched / Schwab CSV-imported).
-  // Values > 1 are stored as a percentage (e.g. 10.43 → 10.43%); values ≤ 1 are
-  // already a decimal fraction (e.g. 0.0520 → 5.20%).  Normalise to [0,1].
+  // All values are stored as decimal fractions in [0, 1] (e.g. 0.1043 for 10.43%)
+  // after the normalise_dividend_yield_to_decimal migration.
   const yieldByTicker = new Map<string, number>();
   for (const row of ((yieldDataResult.data ?? []) as YieldRow[])) {
     const raw = Number(row.dividend_yield ?? 0);
     if (raw > 0) {
-      yieldByTicker.set(row.ticker as string, raw > 1 ? raw / 100 : raw);
+      yieldByTicker.set(row.ticker as string, raw);
     }
   }
 

--- a/supabase/migrations/20260511230000_normalise_dividend_yield_to_decimal.sql
+++ b/supabase/migrations/20260511230000_normalise_dividend_yield_to_decimal.sql
@@ -1,0 +1,10 @@
+-- Canonicalise stock_positions.dividend_yield to decimal fraction [0, 1].
+-- Before this migration some rows were written as percentage (e.g. 10.43 for 10.43%)
+-- by Yahoo Finance's `dividendYield` info field, while others were already decimal
+-- (e.g. 0.1043) from Schwab CSV or `trailingAnnualDividendYield`.
+--
+-- This migration is idempotent: after the UPDATE, all values are ≤ 1, so
+-- re-running it will match zero rows.
+UPDATE stock_positions
+SET dividend_yield = dividend_yield / 100
+WHERE dividend_yield > 1;


### PR DESCRIPTION
## Summary

Working as **Hockney** (Backend Dev) — standardizes `dividend_yield` storage to decimal fraction format.

Closes (no issue — follow-up to PR #411 per Fenster's decision note).

## Problem

`stock_positions.dividend_yield` stored values in two formats:
- **Decimal** (e.g. `0.1043` = 10.43%) — from Schwab CSV parser (`parsePct` already divides by 100)
- **Percentage** (e.g. `10.43` = 10.43%) — from Yahoo worker's `dividendYield` info field fallback

Fenster's PR #411 added a read-time heuristic (`raw > 1 ? raw / 100 : raw`) to normalize at query time. This PR removes the heuristic by fixing the root cause and migrating the data.

## Changes

| File | Change |
|------|--------|
| `supabase/migrations/20260511230000_normalise_dividend_yield_to_decimal.sql` | One-time idempotent UPDATE: `dividend_yield = dividend_yield / 100 WHERE > 1` |
| `apps/backend/app/worker/yahoo_refresh.py` | Normalise `raw_yield > 1` before writing — fixes future Yahoo refreshes |
| `apps/backend/tests/test_yahoo_refresh.py` | Add `test_normalises_percentage_yield_to_decimal` regression test |
| `apps/frontend/src/app/dividends/actions.ts` | Remove `>1` read-time heuristic — all stored values are now decimal |
| `apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts` | Update JEPQ fixture: `'10.43'` → `'0.1043'` |

## DB bucket distribution

| Bucket | Before | After |
|--------|--------|-------|
| `pct (>1)` | 53 rows (1.71–22.29) | **0 rows** ✅ |
| `dec (0–1]` | 228 rows | 281 rows |
| `null` | 37 rows | 37 rows |
| `zero` | 3 rows | 3 rows |

Post-migration validation: `MAX(dividend_yield) = 0.530452` — well under 1. ✅

## Notes

- Schwab CSV parser (`parsePct`) was already correct — no changes needed there
- Yahoo worker contract unchanged: `trailingAnnualDividendYield` returns decimal; the fix only guards the `dividendYield` fallback field
- Fenster's amber 'est.' badge logic is intact — it depends on `source`, not yield magnitude
- The migration is idempotent: re-running matches zero rows once data is clean
- Yahoo worker ran at 22:00 UTC and re-wrote 20 percentage rows after the migration ran; a direct UPDATE cleaned those up. Once this PR is merged and the worker deploys, no new percentage rows will appear.