### PR TITLE
fix(yield): decimal enforcement CHECK constraint + worker container rebuild

### DIFF
--- a/supabase/migrations/20260512010000_enforce_dividend_yield_decimal.sql
+++ b/supabase/migrations/20260512010000_enforce_dividend_yield_decimal.sql
@@ -1,0 +1,10 @@
+-- Enforce dividend_yield is always stored as decimal fraction [0, 1].
+-- Any future worker bug writing a percentage (e.g. 14.06 for 14.06%) will
+-- cause a loud constraint violation rather than silently inflating UI numbers.
+--
+-- The normalise migration (20260511230000) already converted all existing rows;
+-- this constraint locks the door going forward.
+
+ALTER TABLE stock_positions
+    ADD CONSTRAINT chk_dividend_yield_decimal
+    CHECK (dividend_yield IS NULL OR (dividend_yield >= 0 AND dividend_yield <= 1));


### PR DESCRIPTION
## Working as Hockney (Backend Dev)

## Root Cause
The backend container `trading_journal_backend_supabase` was running pre-PR-#413 code that lacked the `raw_float > 1` normalization. After #413's migration converted 53 percentage rows to decimal, the stale worker ran again and overwrote XFLT back to `14.06` (percentage) — causing the UI to show ~$18k instead of the expected ~$9k for the Schwab account.

## Changes
- **`supabase/migrations/20260512010000_enforce_dividend_yield_decimal.sql`** — CHECK constraint `chk_dividend_yield_decimal` enforcing `dividend_yield IS NULL OR (dividend_yield BETWEEN 0 AND 1)`. Any future percentage write fails loudly instead of silently inflating UI values.

## Actions Taken (operational)
1. Rebuilt container from current source (SHA `33fd12cab77e`) — now has `raw_float > 1` normalization at write time
2. Fixed stale DB rows: `UPDATE stock_positions SET dividend_yield = dividend_yield / 100 WHERE dividend_yield > 1`
3. Verified post-rebuild Yahoo refresh: XFLT = `0.140600` ✅

## Before / After
| State | XFLT dividend_yield | Bucket distribution |
|-------|-------------------|---------------------|
| Before fix | 14.060000 | 3 pct rows |
| After fix + refresh | 0.140600 | 281 decimal, 40 null — 0 pct |

## Tests
- Backend: 622/622 passed ✅
- CHECK constraint applied to Supabase prod ✅

Closes #413 regression