### PR TITLE
fix(dividends): TASE/ILA positions show correct ILS amounts (CLIS ₪499.95 not $49,995)

### DIFF
--- a/apps/frontend/src/app/dividends/__tests__/DividendPositionsTable.test.tsx
+++ b/apps/frontend/src/app/dividends/__tests__/DividendPositionsTable.test.tsx
@@ -20,6 +20,7 @@ const makePosition = (overrides: Partial<DividendPosition> = {}): DividendPositi
   avg_cost: 50.00,
   current_price: 55.00,
   market_value: 5500.00,
+  currency: "USD",
   ttm_div_per_share: 2.50,
   ttm_dividend_total: 250.00,
   ttm_yield_pct: 4.545,
@@ -97,10 +98,27 @@ describe("DividendPositionsTable", () => {
     expect(headers).toHaveLength(14);
   });
 
-  it("monetary values include $ prefix via formatCurrency", () => {
-    render(<DividendPositionsTable rows={[makePosition({ market_value: 5500 })]} />);
+  it("monetary values include $ prefix for USD positions via formatCurrency", () => {
+    render(<DividendPositionsTable rows={[makePosition({ market_value: 5500, currency: "USD" })]} />);
     // formatCurrency(5500, 'USD') → '$5,500.00'
     expect(screen.getByText("$5,500.00")).toBeInTheDocument();
+  });
+
+  it("uses ILS symbol (₪) for ILA/ILS positions", () => {
+    render(
+      <DividendPositionsTable
+        rows={[
+          makePosition({
+            ticker: "224014",
+            market_value: 29582.9,
+            currency: "ILS",
+            forward_dividend_annual: 499.95,
+          }),
+        ]}
+      />,
+    );
+    // formatCurrency(499.95, 'ILS') → '₪499.95'
+    expect(screen.getByText("₪499.95")).toBeInTheDocument();
   });
 
   it("yield percentage shows 2 decimals with % suffix", () => {

--- a/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
+++ b/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
@@ -53,10 +53,30 @@ const IBKR_POS_JEPI = {
   cost_basis: 55.0,
   mark_price: 57.5,
   market_value: 5750,
+  market_value_local: null,
   unrealized_pnl: 250,
   currency: 'USD',
   as_of_date: '2026-05-01',
   source: 'flex' as const,
+};
+
+/** CLIS (Clal Insurance, 224014) — TASE position in LeumiIRA with ILA currency.
+ *  mark_price is in agorot (1/100 of ILS); market_value is canonical ILS. */
+const IRA_POS_CLIS = {
+  id: 'pos-clis',
+  account_id: 72,
+  ticker: '224014',
+  description: 'Clal Insurance',
+  sub_category: 'Stock',
+  quantity: 101,
+  cost_basis: null,
+  mark_price: 29290,         // agorot
+  market_value: 29582.90,    // canonical ILS
+  market_value_local: 29582.90,
+  unrealized_pnl: null,
+  currency: 'ILA',           // broker code for Israeli agorot
+  as_of_date: '2026-05-12',
+  source: 'manual' as const,
 };
 
 /** JEPI paid $10.65/month × 12 = ~$127.80/year (but we use exact TTM sum here). */
@@ -646,6 +666,51 @@ describe('getDividendPositions', () => {
     // forward yield from accruals: gross_rate × paymentsPerYear(null/annual) = 0.2705 × 1 = 0.2705
     // roundCurrency rounds to 2dp: 0.27
     expect(result[0].forward_div_per_share).toBe(0.27);
+  });
+
+  it('[regression] TASE/ILA position uses canonical ILS price (mark_price ÷ 100), not agorot', async () => {
+    // CLIS (224014): mark_price=29290 agorot, market_value=29582.90 ILS, qty=101, yield=0.0169.
+    // Bug (pre-fix): forwardDividendAnnual = 29290 × 0.0169 × 101 = 49,995 (100× too big, labelled USD).
+    // Fix: canonicalPrice = 29290 / 100 = 292.90 ILS → 292.90 × 0.0169 = 4.95/sh → 4.95 × 101 = 499.95 ILS.
+    mockAuth();
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 72, account_id: null }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: [], error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: '224014', dividend_yield: '0.0169' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([IRA_POS_CLIS]);
+
+    const result = await getDividendPositions('ira');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('224014');
+    expect(row.source).toBe('csv');
+
+    // canonical price must be ILS (agorot ÷ 100)
+    expect(row.current_price).toBeCloseTo(292.90, 2);
+
+    // market_value from stored pos.market_value (canonical ILS), not qty × mark_price
+    expect(row.market_value).toBe(29582.90);
+
+    // forward_div_per_share = 292.90 × 0.0169 ≈ 4.95 ILS/share
+    expect(row.forward_div_per_share).toBe(4.95);
+
+    // forward_dividend_annual = 4.95 × 101 = 499.95 ILS  (NOT $49,995)
+    expect(row.forward_dividend_annual).toBe(499.95);
+
+    // currency normalised from ILA → ILS
+    expect(row.currency).toBe('ILS');
   });
 });
 

--- a/apps/frontend/src/app/dividends/actions.ts
+++ b/apps/frontend/src/app/dividends/actions.ts
@@ -1104,7 +1104,15 @@ export async function getDividendPositions(
     if (!hasTTM && !hasAccrual && !hasYield) continue;
 
     const qty = pos.quantity;
-    const price = pos.mark_price;
+
+    // ILA (Israeli agorot) is the broker currency code for TASE positions.
+    // mark_price is stored in agorot (1/100 of ILS). Normalise to ILS so that
+    // all dividend calculations use canonical per-share prices, avoiding the
+    // 100× inflation seen in PR #418 (LUMI) and now replicated here.
+    const posCurrency = pos.currency === 'ILA' ? 'ILS' : pos.currency;
+    const rawPrice = pos.mark_price;
+    const canonicalPrice =
+      pos.currency === 'ILA' && rawPrice !== null ? rawPrice / 100 : rawPrice;
 
     // Frequency detection from historical ex-dates
     const exDates = allExDatesByTicker.get(ticker) ?? [];
@@ -1116,20 +1124,21 @@ export async function getDividendPositions(
       hasTTM && qty > 0 ? roundCurrency(ttmTotal! / qty) : null;
     const ttmDividendTotal = hasTTM ? roundCurrency(ttmTotal!) : null;
     const ttmYieldPct =
-      ttmDivPerShare !== null && price !== null && price > 0
-        ? roundDecimal((ttmDivPerShare / price) * 100, 4)
+      ttmDivPerShare !== null && canonicalPrice !== null && canonicalPrice > 0
+        ? roundDecimal((ttmDivPerShare / canonicalPrice) * 100, 4)
         : null;
 
     // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised);
     // fall back to stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
+    // Always use canonicalPrice (ILS for ILA, not agorot) to avoid 100× inflation.
     let forwardDivPerShare: number | null = null;
     if (hasAccrual) {
       forwardDivPerShare = roundCurrency(accrual!.gross_rate * ppy);
     } else if (hasTTM && ttmDivPerShare !== null) {
       forwardDivPerShare = ttmDivPerShare;
-    } else if (hasYield && price !== null && price > 0) {
-      // Estimate: annualised dividend per share = price × yield fraction
-      forwardDivPerShare = roundCurrency(price * yieldFraction);
+    } else if (hasYield && canonicalPrice !== null && canonicalPrice > 0) {
+      // Estimate: annualised dividend per share = canonical_price × yield fraction
+      forwardDivPerShare = roundCurrency(canonicalPrice * yieldFraction);
     }
 
     const forwardDividendAnnual =
@@ -1137,22 +1146,29 @@ export async function getDividendPositions(
         ? roundCurrency(forwardDivPerShare * qty)
         : null;
     const forwardYieldPct =
-      forwardDivPerShare !== null && price !== null && price > 0
-        ? roundDecimal((forwardDivPerShare / price) * 100, 4)
+      forwardDivPerShare !== null && canonicalPrice !== null && canonicalPrice > 0
+        ? roundDecimal((forwardDivPerShare / canonicalPrice) * 100, 4)
         : null;
 
+    // Prefer stored canonical market_value (ILS for TASE, USD for US) over
+    // qty × raw mark_price (which is in agorot for ILA and would be 100× inflated).
     const marketValue =
-      qty > 0 && price !== null
-        ? roundCurrency(qty * price)
-        : (pos.market_value ?? null);
+      pos.market_value != null
+        ? pos.market_value
+        : pos.market_value_local != null
+          ? pos.market_value_local
+          : canonicalPrice !== null && qty > 0
+            ? roundCurrency(qty * canonicalPrice)
+            : null;
 
     result.push({
       ticker,
       name: pos.description,
       quantity: qty,
       avg_cost: pos.cost_basis,
-      current_price: price,
+      current_price: canonicalPrice,
       market_value: marketValue,
+      currency: posCurrency,
       ttm_div_per_share: ttmDivPerShare,
       ttm_dividend_total: ttmDividendTotal,
       ttm_yield_pct: ttmYieldPct,
@@ -1183,7 +1199,12 @@ export async function getDividendSummary(): Promise<DividendSummaryResult> {
   ]);
 
   const sum = (positions: DividendPosition[]) =>
-    positions.reduce((total, p) => total + (p.forward_dividend_annual ?? 0), 0);
+    positions.reduce((total, p) => {
+      const amt = p.forward_dividend_annual ?? 0;
+      // Convert each position's amount to USD for a consistent aggregate total.
+      // ILA positions are already stored in canonical ILS; convertCurrency handles ILS→USD.
+      return total + convertCurrency(amt, p.currency ?? 'USD', 'USD');
+    }, 0);
 
   const ibkrTotal = roundCurrency(sum(ibkr));
   const schwabTotal = roundCurrency(sum(schwab));

--- a/apps/frontend/src/components/Dividends/DividendPositionsTable.tsx
+++ b/apps/frontend/src/components/Dividends/DividendPositionsTable.tsx
@@ -5,9 +5,9 @@ import { formatCurrency } from "@/lib/currency";
 
 // ── Formatters ─────────────────────────────────────────────────────────────────
 
-function fmtMoney(val: number | null): string {
+function fmtMoney(val: number | null, currency = "USD"): string {
   if (val === null || val === undefined) return "—";
-  return formatCurrency(val, "USD");
+  return formatCurrency(val, currency);
 }
 
 function fmtPct(val: number | null): string {
@@ -86,16 +86,16 @@ export default function DividendPositionsTable({ rows }: Props) {
                 {row.name ?? "—"}
               </td>
               <td className="px-3 py-2 text-right">{fmtQty(row.quantity)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.avg_cost)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.current_price)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.market_value)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.ttm_div_per_share)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.avg_cost, row.currency)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.current_price, row.currency)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.market_value, row.currency)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.ttm_div_per_share, row.currency)}</td>
               <td className="px-3 py-2 text-right">{fmtPct(row.ttm_yield_pct)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.ttm_dividend_total)}</td>
-              <td className="px-3 py-2 text-right">{fmtMoney(row.forward_div_per_share)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.ttm_dividend_total, row.currency)}</td>
+              <td className="px-3 py-2 text-right">{fmtMoney(row.forward_div_per_share, row.currency)}</td>
               <td className="px-3 py-2 text-right">{fmtPct(row.forward_yield_pct)}</td>
               <td className="px-3 py-2 text-right font-medium text-green-400">
-                {fmtMoney(row.forward_dividend_annual)}
+                {fmtMoney(row.forward_dividend_annual, row.currency)}
                 {row.source === 'csv' && (
                   <span
                     className="ml-1 inline-block rounded-full bg-amber-900/60 px-1.5 py-0.5 text-[10px] font-normal text-amber-300 align-middle"

--- a/apps/frontend/src/types/dividends.ts
+++ b/apps/frontend/src/types/dividends.ts
@@ -22,8 +22,13 @@ export interface DividendPosition {
   name: string | null;
   quantity: number;
   avg_cost: number | null;
-  current_price: number | null; // mark_price from stock_positions
-  market_value: number | null; // quantity × current_price
+  /** Canonical price in the position's display currency (ILA agorot divided by 100 → ILS). */
+  current_price: number | null;
+  /** Canonical market value in the position's display currency (ILS for TASE, USD for US, etc.). */
+  market_value: number | null;
+  /** ISO 4217 display currency code for all monetary amounts on this position.
+   *  ILA broker code is normalised to ILS (₪). */
+  currency: string;
 
   // TTM (trailing 12 months from CURRENT_DATETIME = 2026-05-11)
   ttm_div_per_share: number | null;


### PR DESCRIPTION
## Problem

Working as **Fenster** (Frontend Dev).

Same LUMI 7.6M pattern (PR #418) — but on the **/dividends page** instead of /trading/accounts.

TASE position CLIS (224014, Clal Insurance, 101 shares) showed **$49,995** annual dividend when DB says **₪499.95**.

Root cause: `getDividendPositions` used `pos.mark_price` (stored in **agorot**, 1/100 of ILS) directly as the per-share price in the `hasYield` dividend estimation path. This caused a **100× inflation** and the display labelled everything USD regardless of position currency.

## Fix

| File | Change |
|------|--------|
| `types/dividends.ts` | Added `currency: string` field to `DividendPosition` |
| `app/dividends/actions.ts` | `canonicalPrice = mark_price / 100` for ILA; prefer stored `market_value` over `qty × mark_price`; use `canonicalPrice` in all calculations; `getDividendSummary` converts ILS→USD via `convertCurrency()` |
| `components/Dividends/DividendPositionsTable.tsx` | `fmtMoney(val, currency)` uses per-row currency instead of hardcoded USD |

## Verification

- CLIS (224014): $49,995 → ₪499.95 ✓ (= 29,582.90 × 0.0169)
- All other TASE positions use same ILA→ILS normalisation
- USD positions: `canonicalPrice = mark_price` (no change) — all existing tests pass
- 634/634 tests pass ✅

## Tests added

- `[regression] TASE/ILA position uses canonical ILS price (mark_price ÷ 100), not agorot`
- `uses ILS symbol (₪) for ILA/ILS positions` in DividendPositionsTable

## Round 4 lesson re-confirmed

Display-layer fixes need to cover **all surfaces**. PR #418 fixed `/trading/accounts`; this PR fixes `/dividends`. Every new view that renders TASE positions must normalise ILA agorot → ILS.