### PR TITLE
fix(currency): Round 8 Phase 2 — extend ÷100 guard to GBP, add GBP rate, QQQI TTM guard

### DIFF
--- a/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
+++ b/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
@@ -712,6 +712,197 @@ describe('getDividendPositions', () => {
     // currency normalised from ILA → ILS
     expect(row.currency).toBe('ILS');
   });
+
+  it('[regression] GBP position (RIO) uses canonicalPrice ÷ 100, yield computed in GBP not pence', async () => {
+    // RIO (Rio Tinto, LSE): broker reports mark_price in pence (GBp = 1/100 GBP).
+    // Pre-fix: canonicalPrice = 7927 pence → yield denominator 100× too large → ~0.05% yield.
+    // Post-fix: canonicalPrice = 79.27 GBP → yield ~5.22%.
+    mockAuth();
+
+    const RIO_POS = {
+      id: 'pos-rio',
+      account_id: 1,
+      ticker: 'RIO',
+      description: 'Rio Tinto PLC',
+      sub_category: 'Stock',
+      quantity: 199,
+      cost_basis: null,
+      mark_price: 7927,          // pence (GBp)
+      market_value: 15774.73,    // GBP (already in major unit)
+      market_value_local: 15774.73,
+      unrealized_pnl: null,
+      currency: 'GBP',           // IBKR sends 'GBP' but stores pence in mark_price
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 1, account_id: IBKR_ACCOUNT_ID_TEXT }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: [], error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: 'RIO', dividend_yield: '0.0522' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([RIO_POS]);
+
+    const result = await getDividendPositions('ibkr');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('RIO');
+    expect(row.source).toBe('csv');
+
+    // canonical price = 7927 pence ÷ 100 = 79.27 GBP (NOT 7927)
+    expect(row.current_price).toBeCloseTo(79.27, 2);
+
+    // market_value from stored canonical GBP value, not qty × pence price
+    expect(row.market_value).toBe(15774.73);
+
+    // currency stays GBP (not ILA-style normalisation needed for GBP itself)
+    expect(row.currency).toBe('GBP');
+
+    // forward div/share = 79.27 × 0.0522 = 4.14 GBP/share
+    expect(row.forward_div_per_share).toBe(4.14);
+
+    // forward yield = 4.14 / 79.27 × 100 ≈ 5.22% (not 0.05% which would result from pence denominator)
+    expect(row.forward_yield_pct).toBeGreaterThan(5.0);
+    expect(row.forward_yield_pct).toBeLessThan(5.5);
+  });
+
+  it('[regression] LUMI ILA position ÷100 guard: yield 4.56%, market value in ILS not agorot', async () => {
+    // Leumi bank (TASE): broker reports mark_price in agorot, market_value in ILS.
+    // mark_price = 7550 agorot → canonicalPrice = 75.50 ILS
+    // forward yield = 0.0456 × 75.50 = 3.44 ILS/sh → yield ~4.56%
+    mockAuth();
+
+    const LUMI_POS = {
+      id: 'pos-lumi',
+      account_id: 72,
+      ticker: '1083',
+      description: 'Bank Leumi',
+      sub_category: 'Stock',
+      quantity: 1010,
+      cost_basis: null,
+      mark_price: 7550,          // agorot
+      market_value: 76255.0,     // canonical ILS (≈ 1010 × 75.50)
+      market_value_local: 76255.0,
+      unrealized_pnl: null,
+      currency: 'ILA',
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 72, account_id: null }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: [], error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: '1083', dividend_yield: '0.0456' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([LUMI_POS]);
+
+    const result = await getDividendPositions('ira');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('1083');
+    expect(row.source).toBe('csv');
+
+    // canonical price = 7550 ÷ 100 = 75.50 ILS
+    expect(row.current_price).toBeCloseTo(75.50, 2);
+
+    expect(row.market_value).toBe(76255.0);
+    expect(row.currency).toBe('ILS');
+
+    // forward div/share = 75.50 × 0.0456 = 3.44 ILS/share (NOT 0.03 from agorot denominator)
+    expect(row.forward_div_per_share).toBe(3.44);
+    expect(row.forward_yield_pct).toBeGreaterThan(4.5);
+    expect(row.forward_yield_pct).toBeLessThan(4.7);
+  });
+
+  it('[regression] QQQI incomplete TTM (1 payment) falls back to DB dividend_yield 13.96%', async () => {
+    // QQQI is a monthly ETF. DB has only 2 of ~12 expected monthly payments
+    // (cross-account bleed from IBKR, showing up against LeumiIRA shares).
+    // With < 3 TTM payments ttmIsTrustworthy=false, forward yield uses DB 13.96%
+    // instead of the distorted ~0.48% derived from the 2-payment TTM total.
+    mockAuth();
+
+    const QQQI_POS = {
+      id: 'pos-qqqi',
+      account_id: 72,
+      ticker: 'QQQI',
+      description: 'Nasdaq-100 Hedged Equity Income ETF',
+      sub_category: 'ETF',
+      quantity: 700,
+      cost_basis: null,
+      mark_price: 56.59,
+      market_value: 39613.0,  // 700 × 56.59
+      market_value_local: null,
+      unrealized_pnl: null,
+      currency: 'USD',
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    // Only 2 TTM payments (incomplete — should be ~12 for a monthly ETF)
+    const ONE_YEAR_AGO = new Date();
+    ONE_YEAR_AGO.setDate(ONE_YEAR_AGO.getDate() - 30);
+    const recentDate = ONE_YEAR_AGO.toISOString().split('T')[0];
+    const twoMonthsAgo = new Date();
+    twoMonthsAgo.setDate(twoMonthsAgo.getDate() - 60);
+    const olderDate = twoMonthsAgo.toISOString().split('T')[0];
+
+    const payments = [
+      { symbol: 'QQQI', amount: '50.00', ex_date: recentDate, report_date: recentDate, type: 'Dividends' },
+      { symbol: 'QQQI', amount: '50.00', ex_date: olderDate, report_date: olderDate, type: 'Dividends' },
+    ];
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 72, account_id: null }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: payments, error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: 'QQQI', dividend_yield: '0.1396' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([QQQI_POS]);
+
+    const result = await getDividendPositions('ira');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('QQQI');
+
+    // TTM data is still shown (hasTTM=true), but it reflects the incomplete 2-payment sample
+    expect(row.ttm_dividend_total).not.toBeNull();
+
+    // Forward yield must use DB 13.96% NOT the distorted TTM yield
+    // TTM-derived would be ~100/700/56.59 × 100 ≈ 0.25% — nowhere near 13.96%
+    // DB-derived: 56.59 × 0.1396 ≈ 7.90/share → yield ≈ 13.96%
+    expect(row.forward_div_per_share).toBeGreaterThan(7.0);
+    expect(row.forward_yield_pct).toBeGreaterThan(13.0);
+    expect(row.forward_yield_pct).toBeLessThan(15.0);
+  });
 });
 
 // ── getDividendSummary ────────────────────────────────────────────────────────

--- a/apps/frontend/src/app/dividends/actions.ts
+++ b/apps/frontend/src/app/dividends/actions.ts
@@ -1037,6 +1037,7 @@ export async function getDividendPositions(
 
   // Build per-ticker maps from payment rows.
   const ttmTotalByTicker = new Map<string, number>();
+  const ttmCountByTicker = new Map<string, number>();
   const lastPayDateByTicker = new Map<string, string>();
   const allExDatesByTicker = new Map<string, string[]>();
 
@@ -1056,6 +1057,7 @@ export async function getDividendPositions(
     // TTM accumulation — compare effective date against TTM window
     if (effectiveDate >= ttmStartStr) {
       ttmTotalByTicker.set(sym, (ttmTotalByTicker.get(sym) ?? 0) + amt);
+      ttmCountByTicker.set(sym, (ttmCountByTicker.get(sym) ?? 0) + 1);
     }
 
     // Track most recent payment date
@@ -1100,19 +1102,33 @@ export async function getDividendPositions(
     const yieldFraction = yieldByTicker.get(ticker) ?? 0;
     const hasYield = yieldFraction > 0;
 
+    // TTM completeness guard: an incomplete TTM sample (e.g. QQQI with only 2 of
+    // 12 expected monthly payments in the DB) produces a misleadingly low forward
+    // yield. Require at least 3 in-window payments before trusting TTM as a
+    // forward proxy. Positions with an untrustworthy TTM fall through to
+    // hasYield (stock_positions.dividend_yield from Yahoo).
+    const MIN_TTM_PAYMENTS_FOR_TRUST = 3;
+    const ttmCount = ttmCountByTicker.get(ticker) ?? 0;
+    const ttmIsTrustworthy = hasTTM && ttmCount >= MIN_TTM_PAYMENTS_FOR_TRUST;
+
     // Include position only when at least one dividend signal is present
     if (!hasTTM && !hasAccrual && !hasYield) continue;
 
     const qty = pos.quantity;
 
     // ILA (Israeli agorot) is the broker currency code for TASE positions.
-    // mark_price is stored in agorot (1/100 of ILS). Normalise to ILS so that
-    // all dividend calculations use canonical per-share prices, avoiding the
-    // 100× inflation seen in PR #418 (LUMI) and now replicated here.
-    const posCurrency = pos.currency === 'ILA' ? 'ILS' : pos.currency;
+    // GBP (GBp) is the broker code for LSE positions quoted in pence.
+    // mark_price is stored in sub-units (agorot / pence). Normalise to the
+    // major unit (ILS / GBP) so dividend calculations use canonical per-share
+    // prices, avoiding the 100× inflation seen in PR #418 (LUMI/BARC/RIO).
+    const posCurrency = pos.currency === 'ILA' ? 'ILS'
+      : pos.currency === 'GBp' ? 'GBP'
+      : pos.currency;
     const rawPrice = pos.mark_price;
     const canonicalPrice =
-      pos.currency === 'ILA' && rawPrice !== null ? rawPrice / 100 : rawPrice;
+      (pos.currency === 'ILA' || pos.currency === 'GBP' || pos.currency === 'GBp') && rawPrice !== null
+        ? rawPrice / 100
+        : rawPrice;
 
     // Frequency detection from historical ex-dates
     const exDates = allExDatesByTicker.get(ticker) ?? [];
@@ -1128,13 +1144,14 @@ export async function getDividendPositions(
         ? roundDecimal((ttmDivPerShare / canonicalPrice) * 100, 4)
         : null;
 
-    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised);
-    // fall back to stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
-    // Always use canonicalPrice (ILS for ILA, not agorot) to avoid 100× inflation.
+    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised)
+    // when the TTM sample is trustworthy (≥3 payments); fall back to
+    // stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
+    // Always use canonicalPrice (ILS for ILA, GBP for GBp, not sub-units) to avoid 100× inflation.
     let forwardDivPerShare: number | null = null;
     if (hasAccrual) {
       forwardDivPerShare = roundCurrency(accrual!.gross_rate * ppy);
-    } else if (hasTTM && ttmDivPerShare !== null) {
+    } else if (ttmIsTrustworthy && ttmDivPerShare !== null) {
       forwardDivPerShare = ttmDivPerShare;
     } else if (hasYield && canonicalPrice !== null && canonicalPrice > 0) {
       // Estimate: annualised dividend per share = canonical_price × yield fraction

--- a/apps/frontend/src/components/trading/accounts/AggregatePortfolioFooter.tsx
+++ b/apps/frontend/src/components/trading/accounts/AggregatePortfolioFooter.tsx
@@ -34,12 +34,15 @@ function accountMarketValue(positions: StockPosition[]): number {
     // Use market_value_local as fallback for positions the Yahoo worker hasn't
     // refreshed yet (market_value=null).
     const mv = p.market_value ?? p.market_value_local ?? 0;
-    // TASE positions (currency='ILA') store market_value in ILS.
-    // Convert to USD for a consistent portfolio-wide display currency.
-    if (p.currency.toUpperCase() === "ILA") {
-      return sum + convertCurrency(mv, "ILS", "USD");
-    }
-    return sum + mv;
+    // Normalise broker sub-unit codes to ISO major units before conversion:
+    //   ILA (Israeli agorot) → ILS  (market_value is already in ILS)
+    //   GBp (pence)          → GBP  (market_value is already in GBP)
+    // All other currencies (USD, EUR…) are passed through; convertCurrency
+    // handles them via CURRENCY_RATES.
+    const sourceCurrency = p.currency === "ILA" ? "ILS"
+      : p.currency === "GBp" ? "GBP"
+      : p.currency;
+    return sum + convertCurrency(mv, sourceCurrency, "USD");
   }, 0);
 }
 
@@ -52,9 +55,10 @@ function topFiveHoldings(accounts: AccountBalance[]): string {
   for (const { positions } of accounts) {
     for (const p of positions) {
       const mv = p.market_value ?? p.market_value_local ?? 0;
-      const usdValue = p.currency.toUpperCase() === "ILA"
-        ? convertCurrency(mv, "ILS", "USD")
-        : mv;
+      const sourceCurrency = p.currency === "ILA" ? "ILS"
+        : p.currency === "GBp" ? "GBP"
+        : p.currency;
+      const usdValue = convertCurrency(mv, sourceCurrency, "USD");
       valueByTicker.set(p.ticker, (valueByTicker.get(p.ticker) ?? 0) + usdValue);
     }
   }

--- a/apps/frontend/src/components/trading/accounts/StockPositionsTable.tsx
+++ b/apps/frontend/src/components/trading/accounts/StockPositionsTable.tsx
@@ -22,22 +22,31 @@ function formatCurrency(value: number | null | undefined, currency = "USD"): str
 }
 
 /**
- * Normalises 'ILA' (Israeli agorot) to 'ILS' for display purposes.
- * market_value is stored in ILS even when currency='ILA'; using 'ILA' as the
- * Intl currency code is misleading so we always render as ILS.
+ * Normalises broker sub-unit currency codes to their ISO 4217 parents:
+ *   ILA (Israeli agorot) → ILS
+ *   GBp (pence)          → GBP
+ *
+ * market_value is already stored in the major unit (ILS / GBP), so using the
+ * raw broker code as an Intl currency code would either crash (ILA is not ISO)
+ * or display the wrong symbol (GBp renders as 'GBP' anyway but is non-standard).
  */
 function toDisplayCurrency(currency: string): string {
-  return currency.toUpperCase() === "ILA" ? "ILS" : currency;
+  const upper = currency.toUpperCase();
+  if (upper === "ILA") return "ILS";
+  if (upper === "GBP") return "GBP"; // normalises 'GBp' → 'GBP' too
+  return currency;
 }
 
 /**
- * Converts a per-share mark_price to its display value.
- * TASE positions store mark_price in agorot (ILA = 1/100 ILS), so divide by
- * 100 before rendering to show the familiar ILS per-share price.
+ * Converts a per-share price (mark_price, cost_basis, unrealized_pnl) to its
+ * display value.  Brokers store TASE and LSE prices in sub-units:
+ *   ILA (agorot)  = 1/100 ILS  → divide by 100 before display
+ *   GBP / GBp (pence) = 1/100 GBP → divide by 100 before display
  */
 function toDisplayMarkPrice(price: number | null, currency: string): number | null {
   if (price == null) return null;
-  return currency.toUpperCase() === "ILA" ? price / 100 : price;
+  const upper = currency.toUpperCase();
+  return (upper === "ILA" || upper === "GBP") ? price / 100 : price;
 }
 
 function formatQuantity(value: number): string {
@@ -169,7 +178,7 @@ function PositionRow({ position, mode, onDelete, onEdit }: PositionRowProps) {
       <td className={`px-4 py-3 text-right font-medium ${pnlColor}`}>
         {position.unrealized_pnl == null
           ? "—"
-          : `${position.unrealized_pnl >= 0 ? "+" : ""}${formatCurrency(position.unrealized_pnl, position.currency)}`}
+          : `${position.unrealized_pnl >= 0 ? "+" : ""}${formatCurrency(toDisplayMarkPrice(position.unrealized_pnl, position.currency), toDisplayCurrency(position.currency))}`}
       </td>
       {mode === "editable" && (
         <td className="px-4 py-3 text-center">

--- a/apps/frontend/src/components/trading/accounts/__tests__/StockPositionsTable.test.tsx
+++ b/apps/frontend/src/components/trading/accounts/__tests__/StockPositionsTable.test.tsx
@@ -145,4 +145,43 @@ describe("StockPositionsTable", () => {
     expect(screen.getByText(/Total Market Value/)).toBeInTheDocument();
     expect(screen.getByTestId("positions-table")).toHaveTextContent("$8,392.40");
   });
+
+  // ── GBP / pence display (÷100 guard) ─────────────────────────────────────────
+
+  it("divides GBP mark_price by 100 before display (pence → GBP)", () => {
+    const gbpPos = makePosition({
+      ticker: "RIO",
+      currency: "GBP",
+      mark_price: 7927,          // stored in pence
+      cost_basis: 7800,          // stored in pence
+      market_value: 15774.73,    // already in GBP
+    });
+    render(<StockPositionsTable mode="readonly" positions={[gbpPos]} />);
+    // mark_price displayed as £79.27 (not £7,927)
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£79.27");
+    // market_value shown as-is in GBP
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£15,774.73");
+  });
+
+  it("formats GBP market values correctly", () => {
+    render(<StockPositionsTable mode="readonly" positions={[makePosition({ market_value: 15774.73, currency: "GBP" })]} />);
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£15,774.73");
+  });
+
+  // ── ILA crash prevention ──────────────────────────────────────────────────────
+
+  it("renders ILA position without crashing (ILA→ILS Intl normalisation)", () => {
+    const ilaPos = makePosition({
+      ticker: "1083",
+      currency: "ILA",
+      mark_price: 7550,        // agorot
+      cost_basis: 7400,        // agorot
+      market_value: 76255.0,   // canonical ILS
+      unrealized_pnl: 855.0,   // ILS
+    });
+    // Prior to fix, passing 'ILA' to Intl.NumberFormat threw RangeError
+    expect(() => render(<StockPositionsTable mode="readonly" positions={[ilaPos]} />)).not.toThrow();
+    // mark_price displayed as ₪75.50 (agorot ÷ 100 = ILS)
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("₪75.50");
+  });
 });

--- a/apps/frontend/src/lib/currency.test.ts
+++ b/apps/frontend/src/lib/currency.test.ts
@@ -5,8 +5,9 @@ describe('CURRENCY_RATES', () => {
   it('should define all supported currencies', () => {
     expect(CURRENCY_RATES).toEqual({
       ILS: 1,
-      USD: 3,
-      EUR: 3.5,
+      USD: 3.6,
+      GBP: 4.6,
+      EUR: 3.9,
     });
   });
 
@@ -14,8 +15,9 @@ describe('CURRENCY_RATES', () => {
     expect(CURRENCY_RATES.ILS).toBe(1);
   });
 
-  it('should have valid exchange rates for USD and EUR', () => {
+  it('should have valid exchange rates for USD, GBP and EUR', () => {
     expect(CURRENCY_RATES.USD).toBeGreaterThan(0);
+    expect(CURRENCY_RATES.GBP).toBeGreaterThan(0);
     expect(CURRENCY_RATES.EUR).toBeGreaterThan(0);
   });
 });
@@ -33,39 +35,50 @@ describe('convertCurrency', () => {
     it('should return same amount when converting EUR to EUR', () => {
       expect(convertCurrency(100, 'EUR', 'EUR')).toBe(100);
     });
+
+    it('should return same amount when converting GBP to GBP', () => {
+      expect(convertCurrency(100, 'GBP', 'GBP')).toBe(100);
+    });
   });
 
   describe('known conversion values', () => {
-    it('should convert 300 ILS to 100 USD correctly', () => {
-      // 300 ILS * 1 = 300 in ILS base
-      // 300 / 3 = 100 USD
-      expect(convertCurrency(300, 'ILS', 'USD')).toBe(100);
+    it('should convert 360 ILS to 100 USD correctly', () => {
+      // 360 ILS * 1 = 360 in ILS base; 360 / 3.6 = 100 USD
+      expect(convertCurrency(360, 'ILS', 'USD')).toBe(100);
     });
 
-    it('should convert 100 USD to 300 ILS correctly', () => {
-      // 100 USD * 3 = 300 in ILS base
-      // 300 / 1 = 300 ILS
-      expect(convertCurrency(100, 'USD', 'ILS')).toBe(300);
+    it('should convert 100 USD to 360 ILS correctly', () => {
+      // 100 USD * 3.6 = 360 in ILS base; 360 / 1 = 360 ILS
+      expect(convertCurrency(100, 'USD', 'ILS')).toBe(360);
     });
 
-    it('should convert 350 ILS to 100 EUR correctly', () => {
-      // 350 ILS * 1 = 350 in ILS base
-      // 350 / 3.5 = 100 EUR
-      expect(convertCurrency(350, 'ILS', 'EUR')).toBe(100);
+    it('should convert 390 ILS to 100 EUR correctly', () => {
+      // 390 ILS * 1 = 390 in ILS base; 390 / 3.9 = 100 EUR
+      expect(convertCurrency(390, 'ILS', 'EUR')).toBe(100);
     });
 
-    it('should convert 100 USD to 85.71428... EUR correctly', () => {
-      // 100 USD * 3 = 300 in ILS base
-      // 300 / 3.5 = 85.714285... EUR
+    it('should convert 100 USD to ~92.31 EUR correctly', () => {
+      // 100 USD * 3.6 = 360 in ILS base; 360 / 3.9 ≈ 92.308 EUR
       const result = convertCurrency(100, 'USD', 'EUR');
-      expect(result).toBeCloseTo(85.714285, 5);
+      expect(result).toBeCloseTo(92.307692, 5);
     });
 
-    it('should convert 100 EUR to 116.666... USD correctly', () => {
-      // 100 EUR * 3.5 = 350 in ILS base
-      // 350 / 3 = 116.66666... USD
+    it('should convert 100 EUR to ~108.33 USD correctly', () => {
+      // 100 EUR * 3.9 = 390 in ILS base; 390 / 3.6 ≈ 108.333 USD
       const result = convertCurrency(100, 'EUR', 'USD');
-      expect(result).toBeCloseTo(116.666666, 5);
+      expect(result).toBeCloseTo(108.333333, 5);
+    });
+
+    it('[GBP] should convert 100 GBP to ~127.78 USD', () => {
+      // 100 GBP * 4.6 = 460 ILS; 460 / 3.6 ≈ 127.78 USD (not ~28 USD with old missing rate)
+      const result = convertCurrency(100, 'GBP', 'USD');
+      expect(result).toBeCloseTo(127.777, 2);
+    });
+
+    it('[GBP] should convert 100 USD to ~78.26 GBP', () => {
+      // 100 * 3.6 = 360 ILS; 360 / 4.6 ≈ 78.26 GBP
+      const result = convertCurrency(100, 'USD', 'GBP');
+      expect(result).toBeCloseTo(78.260869, 4);
     });
   });
 
@@ -85,18 +98,18 @@ describe('convertCurrency', () => {
     });
 
     it('should handle negative amounts', () => {
-      expect(convertCurrency(-100, 'USD', 'ILS')).toBe(-300);
+      expect(convertCurrency(-100, 'USD', 'ILS')).toBe(-360);
     });
 
     it('should handle very large amounts', () => {
       const largeAmount = 1000000000; // 1 billion
       const result = convertCurrency(largeAmount, 'USD', 'ILS');
-      expect(result).toBe(3000000000); // 3 billion
+      expect(result).toBe(3600000000); // 3.6 billion
     });
 
     it('should handle decimal amounts with precision', () => {
       const result = convertCurrency(123.456, 'ILS', 'USD');
-      expect(result).toBeCloseTo(41.152, 3);
+      expect(result).toBeCloseTo(34.293, 3);
     });
   });
 
@@ -106,20 +119,20 @@ describe('convertCurrency', () => {
     });
 
     it('should default to ILS for "to" currency when only from is specified', () => {
-      expect(convertCurrency(100, 'USD')).toBe(300);
+      expect(convertCurrency(100, 'USD')).toBe(360);
     });
   });
 
   describe('invalid currency codes', () => {
     it('should fallback to rate 1 for unknown "from" currency', () => {
-      // Unknown currency uses rate 1, treated as ILS
+      // Unknown currency uses rate 1, treated as ILS; JPY is not in CURRENCY_RATES
       // @ts-expect-error - testing runtime behavior
-      expect(convertCurrency(100, 'GBP', 'USD')).toBe(100 / 3);
+      expect(convertCurrency(100, 'JPY', 'USD')).toBeCloseTo(100 / 3.6, 5);
     });
 
     it('should fallback to rate 1 for unknown "to" currency', () => {
       // @ts-expect-error - testing runtime behavior
-      expect(convertCurrency(100, 'USD', 'GBP')).toBe(300);
+      expect(convertCurrency(100, 'USD', 'JPY')).toBe(360);
     });
   });
 });
@@ -140,6 +153,29 @@ describe('formatCurrency', () => {
       const result = formatCurrency(1234.56, 'EUR');
       expect(result).toContain('1,234.56');
       expect(result).toContain('€');
+    });
+
+    it('should format GBP with pound sign and 2 decimals', () => {
+      const result = formatCurrency(1234.56, 'GBP');
+      expect(result).toContain('1,234.56');
+      expect(result).toContain('£');
+    });
+  });
+
+  describe('broker sub-unit code normalisation', () => {
+    it('[ILA] normalises ILA to ILS — does not throw RangeError', () => {
+      // ILA is not an ISO 4217 code; Intl.NumberFormat would throw without normalisation.
+      expect(() => formatCurrency(100, 'ILA')).not.toThrow();
+      const result = formatCurrency(100, 'ILA');
+      expect(result).toContain('₪');
+      expect(result).toContain('100.00');
+    });
+
+    it('[GBp] normalises GBp to GBP — does not throw RangeError', () => {
+      expect(() => formatCurrency(100, 'GBp')).not.toThrow();
+      const result = formatCurrency(100, 'GBp');
+      expect(result).toContain('£');
+      expect(result).toContain('100.00');
     });
   });
 
@@ -209,7 +245,7 @@ describe('formatCurrency', () => {
 
 describe('CurrencyCode type', () => {
   it('should be a valid union type of supported currencies', () => {
-    const currencies: CurrencyCode[] = ['ILS', 'USD', 'EUR'];
+    const currencies: CurrencyCode[] = ['ILS', 'USD', 'GBP', 'EUR'];
     currencies.forEach(code => {
       expect(CURRENCY_RATES[code]).toBeDefined();
     });

--- a/apps/frontend/src/lib/currency.ts
+++ b/apps/frontend/src/lib/currency.ts
@@ -1,8 +1,9 @@
 
 export const CURRENCY_RATES = {
     'ILS': 1,
-    'USD': 3,
-    'EUR': 3.5
+    'USD': 3.6,   // ~3.6 ILS per USD
+    'GBP': 4.6,   // ~4.6 ILS per GBP
+    'EUR': 3.9    // ~3.9 ILS per EUR
 } as const;
 
 export type CurrencyCode = keyof typeof CURRENCY_RATES;
@@ -17,10 +18,22 @@ export const convertCurrency = (amount: number, from: string = 'ILS', to: string
     return inILS / toRate;
 };
 
+/**
+ * Formats a monetary amount as a localised currency string.
+ *
+ * Broker sub-unit codes (ILA = Israeli agorot, GBp = pence) are normalised
+ * to their ISO parents (ILS, GBP) before being passed to Intl.NumberFormat.
+ * Without this step, Intl throws RangeError for non-ISO codes.
+ */
 export const formatCurrency = (amount: number, currency: string = 'USD', compact: boolean = false): string => {
+    // Normalise broker sub-unit codes to ISO 4217 before Intl call.
+    const isoCode = currency === 'ILA' ? 'ILS'
+        : currency === 'GBp' ? 'GBP'
+        : currency.toUpperCase();
+
     return new Intl.NumberFormat('en-US', {
         style: 'currency',
-        currency: currency,
+        currency: isoCode,
         maximumFractionDigits: compact ? 0 : 2,
         notation: compact ? 'compact' : 'standard'
     }).format(amount);


### PR DESCRIPTION
## Working as Fenster (Frontend Dev)

### Summary
Round 8 Phase 2 frontend display fixes. The Yahoo worker code (commit d853426) was correct — this PR fixes the display layer so the now-correct DB data renders correctly.

### Changes

| File | Change |
|------|--------|
| `lib/currency.ts` | Add `GBP: 4.6` to CURRENCY_RATES; update USD: 3→3.6, EUR: 3.5→3.9; defensive ILA→ILS + GBp→GBP normalisation in `formatCurrency` |
| `dividends/actions.ts` | Extend `canonicalPrice ÷100` guard to GBP; add `ttmCountByTicker` + `MIN_TTM_PAYMENTS_FOR_TRUST=3` guard (fixes QQQI 0.48%→13.96%) |
| `StockPositionsTable.tsx` | Extend `toDisplayMarkPrice`/`toDisplayCurrency` to GBP; fix `unrealized_pnl` Intl crash for ILA/GBP |
| `AggregatePortfolioFooter.tsx` | Universal `convertCurrency` pattern for ILA, GBP, USD, EUR via CURRENCY_RATES |

### Expected display values after fix (Keaton spec §B.4)
- **RIO GBP price column:** £79.27 (was £7,927)
- **LUMI ILA forward ÷SH:** ₪3.44 (was ~₪0.03)
- **QQQI yield:** ~13.96% (was 0.48% from incomplete 2-payment TTM)

### Testing
- 646 tests pass (56 test files) — zero regressions
- 12 new regression tests: RIO/GBP ÷100, LUMI/ILA ÷100, QQQI TTM guard, formatCurrency(ILA/GBp) safety

### Coordination
Pairs with Round 8 Phase 2 backend (Hockney — container rebuild + SQL UPDATEs).
Defers Keaton's 'major currency everywhere' migration to a separate issue.

⚠️ Rate update (USD: 3→3.6, EUR: 3.5→3.9) — review if any other code depends on exact rate values.