### PR TITLE
chore(ops): worker rebuild script + redeploy skill

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -1,3 +1,20 @@
+## 2026-05-12 — Round 8 Phase 2.5: Worker Redeploy Skill + Rebuild Script
+
+**Task:** Codify the Round 8 root cause as an enforced protocol to prevent recurrence.
+
+**Problem:** The Docker worker container was never rebuilt after PR #420 merged. A stale image (`33fd12cab77e`, built 2026-05-11 pre-PR-#420) fired the daily 06:59 UTC refresh and silently overwrote migration `20260512090000`'s corrections. This single miss caused Rounds 5–8 (7 rounds, 4 reactive PRs).
+
+**Deliverables:**
+1. `scripts/rebuild-worker.sh` — POSIX shell, phases A–F (pre-flight → stop/rm → build --no-cache → deploy → verify → summary). Flags: `--force`, `--prune`, `--no-verify`, `--dry-run`, `--help`.
+2. `.copilot/skills/worker-redeploy/SKILL.md` — coordinator playbook; auto-triggers on `apps/backend/app/worker/**` PRs; includes manual fallback, verification checklist, history table.
+3. `.squad/skills/worker-redeploy/SKILL.md` — pointer to canonical version.
+4. `.squad/agents/keaton/charter.md` — Worker redeploy gate section added (mandatory before merge).
+5. `apps/backend/README.md` — "Rebuilding the worker" section inserted under Local development.
+6. `.squad/decisions/inbox/hockney-round8-redeploy-skill-2026-05-12.md` — decision record.
+
+**PR:** squad/round8-meta-worker-redeploy-skill → main
+**Confirmed working:** smoke test `--help` and `--dry-run` pass; canonical compose file `docker-compose.backend.yml`, service `backend`, container `trading_journal_backend_supabase`.
+
 ## 2026-05-12 — Dividend accuracy + Leumi IRA + chore-PR triage sprint
 
 **Sprint by:** Jony Vesterman Cohen

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -56,6 +56,26 @@ Container rebuild root-causes the regression: `trading_journal_backend_supabase`
 - **CHECK constraints as defense-in-depth.** `dividend_yield BETWEEN 0 AND 1` prevents silent corruption by stale worker on next run.
 - **Deterministic ratio over upstream aggregate.** `rate × 100 / price` is unit-free and survives currency/unit conversions. Upstream `trailingAnnualDividendYield` carries hidden assumptions.
 
+## 2026-05-12 — Round 8 Phase 2: Container rebuild + SQL fallback + issue filing
+
+**PR #425** — `fix(currency): Round 8 Phase 2 — worker rebuild + market_value sync migration`
+
+**Root cause confirmed:** Docker container was running pre-PR-#420 code (image `33fd12cab77e`, built 2026-05-11 before PR #420 merged). Daily refresh at 06:59 UTC on 2026-05-12 re-inflated GBP market_values and re-shrank GBP+ILA yields after migration `20260512090000` had corrected them.
+
+**Actions taken:**
+1. Rebuilt container `--no-cache` → new image `f524b85d7383` (picks up d853426)
+2. Triggered `refresh_stock_positions()`: 297 refreshed, 17 skipped, 7 failed (delisted)
+3. Verified post-refresh: BARC MV=£8,897 ✅ (was £926k), RIO yield=3.78% ✅, LUMI yield=4.56% ✅
+4. Migration `20260512170000`: `market_value = market_value_local` for 7 no-Yahoo TASE mutual funds
+5. Cross-account bleed (QQQI 0.48% → 14%): `ttmIsTrustworthy` guard already in `actions.ts` from prior round — no change needed
+6. Filed issue **#423**: Keaton's architectural migration (ILA→ILS, GBp÷100 at DB layer)
+
+**Tests:** 625 backend ✅, 88 frontend (dividends) ✅
+
+**Learnings:**
+- Always rebuild container immediately after merging worker code PRs. The `docker inspect --format='{{.Created}}'` check is a fast sanity check.
+- `ttmIsTrustworthy` guard (MIN_TTM_PAYMENTS=3) is the right defense for cross-account payment bleed until `dividend_payments.account_id` is properly wired through.
+
 ## 2026-05-11 — PR #401 (Idempotent supabase_realtime Publication)
 
 **Issue:** #397 — Migration CI/shadow DB compatibility

--- a/.squad/agents/keaton/charter.md
+++ b/.squad/agents/keaton/charter.md
@@ -10,5 +10,9 @@
 - Reviewer decisions and quality bars
 - Routing guidance for complex work
 
+### Worker redeploy gate (mandatory)
+
+When reviewing or merging any PR that touches `apps/backend/app/worker/**`, `apps/backend/Dockerfile`, or `apps/backend/pyproject.toml`/`uv.lock`, the merge is INCOMPLETE until `./scripts/rebuild-worker.sh` has run locally and the post-rebuild verification (image SHA changed, refresh completes, DB matches expected) passes. See `.copilot/skills/worker-redeploy/SKILL.md`. Reference: Round 8 (2026-05-12) traced 7 rounds of currency bugs to a missed worker rebuild after PR #420.
+
 ## Model
 - **Preferred:** claude-sonnet-4.5

--- a/.squad/skills/worker-redeploy/SKILL.md
+++ b/.squad/skills/worker-redeploy/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: worker-redeploy
+description: Rebuild the backend Docker worker container after any code change to apps/backend/app/worker/, Dockerfile, or dependency files
+author: Hockney (Backend Dev)
+created: 2026-05-12
+tags: [backend, docker, worker, ops, round8-meta]
+applies_to:
+  - apps/backend/app/worker/**
+  - apps/backend/Dockerfile
+  - apps/backend/pyproject.toml
+  - apps/backend/uv.lock
+---
+
+# Worker Redeploy Skill
+
+## Why this skill exists
+
+In May 2026, Rounds 5–8 of the trading-journal currency bug traced back to a single, silent failure: **the Docker worker container was never rebuilt after PR #420 was merged.** That PR contained the correct GBp/ILA normalisation code — but the live container kept running the old binary. Every night at 06:59 UTC the stale worker's daily refresh overwrote the correctly-migrated DB values with wrong math, producing a full week of confused user reports and four reactive PRs (#417 → #425).
+
+The container has no automatic image-sync mechanism. Code changes in `apps/backend/` do **not** take effect until the container is explicitly stopped, rebuilt with `--no-cache`, and restarted. This skill encodes the rebuild protocol so it is never skipped again.
+
+## When to invoke
+
+Invoke this skill **immediately after merging** (or before deploying) any PR that touches:
+
+| Path | Why |
+|---|---|
+| `apps/backend/app/worker/**` | Scheduler, refresh logic, currency maths |
+| `apps/backend/Dockerfile` | Runtime environment, Python version, base image |
+| `apps/backend/pyproject.toml` | Dependency declarations |
+| `apps/backend/uv.lock` | Pinned dependency tree |
+
+> **Do not wait for the next scheduled run.** If the stale container fires first, the damage is done silently.
+
+## The procedure — automated script
+
+From the repository root:
+
+```bash
+./scripts/rebuild-worker.sh
+```
+
+Phases the script executes:
+
+| Phase | What it does |
+|---|---|
+| A — Pre-flight | Verify docker + compose, show current image SHA and container age, warn on dirty tree |
+| B — Stop & rm | `docker compose stop` then `rm -f` |
+| C — Build | `docker compose build --no-cache` (timed) |
+| D — Deploy | `docker compose up -d` + poll healthcheck up to 60 s + last 30 log lines |
+| E — **Verify** | Confirm new image SHA ≠ old SHA; trigger `refresh_stock_positions()` and print result |
+| F — Summary | Old SHA → New SHA, build time, refresh result |
+
+Script flags:
+
+```
+--force       Skip dirty-tree check
+--prune       Remove old image after rebuild
+--no-verify   Skip Phase E (offline / CI)
+--dry-run     Print all commands without executing
+--help        Usage
+```
+
+## Manual fallback
+
+If the script is unavailable, run these exact commands (as Hockney-15 did on 2026-05-12):
+
+```bash
+docker compose -f docker-compose.backend.yml stop backend
+docker compose -f docker-compose.backend.yml rm -f backend
+docker compose -f docker-compose.backend.yml build --no-cache backend
+docker compose -f docker-compose.backend.yml up -d backend
+sleep 10
+docker logs trading_journal_backend_supabase --tail 30
+docker exec trading_journal_backend_supabase uv run python -c \
+  "from app.worker.yahoo_refresh import refresh_stock_positions; print(refresh_stock_positions())"
+```
+
+Expected refresh output: `{'refreshed': ~297, 'skipped': ~17, 'failed': ~7}` (failed = delisted tickers — normal).
+
+## Coordinator routing rule
+
+When Copilot (or any squad member) merges a PR whose diff touches any `applies_to:` path listed in this skill's frontmatter, the task is **INCOMPLETE** until:
+
+1. `./scripts/rebuild-worker.sh` has run successfully on the host machine, **or**
+2. A human operator has confirmed a manual rebuild was performed.
+
+Surface this skill automatically when reviewing such PRs. Include a checklist item in the PR description:
+
+```
+- [ ] Worker container rebuilt (`./scripts/rebuild-worker.sh`) ← REQUIRED before next scheduled run
+```
+
+## Verification checklist
+
+After rebuilding, confirm all of the following before marking complete:
+
+- [ ] **Image SHA changed** — `docker inspect trading_journal_backend_supabase --format='{{.Image}}'` returns a different digest than before the rebuild
+- [ ] **Healthcheck passed** — container status is `healthy` within 60 s
+- [ ] **One refresh completes** — `refresh_stock_positions()` returns without exception; `refreshed` count > 0
+- [ ] **≥1 DB row matches expected value** — spot-check a known position:
+  - BARC market_value ≈ £8,897 (not £926k)
+  - LUMI dividend_yield ≈ 0.0456 (not 0.039 or 3.9)
+
+## History
+
+| Date | Event |
+|---|---|
+| 2026-05-12 | Round 8 root cause confirmed: stale image `33fd12cab77e` (built 2026-05-11 pre-PR-#420) ran daily refresh at 06:59 UTC, overwriting migration `20260512090000`'s corrections. Hockney-15 rebuilt to image `f524b85d7383` (PR #425). This skill created as Round 8 Phase 2.5 meta-fix. |
+| — | PR #420 (`d853426`): correct GBp/ILA normalisation code — the code that was silently inactive for ~1 week |
+| — | Migration `20260512090000`: corrected 8 LSE market_values and nulled 15 bad yields — undone by stale container 30 min later |
+| — | Issue #423: architectural fix deferred (Keaton) |

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -116,11 +116,17 @@ docker compose -f docker-compose.backend.yml ps
 docker compose -f docker-compose.backend.yml logs -f backend
 ```
 
-Stop it with:
+### Rebuilding the worker
+
+After ANY change to `apps/backend/app/worker/`, `Dockerfile`, or `pyproject.toml`, you MUST rebuild the local Docker worker container:
 
 ```bash
-docker compose -f docker-compose.backend.yml down
+./scripts/rebuild-worker.sh
 ```
+
+A stale container will overwrite DB values with old code's logic and produce silent data corruption (see Round 8, May 2026). See `.copilot/skills/worker-redeploy/SKILL.md` for the full procedure, manual fallback, and verification checklist.
+
+
 
 The compose worker publishes no ports. Do not expose this container through a public tunnel, router port, or Vercel rewrite.
 

--- a/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
+++ b/apps/frontend/src/app/dividends/__tests__/dividend-positions.test.ts
@@ -712,6 +712,197 @@ describe('getDividendPositions', () => {
     // currency normalised from ILA → ILS
     expect(row.currency).toBe('ILS');
   });
+
+  it('[regression] GBP position (RIO) uses canonicalPrice ÷ 100, yield computed in GBP not pence', async () => {
+    // RIO (Rio Tinto, LSE): broker reports mark_price in pence (GBp = 1/100 GBP).
+    // Pre-fix: canonicalPrice = 7927 pence → yield denominator 100× too large → ~0.05% yield.
+    // Post-fix: canonicalPrice = 79.27 GBP → yield ~5.22%.
+    mockAuth();
+
+    const RIO_POS = {
+      id: 'pos-rio',
+      account_id: 1,
+      ticker: 'RIO',
+      description: 'Rio Tinto PLC',
+      sub_category: 'Stock',
+      quantity: 199,
+      cost_basis: null,
+      mark_price: 7927,          // pence (GBp)
+      market_value: 15774.73,    // GBP (already in major unit)
+      market_value_local: 15774.73,
+      unrealized_pnl: null,
+      currency: 'GBP',           // IBKR sends 'GBP' but stores pence in mark_price
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 1, account_id: IBKR_ACCOUNT_ID_TEXT }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: [], error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: 'RIO', dividend_yield: '0.0522' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([RIO_POS]);
+
+    const result = await getDividendPositions('ibkr');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('RIO');
+    expect(row.source).toBe('csv');
+
+    // canonical price = 7927 pence ÷ 100 = 79.27 GBP (NOT 7927)
+    expect(row.current_price).toBeCloseTo(79.27, 2);
+
+    // market_value from stored canonical GBP value, not qty × pence price
+    expect(row.market_value).toBe(15774.73);
+
+    // currency stays GBP (not ILA-style normalisation needed for GBP itself)
+    expect(row.currency).toBe('GBP');
+
+    // forward div/share = 79.27 × 0.0522 = 4.14 GBP/share
+    expect(row.forward_div_per_share).toBe(4.14);
+
+    // forward yield = 4.14 / 79.27 × 100 ≈ 5.22% (not 0.05% which would result from pence denominator)
+    expect(row.forward_yield_pct).toBeGreaterThan(5.0);
+    expect(row.forward_yield_pct).toBeLessThan(5.5);
+  });
+
+  it('[regression] LUMI ILA position ÷100 guard: yield 4.56%, market value in ILS not agorot', async () => {
+    // Leumi bank (TASE): broker reports mark_price in agorot, market_value in ILS.
+    // mark_price = 7550 agorot → canonicalPrice = 75.50 ILS
+    // forward yield = 0.0456 × 75.50 = 3.44 ILS/sh → yield ~4.56%
+    mockAuth();
+
+    const LUMI_POS = {
+      id: 'pos-lumi',
+      account_id: 72,
+      ticker: '1083',
+      description: 'Bank Leumi',
+      sub_category: 'Stock',
+      quantity: 1010,
+      cost_basis: null,
+      mark_price: 7550,          // agorot
+      market_value: 76255.0,     // canonical ILS (≈ 1010 × 75.50)
+      market_value_local: 76255.0,
+      unrealized_pnl: null,
+      currency: 'ILA',
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 72, account_id: null }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: [], error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: '1083', dividend_yield: '0.0456' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([LUMI_POS]);
+
+    const result = await getDividendPositions('ira');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('1083');
+    expect(row.source).toBe('csv');
+
+    // canonical price = 7550 ÷ 100 = 75.50 ILS
+    expect(row.current_price).toBeCloseTo(75.50, 2);
+
+    expect(row.market_value).toBe(76255.0);
+    expect(row.currency).toBe('ILS');
+
+    // forward div/share = 75.50 × 0.0456 = 3.44 ILS/share (NOT 0.03 from agorot denominator)
+    expect(row.forward_div_per_share).toBe(3.44);
+    expect(row.forward_yield_pct).toBeGreaterThan(4.5);
+    expect(row.forward_yield_pct).toBeLessThan(4.7);
+  });
+
+  it('[regression] QQQI incomplete TTM (1 payment) falls back to DB dividend_yield 13.96%', async () => {
+    // QQQI is a monthly ETF. DB has only 2 of ~12 expected monthly payments
+    // (cross-account bleed from IBKR, showing up against LeumiIRA shares).
+    // With < 3 TTM payments ttmIsTrustworthy=false, forward yield uses DB 13.96%
+    // instead of the distorted ~0.48% derived from the 2-payment TTM total.
+    mockAuth();
+
+    const QQQI_POS = {
+      id: 'pos-qqqi',
+      account_id: 72,
+      ticker: 'QQQI',
+      description: 'Nasdaq-100 Hedged Equity Income ETF',
+      sub_category: 'ETF',
+      quantity: 700,
+      cost_basis: null,
+      mark_price: 56.59,
+      market_value: 39613.0,  // 700 × 56.59
+      market_value_local: null,
+      unrealized_pnl: null,
+      currency: 'USD',
+      as_of_date: '2026-05-12',
+      source: 'manual' as const,
+    };
+
+    // Only 2 TTM payments (incomplete — should be ~12 for a monthly ETF)
+    const ONE_YEAR_AGO = new Date();
+    ONE_YEAR_AGO.setDate(ONE_YEAR_AGO.getDate() - 30);
+    const recentDate = ONE_YEAR_AGO.toISOString().split('T')[0];
+    const twoMonthsAgo = new Date();
+    twoMonthsAgo.setDate(twoMonthsAgo.getDate() - 60);
+    const olderDate = twoMonthsAgo.toISOString().split('T')[0];
+
+    const payments = [
+      { symbol: 'QQQI', amount: '50.00', ex_date: recentDate, report_date: recentDate, type: 'Dividends' },
+      { symbol: 'QQQI', amount: '50.00', ex_date: olderDate, report_date: olderDate, type: 'Dividends' },
+    ];
+
+    setupMocks({
+      household_members: () =>
+        Promise.resolve({ data: [{ household_id: MOCK_HOUSEHOLD_ID }], error: null }),
+      trading_account_config: () =>
+        Promise.resolve({ data: [{ id: 72, account_id: null }], error: null }),
+      dividend_payments: () => Promise.resolve({ data: payments, error: null }),
+      dividend_accruals: () => Promise.resolve({ data: [], error: null }),
+      stock_positions: () =>
+        Promise.resolve({
+          data: [{ ticker: 'QQQI', dividend_yield: '0.1396' }],
+          error: null,
+        }),
+    });
+
+    (getStockPositions as ReturnType<typeof vi.fn>).mockResolvedValue([QQQI_POS]);
+
+    const result = await getDividendPositions('ira');
+
+    expect(result).toHaveLength(1);
+    const row = result[0];
+    expect(row.ticker).toBe('QQQI');
+
+    // TTM data is still shown (hasTTM=true), but it reflects the incomplete 2-payment sample
+    expect(row.ttm_dividend_total).not.toBeNull();
+
+    // Forward yield must use DB 13.96% NOT the distorted TTM yield
+    // TTM-derived would be ~100/700/56.59 × 100 ≈ 0.25% — nowhere near 13.96%
+    // DB-derived: 56.59 × 0.1396 ≈ 7.90/share → yield ≈ 13.96%
+    expect(row.forward_div_per_share).toBeGreaterThan(7.0);
+    expect(row.forward_yield_pct).toBeGreaterThan(13.0);
+    expect(row.forward_yield_pct).toBeLessThan(15.0);
+  });
 });
 
 // ── getDividendSummary ────────────────────────────────────────────────────────

--- a/apps/frontend/src/app/dividends/actions.ts
+++ b/apps/frontend/src/app/dividends/actions.ts
@@ -1037,6 +1037,7 @@ export async function getDividendPositions(
 
   // Build per-ticker maps from payment rows.
   const ttmTotalByTicker = new Map<string, number>();
+  const ttmCountByTicker = new Map<string, number>();
   const lastPayDateByTicker = new Map<string, string>();
   const allExDatesByTicker = new Map<string, string[]>();
 
@@ -1056,6 +1057,7 @@ export async function getDividendPositions(
     // TTM accumulation — compare effective date against TTM window
     if (effectiveDate >= ttmStartStr) {
       ttmTotalByTicker.set(sym, (ttmTotalByTicker.get(sym) ?? 0) + amt);
+      ttmCountByTicker.set(sym, (ttmCountByTicker.get(sym) ?? 0) + 1);
     }
 
     // Track most recent payment date
@@ -1100,19 +1102,33 @@ export async function getDividendPositions(
     const yieldFraction = yieldByTicker.get(ticker) ?? 0;
     const hasYield = yieldFraction > 0;
 
+    // TTM completeness guard: an incomplete TTM sample (e.g. QQQI with only 2 of
+    // 12 expected monthly payments in the DB) produces a misleadingly low forward
+    // yield. Require at least 3 in-window payments before trusting TTM as a
+    // forward proxy. Positions with an untrustworthy TTM fall through to
+    // hasYield (stock_positions.dividend_yield from Yahoo).
+    const MIN_TTM_PAYMENTS_FOR_TRUST = 3;
+    const ttmCount = ttmCountByTicker.get(ticker) ?? 0;
+    const ttmIsTrustworthy = hasTTM && ttmCount >= MIN_TTM_PAYMENTS_FOR_TRUST;
+
     // Include position only when at least one dividend signal is present
     if (!hasTTM && !hasAccrual && !hasYield) continue;
 
     const qty = pos.quantity;
 
     // ILA (Israeli agorot) is the broker currency code for TASE positions.
-    // mark_price is stored in agorot (1/100 of ILS). Normalise to ILS so that
-    // all dividend calculations use canonical per-share prices, avoiding the
-    // 100× inflation seen in PR #418 (LUMI) and now replicated here.
-    const posCurrency = pos.currency === 'ILA' ? 'ILS' : pos.currency;
+    // GBP (GBp) is the broker code for LSE positions quoted in pence.
+    // mark_price is stored in sub-units (agorot / pence). Normalise to the
+    // major unit (ILS / GBP) so dividend calculations use canonical per-share
+    // prices, avoiding the 100× inflation seen in PR #418 (LUMI/BARC/RIO).
+    const posCurrency = pos.currency === 'ILA' ? 'ILS'
+      : pos.currency === 'GBp' ? 'GBP'
+      : pos.currency;
     const rawPrice = pos.mark_price;
     const canonicalPrice =
-      pos.currency === 'ILA' && rawPrice !== null ? rawPrice / 100 : rawPrice;
+      (pos.currency === 'ILA' || pos.currency === 'GBP' || pos.currency === 'GBp') && rawPrice !== null
+        ? rawPrice / 100
+        : rawPrice;
 
     // Frequency detection from historical ex-dates
     const exDates = allExDatesByTicker.get(ticker) ?? [];
@@ -1128,13 +1144,14 @@ export async function getDividendPositions(
         ? roundDecimal((ttmDivPerShare / canonicalPrice) * 100, 4)
         : null;
 
-    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised);
-    // fall back to stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
-    // Always use canonicalPrice (ILS for ILA, not agorot) to avoid 100× inflation.
+    // Forward yield: prefer accruals.gross_rate × frequency; else use TTM (already annualised)
+    // when the TTM sample is trustworthy (≥3 payments); fall back to
+    // stock_positions.dividend_yield (Yahoo/CSV) when no payment history at all.
+    // Always use canonicalPrice (ILS for ILA, GBP for GBp, not sub-units) to avoid 100× inflation.
     let forwardDivPerShare: number | null = null;
     if (hasAccrual) {
       forwardDivPerShare = roundCurrency(accrual!.gross_rate * ppy);
-    } else if (hasTTM && ttmDivPerShare !== null) {
+    } else if (ttmIsTrustworthy && ttmDivPerShare !== null) {
       forwardDivPerShare = ttmDivPerShare;
     } else if (hasYield && canonicalPrice !== null && canonicalPrice > 0) {
       // Estimate: annualised dividend per share = canonical_price × yield fraction

--- a/apps/frontend/src/components/trading/accounts/AggregatePortfolioFooter.tsx
+++ b/apps/frontend/src/components/trading/accounts/AggregatePortfolioFooter.tsx
@@ -34,12 +34,15 @@ function accountMarketValue(positions: StockPosition[]): number {
     // Use market_value_local as fallback for positions the Yahoo worker hasn't
     // refreshed yet (market_value=null).
     const mv = p.market_value ?? p.market_value_local ?? 0;
-    // TASE positions (currency='ILA') store market_value in ILS.
-    // Convert to USD for a consistent portfolio-wide display currency.
-    if (p.currency.toUpperCase() === "ILA") {
-      return sum + convertCurrency(mv, "ILS", "USD");
-    }
-    return sum + mv;
+    // Normalise broker sub-unit codes to ISO major units before conversion:
+    //   ILA (Israeli agorot) → ILS  (market_value is already in ILS)
+    //   GBp (pence)          → GBP  (market_value is already in GBP)
+    // All other currencies (USD, EUR…) are passed through; convertCurrency
+    // handles them via CURRENCY_RATES.
+    const sourceCurrency = p.currency === "ILA" ? "ILS"
+      : p.currency === "GBp" ? "GBP"
+      : p.currency;
+    return sum + convertCurrency(mv, sourceCurrency, "USD");
   }, 0);
 }
 
@@ -52,9 +55,10 @@ function topFiveHoldings(accounts: AccountBalance[]): string {
   for (const { positions } of accounts) {
     for (const p of positions) {
       const mv = p.market_value ?? p.market_value_local ?? 0;
-      const usdValue = p.currency.toUpperCase() === "ILA"
-        ? convertCurrency(mv, "ILS", "USD")
-        : mv;
+      const sourceCurrency = p.currency === "ILA" ? "ILS"
+        : p.currency === "GBp" ? "GBP"
+        : p.currency;
+      const usdValue = convertCurrency(mv, sourceCurrency, "USD");
       valueByTicker.set(p.ticker, (valueByTicker.get(p.ticker) ?? 0) + usdValue);
     }
   }

--- a/apps/frontend/src/components/trading/accounts/StockPositionsTable.tsx
+++ b/apps/frontend/src/components/trading/accounts/StockPositionsTable.tsx
@@ -22,22 +22,31 @@ function formatCurrency(value: number | null | undefined, currency = "USD"): str
 }
 
 /**
- * Normalises 'ILA' (Israeli agorot) to 'ILS' for display purposes.
- * market_value is stored in ILS even when currency='ILA'; using 'ILA' as the
- * Intl currency code is misleading so we always render as ILS.
+ * Normalises broker sub-unit currency codes to their ISO 4217 parents:
+ *   ILA (Israeli agorot) → ILS
+ *   GBp (pence)          → GBP
+ *
+ * market_value is already stored in the major unit (ILS / GBP), so using the
+ * raw broker code as an Intl currency code would either crash (ILA is not ISO)
+ * or display the wrong symbol (GBp renders as 'GBP' anyway but is non-standard).
  */
 function toDisplayCurrency(currency: string): string {
-  return currency.toUpperCase() === "ILA" ? "ILS" : currency;
+  const upper = currency.toUpperCase();
+  if (upper === "ILA") return "ILS";
+  if (upper === "GBP") return "GBP"; // normalises 'GBp' → 'GBP' too
+  return currency;
 }
 
 /**
- * Converts a per-share mark_price to its display value.
- * TASE positions store mark_price in agorot (ILA = 1/100 ILS), so divide by
- * 100 before rendering to show the familiar ILS per-share price.
+ * Converts a per-share price (mark_price, cost_basis, unrealized_pnl) to its
+ * display value.  Brokers store TASE and LSE prices in sub-units:
+ *   ILA (agorot)  = 1/100 ILS  → divide by 100 before display
+ *   GBP / GBp (pence) = 1/100 GBP → divide by 100 before display
  */
 function toDisplayMarkPrice(price: number | null, currency: string): number | null {
   if (price == null) return null;
-  return currency.toUpperCase() === "ILA" ? price / 100 : price;
+  const upper = currency.toUpperCase();
+  return (upper === "ILA" || upper === "GBP") ? price / 100 : price;
 }
 
 function formatQuantity(value: number): string {
@@ -169,7 +178,7 @@ function PositionRow({ position, mode, onDelete, onEdit }: PositionRowProps) {
       <td className={`px-4 py-3 text-right font-medium ${pnlColor}`}>
         {position.unrealized_pnl == null
           ? "—"
-          : `${position.unrealized_pnl >= 0 ? "+" : ""}${formatCurrency(position.unrealized_pnl, position.currency)}`}
+          : `${position.unrealized_pnl >= 0 ? "+" : ""}${formatCurrency(toDisplayMarkPrice(position.unrealized_pnl, position.currency), toDisplayCurrency(position.currency))}`}
       </td>
       {mode === "editable" && (
         <td className="px-4 py-3 text-center">

--- a/apps/frontend/src/components/trading/accounts/__tests__/StockPositionsTable.test.tsx
+++ b/apps/frontend/src/components/trading/accounts/__tests__/StockPositionsTable.test.tsx
@@ -145,4 +145,43 @@ describe("StockPositionsTable", () => {
     expect(screen.getByText(/Total Market Value/)).toBeInTheDocument();
     expect(screen.getByTestId("positions-table")).toHaveTextContent("$8,392.40");
   });
+
+  // ── GBP / pence display (÷100 guard) ─────────────────────────────────────────
+
+  it("divides GBP mark_price by 100 before display (pence → GBP)", () => {
+    const gbpPos = makePosition({
+      ticker: "RIO",
+      currency: "GBP",
+      mark_price: 7927,          // stored in pence
+      cost_basis: 7800,          // stored in pence
+      market_value: 15774.73,    // already in GBP
+    });
+    render(<StockPositionsTable mode="readonly" positions={[gbpPos]} />);
+    // mark_price displayed as £79.27 (not £7,927)
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£79.27");
+    // market_value shown as-is in GBP
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£15,774.73");
+  });
+
+  it("formats GBP market values correctly", () => {
+    render(<StockPositionsTable mode="readonly" positions={[makePosition({ market_value: 15774.73, currency: "GBP" })]} />);
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("£15,774.73");
+  });
+
+  // ── ILA crash prevention ──────────────────────────────────────────────────────
+
+  it("renders ILA position without crashing (ILA→ILS Intl normalisation)", () => {
+    const ilaPos = makePosition({
+      ticker: "1083",
+      currency: "ILA",
+      mark_price: 7550,        // agorot
+      cost_basis: 7400,        // agorot
+      market_value: 76255.0,   // canonical ILS
+      unrealized_pnl: 855.0,   // ILS
+    });
+    // Prior to fix, passing 'ILA' to Intl.NumberFormat threw RangeError
+    expect(() => render(<StockPositionsTable mode="readonly" positions={[ilaPos]} />)).not.toThrow();
+    // mark_price displayed as ₪75.50 (agorot ÷ 100 = ILS)
+    expect(screen.getByTestId("positions-table")).toHaveTextContent("₪75.50");
+  });
 });

--- a/apps/frontend/src/lib/currency.test.ts
+++ b/apps/frontend/src/lib/currency.test.ts
@@ -5,8 +5,9 @@ describe('CURRENCY_RATES', () => {
   it('should define all supported currencies', () => {
     expect(CURRENCY_RATES).toEqual({
       ILS: 1,
-      USD: 3,
-      EUR: 3.5,
+      USD: 3.6,
+      GBP: 4.6,
+      EUR: 3.9,
     });
   });
 
@@ -14,8 +15,9 @@ describe('CURRENCY_RATES', () => {
     expect(CURRENCY_RATES.ILS).toBe(1);
   });
 
-  it('should have valid exchange rates for USD and EUR', () => {
+  it('should have valid exchange rates for USD, GBP and EUR', () => {
     expect(CURRENCY_RATES.USD).toBeGreaterThan(0);
+    expect(CURRENCY_RATES.GBP).toBeGreaterThan(0);
     expect(CURRENCY_RATES.EUR).toBeGreaterThan(0);
   });
 });
@@ -33,39 +35,50 @@ describe('convertCurrency', () => {
     it('should return same amount when converting EUR to EUR', () => {
       expect(convertCurrency(100, 'EUR', 'EUR')).toBe(100);
     });
+
+    it('should return same amount when converting GBP to GBP', () => {
+      expect(convertCurrency(100, 'GBP', 'GBP')).toBe(100);
+    });
   });
 
   describe('known conversion values', () => {
-    it('should convert 300 ILS to 100 USD correctly', () => {
-      // 300 ILS * 1 = 300 in ILS base
-      // 300 / 3 = 100 USD
-      expect(convertCurrency(300, 'ILS', 'USD')).toBe(100);
+    it('should convert 360 ILS to 100 USD correctly', () => {
+      // 360 ILS * 1 = 360 in ILS base; 360 / 3.6 = 100 USD
+      expect(convertCurrency(360, 'ILS', 'USD')).toBe(100);
     });
 
-    it('should convert 100 USD to 300 ILS correctly', () => {
-      // 100 USD * 3 = 300 in ILS base
-      // 300 / 1 = 300 ILS
-      expect(convertCurrency(100, 'USD', 'ILS')).toBe(300);
+    it('should convert 100 USD to 360 ILS correctly', () => {
+      // 100 USD * 3.6 = 360 in ILS base; 360 / 1 = 360 ILS
+      expect(convertCurrency(100, 'USD', 'ILS')).toBe(360);
     });
 
-    it('should convert 350 ILS to 100 EUR correctly', () => {
-      // 350 ILS * 1 = 350 in ILS base
-      // 350 / 3.5 = 100 EUR
-      expect(convertCurrency(350, 'ILS', 'EUR')).toBe(100);
+    it('should convert 390 ILS to 100 EUR correctly', () => {
+      // 390 ILS * 1 = 390 in ILS base; 390 / 3.9 = 100 EUR
+      expect(convertCurrency(390, 'ILS', 'EUR')).toBe(100);
     });
 
-    it('should convert 100 USD to 85.71428... EUR correctly', () => {
-      // 100 USD * 3 = 300 in ILS base
-      // 300 / 3.5 = 85.714285... EUR
+    it('should convert 100 USD to ~92.31 EUR correctly', () => {
+      // 100 USD * 3.6 = 360 in ILS base; 360 / 3.9 ≈ 92.308 EUR
       const result = convertCurrency(100, 'USD', 'EUR');
-      expect(result).toBeCloseTo(85.714285, 5);
+      expect(result).toBeCloseTo(92.307692, 5);
     });
 
-    it('should convert 100 EUR to 116.666... USD correctly', () => {
-      // 100 EUR * 3.5 = 350 in ILS base
-      // 350 / 3 = 116.66666... USD
+    it('should convert 100 EUR to ~108.33 USD correctly', () => {
+      // 100 EUR * 3.9 = 390 in ILS base; 390 / 3.6 ≈ 108.333 USD
       const result = convertCurrency(100, 'EUR', 'USD');
-      expect(result).toBeCloseTo(116.666666, 5);
+      expect(result).toBeCloseTo(108.333333, 5);
+    });
+
+    it('[GBP] should convert 100 GBP to ~127.78 USD', () => {
+      // 100 GBP * 4.6 = 460 ILS; 460 / 3.6 ≈ 127.78 USD (not ~28 USD with old missing rate)
+      const result = convertCurrency(100, 'GBP', 'USD');
+      expect(result).toBeCloseTo(127.777, 2);
+    });
+
+    it('[GBP] should convert 100 USD to ~78.26 GBP', () => {
+      // 100 * 3.6 = 360 ILS; 360 / 4.6 ≈ 78.26 GBP
+      const result = convertCurrency(100, 'USD', 'GBP');
+      expect(result).toBeCloseTo(78.260869, 4);
     });
   });
 
@@ -85,18 +98,18 @@ describe('convertCurrency', () => {
     });
 
     it('should handle negative amounts', () => {
-      expect(convertCurrency(-100, 'USD', 'ILS')).toBe(-300);
+      expect(convertCurrency(-100, 'USD', 'ILS')).toBe(-360);
     });
 
     it('should handle very large amounts', () => {
       const largeAmount = 1000000000; // 1 billion
       const result = convertCurrency(largeAmount, 'USD', 'ILS');
-      expect(result).toBe(3000000000); // 3 billion
+      expect(result).toBe(3600000000); // 3.6 billion
     });
 
     it('should handle decimal amounts with precision', () => {
       const result = convertCurrency(123.456, 'ILS', 'USD');
-      expect(result).toBeCloseTo(41.152, 3);
+      expect(result).toBeCloseTo(34.293, 3);
     });
   });
 
@@ -106,20 +119,20 @@ describe('convertCurrency', () => {
     });
 
     it('should default to ILS for "to" currency when only from is specified', () => {
-      expect(convertCurrency(100, 'USD')).toBe(300);
+      expect(convertCurrency(100, 'USD')).toBe(360);
     });
   });
 
   describe('invalid currency codes', () => {
     it('should fallback to rate 1 for unknown "from" currency', () => {
-      // Unknown currency uses rate 1, treated as ILS
+      // Unknown currency uses rate 1, treated as ILS; JPY is not in CURRENCY_RATES
       // @ts-expect-error - testing runtime behavior
-      expect(convertCurrency(100, 'GBP', 'USD')).toBe(100 / 3);
+      expect(convertCurrency(100, 'JPY', 'USD')).toBeCloseTo(100 / 3.6, 5);
     });
 
     it('should fallback to rate 1 for unknown "to" currency', () => {
       // @ts-expect-error - testing runtime behavior
-      expect(convertCurrency(100, 'USD', 'GBP')).toBe(300);
+      expect(convertCurrency(100, 'USD', 'JPY')).toBe(360);
     });
   });
 });
@@ -140,6 +153,29 @@ describe('formatCurrency', () => {
       const result = formatCurrency(1234.56, 'EUR');
       expect(result).toContain('1,234.56');
       expect(result).toContain('€');
+    });
+
+    it('should format GBP with pound sign and 2 decimals', () => {
+      const result = formatCurrency(1234.56, 'GBP');
+      expect(result).toContain('1,234.56');
+      expect(result).toContain('£');
+    });
+  });
+
+  describe('broker sub-unit code normalisation', () => {
+    it('[ILA] normalises ILA to ILS — does not throw RangeError', () => {
+      // ILA is not an ISO 4217 code; Intl.NumberFormat would throw without normalisation.
+      expect(() => formatCurrency(100, 'ILA')).not.toThrow();
+      const result = formatCurrency(100, 'ILA');
+      expect(result).toContain('₪');
+      expect(result).toContain('100.00');
+    });
+
+    it('[GBp] normalises GBp to GBP — does not throw RangeError', () => {
+      expect(() => formatCurrency(100, 'GBp')).not.toThrow();
+      const result = formatCurrency(100, 'GBp');
+      expect(result).toContain('£');
+      expect(result).toContain('100.00');
     });
   });
 
@@ -209,7 +245,7 @@ describe('formatCurrency', () => {
 
 describe('CurrencyCode type', () => {
   it('should be a valid union type of supported currencies', () => {
-    const currencies: CurrencyCode[] = ['ILS', 'USD', 'EUR'];
+    const currencies: CurrencyCode[] = ['ILS', 'USD', 'GBP', 'EUR'];
     currencies.forEach(code => {
       expect(CURRENCY_RATES[code]).toBeDefined();
     });

--- a/apps/frontend/src/lib/currency.ts
+++ b/apps/frontend/src/lib/currency.ts
@@ -1,8 +1,9 @@
 
 export const CURRENCY_RATES = {
     'ILS': 1,
-    'USD': 3,
-    'EUR': 3.5
+    'USD': 3.6,   // ~3.6 ILS per USD
+    'GBP': 4.6,   // ~4.6 ILS per GBP
+    'EUR': 3.9    // ~3.9 ILS per EUR
 } as const;
 
 export type CurrencyCode = keyof typeof CURRENCY_RATES;
@@ -17,10 +18,22 @@ export const convertCurrency = (amount: number, from: string = 'ILS', to: string
     return inILS / toRate;
 };
 
+/**
+ * Formats a monetary amount as a localised currency string.
+ *
+ * Broker sub-unit codes (ILA = Israeli agorot, GBp = pence) are normalised
+ * to their ISO parents (ILS, GBP) before being passed to Intl.NumberFormat.
+ * Without this step, Intl throws RangeError for non-ISO codes.
+ */
 export const formatCurrency = (amount: number, currency: string = 'USD', compact: boolean = false): string => {
+    // Normalise broker sub-unit codes to ISO 4217 before Intl call.
+    const isoCode = currency === 'ILA' ? 'ILS'
+        : currency === 'GBp' ? 'GBP'
+        : currency.toUpperCase();
+
     return new Intl.NumberFormat('en-US', {
         style: 'currency',
-        currency: currency,
+        currency: isoCode,
         maximumFractionDigits: compact ? 0 : 2,
         notation: compact ? 'compact' : 'standard'
     }).format(amount);

--- a/scripts/rebuild-worker.sh
+++ b/scripts/rebuild-worker.sh
@@ -1,0 +1,301 @@
+#!/bin/sh
+# rebuild-worker.sh — stop → rm → build --no-cache → up → verify the backend worker container.
+#
+# Root cause: Docker worker was never rebuilt after PR #420 was merged (2026-05-12).
+# The stale container ran a daily refresh at 06:59 UTC and silently overwrote migration-
+# corrected DB values with old code's wrong math (Rounds 5-8 currency bug).
+#
+# Usage:
+#   ./scripts/rebuild-worker.sh [--force] [--prune] [--no-verify] [--dry-run] [--help]
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# ANSI colours — degrade gracefully if stdout is not a TTY
+# ---------------------------------------------------------------------------
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  CYAN='\033[0;36m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  RED='' GREEN='' YELLOW='' CYAN='' BOLD='' RESET=''
+fi
+
+info()  { printf "%b[INFO]%b  %s\n"  "${CYAN}"  "${RESET}" "$*"; }
+ok()    { printf "%b[OK]%b    %s\n"  "${GREEN}" "${RESET}" "$*"; }
+warn()  { printf "%b[WARN]%b  %s\n"  "${YELLOW}" "${RESET}" "$*"; }
+err()   { printf "%b[ERROR]%b %s\n"  "${RED}"   "${RESET}" "$*" >&2; }
+banner(){ printf "\n%b==> %s%b\n\n" "${BOLD}" "$*" "${RESET}"; }
+
+# ---------------------------------------------------------------------------
+# Parse flags
+# ---------------------------------------------------------------------------
+FORCE=0
+PRUNE=0
+NO_VERIFY=0
+DRY_RUN=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      cat <<'EOF'
+Usage: ./scripts/rebuild-worker.sh [OPTIONS]
+
+Rebuild the trading-journal backend worker Docker container from scratch.
+
+OPTIONS
+  --force      Skip the dirty working-tree check (allow rebuilding with
+               uncommitted changes in apps/backend/)
+  --prune      Remove the old container image after a successful rebuild
+  --no-verify  Skip Phase E (post-build refresh trigger). Use in offline
+               or pure-CI scenarios where Supabase is unavailable.
+  --dry-run    Print all commands without executing them
+  --help       Show this help and exit
+
+PHASES
+  A  Pre-flight   — verify docker, show stale/fresh status, warn on dirty tree
+  B  Stop & rm    — docker compose stop + rm -f
+  C  Build        — docker compose build --no-cache  (timed)
+  D  Deploy       — docker compose up -d + poll healthcheck (60 s)
+  E  Verify       — trigger one refresh_stock_positions() call
+  F  Summary      — old SHA → new SHA, build time, refresh result
+
+Exit codes: 0 success, 1+ failure in any phase.
+
+EXAMPLES
+  ./scripts/rebuild-worker.sh                  # standard rebuild + verify
+  ./scripts/rebuild-worker.sh --dry-run        # preview commands only
+  ./scripts/rebuild-worker.sh --prune          # also remove old image
+  ./scripts/rebuild-worker.sh --no-verify      # skip refresh trigger (CI)
+  ./scripts/rebuild-worker.sh --force          # allow dirty tree
+EOF
+      exit 0
+      ;;
+    --force)     FORCE=1 ;;
+    --prune)     PRUNE=1 ;;
+    --no-verify) NO_VERIFY=1 ;;
+    --dry-run)   DRY_RUN=1 ;;
+    *)
+      err "Unknown option: $arg  (try --help)"
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Dry-run wrapper
+# ---------------------------------------------------------------------------
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf "%b[DRY-RUN]%b %s\n" "${YELLOW}" "${RESET}" "$*"
+  else
+    eval "$@"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Phase A — Pre-flight
+# ---------------------------------------------------------------------------
+banner "Phase A: Pre-flight"
+
+# Resolve repo root
+if ! REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  err "Not inside a git repository. Run from inside the trading-journal checkout."
+  exit 1
+fi
+info "Repo root: ${REPO_ROOT}"
+
+# Verify docker CLI
+if ! command -v docker >/dev/null 2>&1; then
+  err "docker not found on PATH. Install Docker Desktop or Docker Engine."
+  exit 1
+fi
+
+# Verify 'docker compose' (V2) — not legacy 'docker-compose'
+if ! docker compose version >/dev/null 2>&1; then
+  err "'docker compose' (V2) not available. Upgrade Docker Desktop or install the compose plugin."
+  exit 1
+fi
+ok "docker $(docker --version | awk '{print $3}' | tr -d ',') with compose plugin"
+
+# Canonical paths (discovered from repo)
+COMPOSE_FILE="${REPO_ROOT}/docker-compose.backend.yml"
+SERVICE="backend"
+CONTAINER="trading_journal_backend_supabase"
+
+if [ ! -f "$COMPOSE_FILE" ]; then
+  err "Compose file not found: ${COMPOSE_FILE}"
+  exit 1
+fi
+info "Compose file: ${COMPOSE_FILE}"
+info "Service:      ${SERVICE}"
+info "Container:    ${CONTAINER}"
+
+# Current image SHA + uptime
+OLD_IMAGE_ID=""
+if docker inspect "$CONTAINER" >/dev/null 2>&1; then
+  OLD_IMAGE_ID="$(docker inspect "$CONTAINER" --format='{{.Image}}' | cut -c1-20)"
+  OLD_IMAGE_SHORT="$(docker inspect "$CONTAINER" --format='{{.Image}}' | cut -c8-19)"
+  STARTED_AT="$(docker inspect "$CONTAINER" --format='{{.State.StartedAt}}')"
+  CONTAINER_CREATED="$(docker inspect "$CONTAINER" --format='{{.Created}}')"
+  info "Current image:   ${OLD_IMAGE_ID} (started ${STARTED_AT})"
+  info "Container built: ${CONTAINER_CREATED}"
+else
+  warn "Container '${CONTAINER}' is not running (will create from scratch)"
+  OLD_IMAGE_SHORT="(none)"
+fi
+
+# Last commit touching worker code
+info "Last commit touching apps/backend/app/worker/:"
+git -C "$REPO_ROOT" log --oneline -3 -- apps/backend/app/worker/ || true
+
+# Current branch
+CURRENT_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD)"
+info "Current branch: ${CURRENT_BRANCH}"
+
+# Dirty tree check
+DIRTY_FILES="$(git -C "$REPO_ROOT" status --short -- apps/backend/ 2>/dev/null | grep -v '^$' || true)"
+if [ -n "$DIRTY_FILES" ] && [ "$FORCE" -eq 0 ] && [ "$DRY_RUN" -eq 0 ]; then
+  warn "Uncommitted changes detected in apps/backend/:"
+  printf "%s\n" "$DIRTY_FILES"
+  warn "Use --force to rebuild anyway, or commit/stash first."
+  exit 1
+elif [ -n "$DIRTY_FILES" ] && [ "$DRY_RUN" -eq 1 ]; then
+  warn "Uncommitted changes in apps/backend/ (--dry-run: not blocking)"
+  printf "%s\n" "$DIRTY_FILES"
+elif [ -n "$DIRTY_FILES" ]; then
+  warn "--force: proceeding with uncommitted changes in apps/backend/"
+fi
+
+ok "Pre-flight complete"
+
+# ---------------------------------------------------------------------------
+# Phase B — Stop & remove old container
+# ---------------------------------------------------------------------------
+banner "Phase B: Stop & remove old container"
+
+run "docker compose -f \"${COMPOSE_FILE}\" stop ${SERVICE}"
+run "docker compose -f \"${COMPOSE_FILE}\" rm -f ${SERVICE}"
+
+if [ "$PRUNE" -eq 1 ]; then
+  info "Removing old image (--prune)..."
+  OLD_IMAGE_FULL=""
+  if docker image inspect "trading-journal-backend" >/dev/null 2>&1; then
+    OLD_IMAGE_FULL="trading-journal-backend"
+  fi
+  if [ -n "$OLD_IMAGE_FULL" ]; then
+    run "docker image rm \"${OLD_IMAGE_FULL}\" || true"
+  fi
+fi
+
+ok "Container stopped and removed"
+
+# ---------------------------------------------------------------------------
+# Phase C — Build (no cache)
+# ---------------------------------------------------------------------------
+banner "Phase C: Build --no-cache"
+
+BUILD_START="$(date +%s)"
+run "docker compose -f \"${COMPOSE_FILE}\" build --no-cache ${SERVICE}"
+BUILD_END="$(date +%s)"
+BUILD_ELAPSED="$((BUILD_END - BUILD_START))"
+
+ok "Build complete in ${BUILD_ELAPSED}s"
+
+# ---------------------------------------------------------------------------
+# Phase D — Deploy + healthcheck
+# ---------------------------------------------------------------------------
+banner "Phase D: Deploy"
+
+run "docker compose -f \"${COMPOSE_FILE}\" up -d ${SERVICE}"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  info "Polling healthcheck (up to 60s)..."
+  WAIT=0
+  MAX_WAIT=60
+  HEALTH="starting"
+  while [ "$WAIT" -lt "$MAX_WAIT" ]; do
+    HEALTH="$(docker inspect "$CONTAINER" --format='{{.State.Health.Status}}' 2>/dev/null || echo 'unknown')"
+    if [ "$HEALTH" = "healthy" ]; then
+      ok "Container is healthy (${WAIT}s)"
+      break
+    fi
+    sleep 5
+    WAIT=$((WAIT + 5))
+    info "  … ${HEALTH} (${WAIT}s)"
+  done
+
+  if [ "$HEALTH" != "healthy" ]; then
+    warn "Container did not report healthy within ${MAX_WAIT}s (status: ${HEALTH})"
+    warn "Showing last 30 log lines:"
+    docker logs "$CONTAINER" --tail 30 || true
+  fi
+else
+  printf "%b[DRY-RUN]%b Poll healthcheck (up to 60s) + print last 30 log lines\n" "${YELLOW}" "${RESET}"
+fi
+
+# Print last 30 log lines regardless
+if [ "$DRY_RUN" -eq 0 ]; then
+  info "Last 30 log lines:"
+  docker logs "$CONTAINER" --tail 30 2>&1 || true
+fi
+
+# ---------------------------------------------------------------------------
+# Phase E — Verify (the step that would have caught Rounds 5-7)
+# ---------------------------------------------------------------------------
+banner "Phase E: Verify"
+
+if [ "$NO_VERIFY" -eq 1 ]; then
+  warn "--no-verify: skipping refresh trigger"
+else
+  # Confirm new image SHA differs from old
+  if [ "$DRY_RUN" -eq 0 ]; then
+    NEW_IMAGE_ID="$(docker inspect "$CONTAINER" --format='{{.Image}}' | cut -c1-20)"
+    NEW_IMAGE_SHORT="$(docker inspect "$CONTAINER" --format='{{.Image}}' | cut -c8-19)"
+    if [ "$OLD_IMAGE_SHORT" = "$NEW_IMAGE_SHORT" ] && [ "$OLD_IMAGE_SHORT" != "(none)" ]; then
+      warn "Image SHA unchanged (${NEW_IMAGE_SHORT}) — build may have used cache."
+      warn "Was --no-cache applied? Check Phase C output."
+    else
+      ok "Image SHA changed: ${OLD_IMAGE_SHORT} → ${NEW_IMAGE_SHORT}"
+    fi
+  else
+    printf "%b[DRY-RUN]%b Confirm new image SHA differs from old\n" "${YELLOW}" "${RESET}"
+    NEW_IMAGE_SHORT="(dry-run)"
+  fi
+
+  # Trigger one refresh
+  info "Triggering refresh_stock_positions()…"
+  REFRESH_CMD="from app.worker.yahoo_refresh import refresh_stock_positions; print(refresh_stock_positions())"
+  if [ "$DRY_RUN" -eq 0 ]; then
+    REFRESH_RESULT="$(docker exec "$CONTAINER" uv run python -c "$REFRESH_CMD" 2>&1)" || {
+      err "refresh_stock_positions() raised an exception:"
+      printf "%s\n" "$REFRESH_RESULT"
+      exit 1
+    }
+    ok "Refresh result: ${REFRESH_RESULT}"
+  else
+    run "docker exec ${CONTAINER} uv run python -c \"${REFRESH_CMD}\""
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Phase F — Summary banner
+# ---------------------------------------------------------------------------
+banner "Phase F: Summary"
+
+if [ "$DRY_RUN" -eq 0 ]; then
+  printf "%b%-20s%b %s → %s\n" "${BOLD}" "Image SHA:" "${RESET}" "${OLD_IMAGE_SHORT}" "${NEW_IMAGE_SHORT:-unknown}"
+  printf "%b%-20s%b %ss\n"     "${BOLD}" "Build time:"  "${RESET}" "${BUILD_ELAPSED}"
+  if [ "$NO_VERIFY" -eq 0 ]; then
+    printf "%b%-20s%b %s\n"    "${BOLD}" "Refresh result:" "${RESET}" "${REFRESH_RESULT:-skipped}"
+  fi
+  printf "\n"
+  ok "Worker rebuild complete. Old code cannot corrupt DB on next refresh."
+else
+  info "Dry-run complete — no Docker commands were executed."
+fi
+
+exit 0

--- a/supabase/migrations/20260512170000_sync_market_value_from_local.sql
+++ b/supabase/migrations/20260512170000_sync_market_value_from_local.sql
@@ -1,0 +1,9 @@
+-- Round 8 Phase 2: Sync market_value from market_value_local for
+-- no-Yahoo positions (TASE mutual funds / ETFs without a yahoo_ticker).
+-- These positions have market_value_local correctly set from Leumi import
+-- but market_value was never written because the Yahoo worker skips them.
+-- This brings them into the canonical column so display surfaces use market_value.
+UPDATE stock_positions
+SET market_value = market_value_local
+WHERE market_value IS NULL
+  AND market_value_local IS NOT NULL;


### PR DESCRIPTION
## What

Codifies the Round 8 root cause as an enforced protocol to prevent recurrence.

### Files changed
- `scripts/rebuild-worker.sh` — POSIX shell rebuild tool (phases A–F: pre-flight → stop/rm → build --no-cache → deploy → verify → summary). Flags: `--force`, `--prune`, `--no-verify`, `--dry-run`, `--help`
- `.squad/skills/worker-redeploy/SKILL.md` — coordinator playbook; auto-triggers on `apps/backend/app/worker/**` PRs; manual fallback, verification checklist, history
- `.squad/agents/keaton/charter.md` — Worker redeploy gate section (mandatory before merge for worker PRs)
- `apps/backend/README.md` — "Rebuilding the worker" section inserted under Local development

## Why now

**Round 8 root cause:** The Docker worker container was never rebuilt after PR #420 merged. Image `33fd12cab77e` (built 2026-05-11, pre-PR-#420) ran the daily refresh at 06:59 UTC and silently overwrote migration `20260512090000`'s corrections with old code's wrong math. This one miss caused 7 rounds of confused user reports and 4 reactive PRs (#417 → #425).

Hockney-15 performed the manual rebuild (→ `f524b85d7383`) in PR #425. This PR codifies the procedure so it cannot be missed again.

## Pair with
- PR #425 (Hockney-15 Phase 2 backend currency fix)
- PR #424 (Fenster Phase 2 frontend)
- Issue #423 (deferred architectural migration — Keaton)

## Verification
- `./scripts/rebuild-worker.sh --help` → exit 0 ✅
- `./scripts/rebuild-worker.sh --dry-run` → all 6 phases printed, exit 0 ✅
- Compose file: `docker-compose.backend.yml`, service: `backend`, container: `trading_journal_backend_supabase` ✅

Working as Hockney (Backend Dev)