### PR TITLE
feat(options): compute options-income estimation series with configurable growth (#428)

### DIFF
--- a/apps/frontend/src/app/options/actions.test.ts
+++ b/apps/frontend/src/app/options/actions.test.ts
@@ -5,7 +5,7 @@ const { mockGetUser } = vi.hoisted(() => ({ mockGetUser: vi.fn() }));
 vi.mock('@/lib/supabase/server', () => ({ createClient: vi.fn() }));
 
 import { createClient } from '@/lib/supabase/server';
-import { getOptionsMonthlyMetrics, getUserAccountsWithOptionsEnabled } from './actions';
+import { getOptionsMonthlyMetrics, getUserAccountsWithOptionsEnabled, getOptionsIncomeEstimation } from './actions';
 
 const MOCK_USER_ID = 'user-uuid-1234';
 const MOCK_HOUSEHOLD_ID = 'household-uuid-5678';
@@ -96,5 +96,150 @@ describe('options dashboard actions', () => {
 
     await expect(getUserAccountsWithOptionsEnabled()).resolves.toEqual([{ id: '7', label: 'DU777', accountId: 'DU777', accountType: 'IBKR' }]);
     expect(accountsQuery.eq).toHaveBeenCalledWith('compute_options_income', true);
+  });
+});
+
+// ── getOptionsIncomeEstimation ─────────────────────────────────────────────────
+
+/**
+ * Helper: build a mock supabase client whose `options_dashboard_monthly` query
+ * returns the supplied rows, and whose `household_members` query resolves normally.
+ */
+function makeEstimationClient(
+  rows: Array<{ period_start: string; cash_flow_total: string | number }>,
+  queryError: null | { message: string } = null,
+) {
+  const order = vi.fn().mockResolvedValue({ data: queryError ? null : rows, error: queryError });
+  const estimationQuery = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    order,
+  };
+  const from = vi.fn((table: string) => {
+    if (table === 'household_members') return householdQuery();
+    if (table === 'options_dashboard_monthly') return estimationQuery;
+    throw new Error(`Unexpected table: ${table}`);
+  });
+  (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from });
+}
+
+describe('getOptionsIncomeEstimation', () => {
+  it('computes 3-year average baseline and projects forward with default 2% growth', async () => {
+    // 3 full years: 2022 = 12000, 2023 = 15000, 2024 = 18000 → avg = 15000
+    makeEstimationClient([
+      { period_start: '2022-01-01', cash_flow_total: '6000' },
+      { period_start: '2022-07-01', cash_flow_total: '6000' },
+      { period_start: '2023-01-01', cash_flow_total: '7500' },
+      { period_start: '2023-07-01', cash_flow_total: '7500' },
+      { period_start: '2024-01-01', cash_flow_total: '9000' },
+      { period_start: '2024-07-01', cash_flow_total: '9000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 0.02, finalYear: currentYear + 2 });
+
+    expect(result.baselineAverage).toBeCloseTo(15000, 5);
+    expect(result.growthRate).toBe(0.02);
+    expect(result.projections).toHaveLength(2);
+
+    // Year 1: 15000 × 1.02^1 = 15300
+    expect(result.projections[0].year).toBe(currentYear + 1);
+    expect(result.projections[0].expectedIncome).toBeCloseTo(15300, 4);
+    expect(result.projections[0].isProjected).toBe(true);
+
+    // Year 2: 15000 × 1.02^2 = 15606
+    expect(result.projections[1].year).toBe(currentYear + 2);
+    expect(result.projections[1].expectedIncome).toBeCloseTo(15606, 4);
+  });
+
+  it('falls back to <3 years of history (2-year average)', async () => {
+    // Only 2 years available: 2023 = 10000, 2024 = 20000 → avg = 15000
+    makeEstimationClient([
+      { period_start: '2023-06-01', cash_flow_total: '10000' },
+      { period_start: '2024-06-01', cash_flow_total: '20000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 0, finalYear: currentYear + 1 });
+
+    expect(result.baselineAverage).toBeCloseTo(15000, 5);
+  });
+
+  it('falls back to 1-year history when only one year exists', async () => {
+    makeEstimationClient([
+      { period_start: '2024-03-01', cash_flow_total: '8000' },
+      { period_start: '2024-09-01', cash_flow_total: '4000' },
+    ]);
+
+    const result = await getOptionsIncomeEstimation({ growthRate: 0, finalYear: new Date().getFullYear() + 1 });
+
+    expect(result.baselineAverage).toBeCloseTo(12000, 5);
+  });
+
+  it('projects 0% growth — every year equals baseline exactly', async () => {
+    makeEstimationClient([
+      { period_start: '2022-01-01', cash_flow_total: '5000' },
+      { period_start: '2023-01-01', cash_flow_total: '5000' },
+      { period_start: '2024-01-01', cash_flow_total: '5000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 0, finalYear: currentYear + 3 });
+
+    expect(result.projections).toHaveLength(3);
+    for (const p of result.projections) {
+      expect(p.expectedIncome).toBeCloseTo(5000, 5);
+    }
+  });
+
+  it('projects negative baseline forward without flooring at zero', async () => {
+    // 3 years of net losses → avg = -3000
+    makeEstimationClient([
+      { period_start: '2022-01-01', cash_flow_total: '-3000' },
+      { period_start: '2023-01-01', cash_flow_total: '-3000' },
+      { period_start: '2024-01-01', cash_flow_total: '-3000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 0.02, finalYear: currentYear + 1 });
+
+    expect(result.baselineAverage).toBeCloseTo(-3000, 5);
+    // -3000 × 1.02^1 = -3060
+    expect(result.projections[0].expectedIncome).toBeCloseTo(-3060, 4);
+    expect(result.projections[0].expectedIncome).toBeLessThan(0);
+  });
+
+  it('returns empty projections for empty history', async () => {
+    makeEstimationClient([]);
+
+    const result = await getOptionsIncomeEstimation({ growthRate: 0.02, finalYear: 2064 });
+
+    expect(result.baselineAverage).toBe(0);
+    expect(result.projections).toHaveLength(0);
+  });
+
+  it('returns empty projections when unauthenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('no session') });
+    (createClient as ReturnType<typeof vi.fn>).mockResolvedValue({ auth: { getUser: mockGetUser }, from: vi.fn() });
+
+    const result = await getOptionsIncomeEstimation({ growthRate: 0.02, finalYear: 2064 });
+
+    expect(result.baselineAverage).toBe(0);
+    expect(result.projections).toHaveLength(0);
+  });
+
+  it('uses default growthRate 0.02 and finalYear 2064 when no params are passed', async () => {
+    makeEstimationClient([
+      { period_start: '2024-01-01', cash_flow_total: '10000' },
+    ]);
+
+    const result = await getOptionsIncomeEstimation();
+
+    expect(result.growthRate).toBe(0.02);
+    // finalYear defaults to 2064 — projections span from currentYear+1 to 2064
+    const currentYear = new Date().getFullYear();
+    expect(result.projections.length).toBe(2064 - currentYear);
+    expect(result.projections[0].year).toBe(currentYear + 1);
+    expect(result.projections[result.projections.length - 1].year).toBe(2064);
   });
 });

--- a/apps/frontend/src/app/options/actions.ts
+++ b/apps/frontend/src/app/options/actions.ts
@@ -486,3 +486,116 @@ export async function getEfficiencyGaugesData(accountId?: string): Promise<impor
     isStale: isOlderThanOneHour(marginAsOf),
   };
 }
+
+// ── Options Income Estimation ─────────────────────────────────────────────────
+
+export interface OptionsIncomeProjection {
+  year: number;
+  expectedIncome: number;
+  isProjected: true;
+}
+
+export interface OptionsIncomeEstimationResult {
+  baselineAverage: number;
+  growthRate: number;
+  projections: OptionsIncomeProjection[];
+}
+
+export interface OptionsIncomeEstimationParams {
+  /**
+   * Annual growth rate applied to the baseline.
+   * Default 2% per user spec (Jony, 2026-05-12). Configurable via settings.optionsGrowthRate.
+   */
+  growthRate?: number;
+  /** Last calendar year to include in the projection horizon. Default 2064. */
+  finalYear?: number;
+}
+
+/**
+ * Computes a forward-looking options income estimation series.
+ *
+ * **Baseline**: averages the last 3 calendar years of realized options cash flow
+ * from `options_dashboard_monthly` (same source as `getOptionsYearlyCashFlow()`).
+ * Monthly `cash_flow_total` values are summed per calendar year, then the most
+ * recent N years (up to 3) are averaged.
+ *
+ * **Fallback**: if fewer than 3 years of history exist, averages whatever is
+ * available (1 or 2 years). If no history exists at all, returns empty projections.
+ *
+ * **Negative baseline**: a negative average is projected forward as-is — no
+ * floor at zero — to honestly represent a loss trajectory.
+ *
+ * **Projection formula** for offset Y (1-indexed from current year + 1):
+ * ```
+ *   expectedIncome(year) = baselineAverage × (1 + growthRate)^Y
+ * ```
+ * All intermediate calculations use `Decimal` for monetary precision.
+ *
+ * @param params.growthRate - Annual growth rate (default 0.02). Pass
+ *   `settings.optionsGrowthRate` from the client SettingsContext.
+ * @param params.finalYear - Last year to include in projections (default 2064).
+ *   Pass `settings.optionsFinalYear` from the client SettingsContext.
+ */
+export async function getOptionsIncomeEstimation(
+  params: OptionsIncomeEstimationParams = {},
+): Promise<OptionsIncomeEstimationResult> {
+  // Default 2% per user spec (Jony, 2026-05-12). Configurable via settings.optionsGrowthRate.
+  const growthRate = typeof params.growthRate === 'number' ? params.growthRate : 0.02;
+  const finalYear = typeof params.finalYear === 'number' ? params.finalYear : 2064;
+
+  const { householdId } = await getAuthenticatedHousehold();
+  if (!householdId) return { baselineAverage: 0, growthRate, projections: [] };
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('options_dashboard_monthly')
+    .select('period_start, cash_flow_total')
+    .eq('household_id', householdId)
+    .order('period_start', { ascending: true });
+
+  if (error) {
+    console.error('[getOptionsIncomeEstimation] query error:', error.message);
+    return { baselineAverage: 0, growthRate, projections: [] };
+  }
+
+  const rows = (data ?? []) as Array<{ period_start: string; cash_flow_total: string | number | null }>;
+
+  // Aggregate monthly rows → yearly totals using Decimal arithmetic.
+  const yearlyMap = new Map<number, Decimal>();
+  for (const row of rows) {
+    const year = new Date(row.period_start).getFullYear();
+    const monthly = new Decimal(decimalString(row.cash_flow_total as NumericLike));
+    yearlyMap.set(year, (yearlyMap.get(year) ?? new Decimal(0)).plus(monthly));
+  }
+
+  if (yearlyMap.size === 0) {
+    return { baselineAverage: 0, growthRate, projections: [] };
+  }
+
+  // Take the last 3 calendar years (up to all available if fewer than 3).
+  const sortedYears = Array.from(yearlyMap.keys()).sort((a, b) => a - b);
+  const lookbackYears = sortedYears.slice(-3);
+
+  const sum = lookbackYears.reduce(
+    (acc, yr) => acc.plus(yearlyMap.get(yr)!),
+    new Decimal(0),
+  );
+  const baselineDecimal = sum.dividedBy(new Decimal(lookbackYears.length));
+  const baselineAverage = baselineDecimal.toDecimalPlaces(10).toNumber();
+
+  // Project from (currentYear + 1) through finalYear.
+  const currentYear = new Date().getFullYear();
+  const projections: OptionsIncomeProjection[] = [];
+  const growthDecimal = new Decimal(1).plus(new Decimal(growthRate));
+
+  for (let year = currentYear + 1; year <= finalYear; year++) {
+    const offset = year - currentYear; // 1-indexed exponent
+    const expectedIncome = baselineDecimal
+      .times(growthDecimal.pow(offset))
+      .toDecimalPlaces(10)
+      .toNumber();
+    projections.push({ year, expectedIncome, isProjected: true });
+  }
+
+  return { baselineAverage, growthRate, projections };
+}

--- a/apps/frontend/src/app/settings/SettingsContext.tsx
+++ b/apps/frontend/src/app/settings/SettingsContext.tsx
@@ -41,7 +41,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   dividendReinvestRate: 0.8,
   cutoffYear: 2040,
   dividendFinalYear: 2064,
-  optionsGrowthRate: 0.05,
+  optionsGrowthRate: 0.02, // Default 2% per user spec (Jony, 2026-05-12). Configurable via settings.optionsGrowthRate.
   optionsFinalYear: 2064,
 
   mainCurrency: 'ILS',


### PR DESCRIPTION
## Summary

Working as **McManus** (Data/Finance Dev)

Implements the options-income estimation engine — the foundational server action that issues #429, #430, #431, and #432 will build on.

## Changes

- **`apps/frontend/src/app/options/actions.ts`**: New `getOptionsIncomeEstimation()` server action — household-scoped, Decimal-precise, projects options income forward using configurable growth rate
- **`apps/frontend/src/app/settings/SettingsContext.tsx`**: Updated `optionsGrowthRate` default from 0.05 → **0.02** per user spec (Jony, 2026-05-12)
- **`apps/frontend/src/app/options/actions.test.ts`**: 8 new unit tests covering 3-year avg, <3yr fallback, 0% growth, negative baseline, empty history — all 11 tests ✅

## Edge Cases
- <3 years history: averages whatever is available, JSDoc documented
- Negative average: projected forward as-is (no floor at zero)
- Empty history: returns empty projections gracefully

## Return Shape
```ts
{ baselineAverage: number; growthRate: number; projections: Array<{ year: number; expectedIncome: number; isProjected: true }> }
```

## Growth Rate Decision
Default changed to **2% (0.02)** per user spec. The existing `optionsGrowthRate` setting in SettingsContext is still the source of truth and remains user-configurable.

Closes #428