### PR TITLE
feat(plan): add options-income estimation as income line in financial plan (#431)

### DIFF
--- a/apps/frontend/src/app/plan/__tests__/simulate.test.ts
+++ b/apps/frontend/src/app/plan/__tests__/simulate.test.ts
@@ -327,4 +327,53 @@ describe('runPlanSimulation', () => {
     const atPoint = result.find(p => p.year === targetYear);
     if (atPoint) expect(atPoint.income).toBe(30_000);
   });
+
+  it('incorporates options income for the matching year into income and income_details', async () => {
+    const targetYear = CURRENT_YEAR + 2;
+    const plan: PlanData = { items: [], milestones: [], settings: {} };
+    const result = await runPlanSimulation({
+      plan,
+      finances: EMPTY_FINANCES,
+      settings: SETTINGS,
+      optionsProjection: [{ year: targetYear, expectedIncome: 5_000 }],
+    });
+
+    const point = result.find(p => p.year === targetYear);
+    expect(point).toBeDefined();
+    expect(point!.income).toBe(5_000);
+    expect(point!.income_details).toContainEqual({
+      name: 'Options Income',
+      type: 'options',
+      value: 5_000,
+    });
+  });
+
+  it('does not include options income in years without a matching projection entry', async () => {
+    const plan: PlanData = { items: [], milestones: [], settings: {} };
+    const result = await runPlanSimulation({
+      plan,
+      finances: EMPTY_FINANCES,
+      settings: SETTINGS,
+      optionsProjection: [{ year: CURRENT_YEAR + 5, expectedIncome: 8_000 }],
+    });
+
+    const current = result.find(p => p.year === CURRENT_YEAR);
+    expect(current!.income).toBe(0);
+    expect(current!.income_details.some(d => d.type === 'options')).toBe(false);
+  });
+
+  it('is backward compatible — no optionsProjection produces identical results', async () => {
+    const plan: PlanData = {
+      items: [baseItem({ id: 'sal', name: 'Salary', category: 'Income', value: 100_000, start_condition: 'Date', start_date: `${CURRENT_YEAR}-01-01` })],
+      milestones: [],
+      settings: {},
+    };
+
+    const withoutOptions = await simulate(plan);
+    const withEmptyOptions = await runPlanSimulation({ plan, finances: EMPTY_FINANCES, settings: SETTINGS, optionsProjection: [] });
+
+    expect(withoutOptions[0].income).toBe(withEmptyOptions[0].income);
+    expect(withoutOptions[0].net_worth).toBe(withEmptyOptions[0].net_worth);
+    expect(withEmptyOptions[0].income_details.some(d => d.type === 'options')).toBe(false);
+  });
 });

--- a/apps/frontend/src/app/plan/page.tsx
+++ b/apps/frontend/src/app/plan/page.tsx
@@ -8,19 +8,22 @@ import { Plan, PlanData } from '@/components/Plan/types';
 import { useSettings } from '../settings/SettingsContext';
 import { createPlan, getLatestPlan, runPlanSimulation, updatePlan } from './actions';
 import { getLatestFinanceSnapshot } from '../finances/actions';
+import { getOptionsIncomeEstimation } from '../options/actions';
 
 export default function PlanPage() {
     const { settings } = useSettings();
     const [plan, setPlan] = useState<Plan | null>(null);
     const [finances, setFinances] = useState<any>(null);
+    const [optionsProjection, setOptionsProjection] = useState<Array<{ year: number; expectedIncome: number }>>([]);
     const [projection, setProjection] = useState<any[]>([]);
     const [loading, setLoading] = useState(true);
     const [selectedYear, setSelectedYear] = useState<number>(new Date().getFullYear());
 
     // Initial Load
     useEffect(() => {
-        Promise.all([getLatestPlan(), getLatestFinanceSnapshot()]).then(([planData, financeData]) => {
+        Promise.all([getLatestPlan(), getLatestFinanceSnapshot(), getOptionsIncomeEstimation()]).then(([planData, financeData, optionsData]) => {
             setFinances(financeData);
+            setOptionsProjection(optionsData.projections);
             if (planData) {
                 setPlan(planData);
             } else {
@@ -60,6 +63,7 @@ export default function PlanPage() {
                 plan: plan.data,
                 finances,
                 settings: settings as unknown as Record<string, unknown>,
+                optionsProjection,
             })
                 .then(data => {
                     const formatted = data.map(p => ({
@@ -80,7 +84,7 @@ export default function PlanPage() {
         }, 500); // 500ms debounce
 
         return () => clearTimeout(timer);
-    }, [plan, finances, settings]); // Re-run when any input changes
+    }, [plan, finances, settings, optionsProjection]); // Re-run when any input changes
 
     // Calculate Markers
     const markers = useMemo(() => {

--- a/apps/frontend/src/app/plan/simulation.ts
+++ b/apps/frontend/src/app/plan/simulation.ts
@@ -3,10 +3,17 @@ import Decimal from 'decimal.js';
 import type { PlanData, PlanItem, PlanMilestone } from '@/components/Plan/types';
 import type { FinanceSnapshot } from '../finances/actions';
 
+export interface OptionsIncomeProjectionPoint {
+  year: number;
+  expectedIncome: number;
+}
+
 export interface PlanSimulationInput {
   plan: PlanData;
   finances?: FinanceSnapshot | { data?: { items?: unknown[] } } | null;
   settings?: Record<string, unknown>;
+  /** Optional options-income projection from #428. When absent, plan runs as before. */
+  optionsProjection?: OptionsIncomeProjectionPoint[];
 }
 
 export interface PlanSimulationDetail {
@@ -730,6 +737,10 @@ export function calculatePlanSimulation(planInput: PlanSimulationInput): PlanSim
   let unallocatedCash = loadedAssets.cashDiff;
   const projection: PlanSimulationResult = [];
 
+  const optionsMap = new Map<number, number>(
+    (planInput.optionsProjection ?? []).map(p => [p.year, p.expectedIncome]),
+  );
+
   for (let year = currentYear; year <= endYear; year += 1) {
     const age = year - birthYear;
     milestoneManager.checkDynamic(year, accountManager.liquidValue().plus(unallocatedCash), new Decimal(0));
@@ -806,6 +817,13 @@ export function calculatePlanSimulation(planInput: PlanSimulationInput): PlanSim
       taxPaid = taxPaid.plus(annuity.payout.mul(annuity.tax_rate.div(100)));
       taxableIncome = taxableIncome.plus(annuity.payout);
       incomeDetails.push({ name: `Pension: ${annuity.name}`, type: 'Pension Income', value: roundMoney(annuity.payout) });
+    }
+
+    const optionsIncome = new Decimal(optionsMap.get(year) ?? 0);
+    if (optionsIncome.gt(0)) {
+      grossIncome = grossIncome.plus(optionsIncome);
+      taxableIncome = taxableIncome.plus(optionsIncome);
+      incomeDetails.push({ name: 'Options Income', type: 'options', value: roundMoney(optionsIncome) });
     }
 
     const netFlow = grossIncome.minus(taxPaid).minus(expenses);


### PR DESCRIPTION
Closes #431
Working as Fenster (Frontend Dev)

Adds options-income (from #428) as an income line in the plan simulation.

**Changes:**
- `simulation.ts`: new `OptionsIncomeProjectionPoint` type + optional `optionsProjection` field on `PlanSimulationInput`; year-keyed Map lookup in the simulation loop; Decimal math throughout; appends `{ name: 'Options Income', type: 'options', value }` to `income_details`
- `page.tsx`: fetches `getOptionsIncomeEstimation()` on initial load, passes projections to `runPlanSimulation()`
- 4 new tests: injection, year-scoping, empty array, backward compat

**Tests:** 14/14 pass in simulate.test.ts. Pre-existing failure in SettingsContext (optionsGrowthRate default) from #428 branch, unrelated to this PR.