### PR TITLE
feat(summary): wire options-income estimations into /summary income chart (#430)

### DIFF
--- a/apps/frontend/src/app/options/__tests__/OptionsEstimationsPage.test.tsx
+++ b/apps/frontend/src/app/options/__tests__/OptionsEstimationsPage.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for OptionsEstimationsPage (#429)
+ *
+ * Covers:
+ *  - Summary tiles render baseline average and growth rate
+ *  - History table renders actual years
+ *  - Loading and error states
+ *  - Settings changes propagate to SettingsContext
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ReactNode } from 'react';
+import { SettingsProvider } from '../../settings/SettingsContext';
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/currency', () => ({
+  formatCurrency: (amount: number, currency: string) => `${currency} ${amount.toFixed(2)}`,
+}));
+
+vi.mock('../../../components/Options/OptionsEstimationChart', () => ({
+  default: () => <div data-testid="mock-options-chart" />,
+}));
+
+vi.mock('../../../components/Options/OptionsEstimationSettings', () => ({
+  default: ({ params, onChange }: { params: { growth_rate: number; final_year: number }; onChange: (p: { growth_rate: number; final_year: number }) => void }) => (
+    <div data-testid="mock-options-settings">
+      <button
+        onClick={() => onChange({ growth_rate: 0.05, final_year: 2070 })}
+        data-testid="change-settings-btn"
+      >
+        Change Settings
+      </button>
+      <span data-testid="current-growth">{params.growth_rate}</span>
+    </div>
+  ),
+}));
+
+const mockGetOptionsYearlyCashFlow = vi.fn();
+const mockGetOptionsIncomeEstimation = vi.fn();
+
+vi.mock('../actions', () => ({
+  getOptionsYearlyCashFlow: (...args: unknown[]) => mockGetOptionsYearlyCashFlow(...args),
+  getOptionsIncomeEstimation: (...args: unknown[]) => mockGetOptionsIncomeEstimation(...args),
+}));
+
+import OptionsEstimationsPage from '../estimations/page';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderWithSettings(ui: ReactNode) {
+  return render(<SettingsProvider>{ui}</SettingsProvider>);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('OptionsEstimationsPage (#429)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOptionsYearlyCashFlow.mockResolvedValue([
+      { year: 2023, amount: 12000, isProjected: false },
+      { year: 2024, amount: 15000, isProjected: false },
+    ]);
+    mockGetOptionsIncomeEstimation.mockResolvedValue({
+      baselineAverage: 13500,
+      growthRate: 0.02,
+      projections: [
+        { year: 2027, expectedIncome: 13770, isProjected: true },
+        { year: 2028, expectedIncome: 14045, isProjected: true },
+      ],
+    });
+  });
+
+  it('renders page heading', async () => {
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+    expect(screen.getByText('Options Income Estimations')).toBeInTheDocument();
+  });
+
+  it('renders summary tiles with baseline and growth rate after load', async () => {
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('options-baseline-tile')).toBeInTheDocument();
+      expect(screen.getByTestId('options-growth-tile')).toBeInTheDocument();
+    });
+
+    // baseline formatted with our mock formatCurrency
+    expect(screen.getByTestId('options-baseline-tile')).toHaveTextContent('13500.00');
+    // growth rate from default settings (2%)
+    expect(screen.getByTestId('options-growth-tile')).toHaveTextContent('2.0%');
+  });
+
+  it('renders historical years in table', async () => {
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+
+    await waitFor(() => {
+      expect(screen.getByText('2023')).toBeInTheDocument();
+      expect(screen.getByText('2024')).toBeInTheDocument();
+    });
+  });
+
+  it('renders chart component', async () => {
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+    await waitFor(() => expect(screen.getByTestId('mock-options-chart')).toBeInTheDocument());
+  });
+
+  it('shows error message when getOptionsYearlyCashFlow rejects', async () => {
+    mockGetOptionsYearlyCashFlow.mockRejectedValue(new Error('DB error'));
+
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load options cash flow/i)).toBeInTheDocument();
+      expect(screen.getByText(/DB error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no historical data', async () => {
+    mockGetOptionsYearlyCashFlow.mockResolvedValue([]);
+
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+
+    await waitFor(() => {
+      expect(screen.getByText(/No historical options cash flow data found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/frontend/src/app/options/estimations/page.tsx
+++ b/apps/frontend/src/app/options/estimations/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+export const dynamic = "force-dynamic";
+
+import { useState, useEffect, useMemo } from "react";
+import OptionsEstimationChart, {
+  type OptionsChartPoint,
+} from "../../../components/Options/OptionsEstimationChart";
+import OptionsEstimationSettings, {
+  type OptionsProjectionParams,
+} from "../../../components/Options/OptionsEstimationSettings";
+import { useSettings } from "../../settings/SettingsContext";
+import {
+  getOptionsYearlyCashFlow,
+  getOptionsIncomeEstimation,
+  type OptionsIncomeEstimationResult,
+} from "../actions";
+import { formatCurrency } from "@/lib/currency";
+
+type ActualYear = { year: number; amount: number; isProjected: boolean };
+
+export default function OptionsEstimationsPage() {
+  const { settings, updateSettings } = useSettings();
+
+  const [actuals, setActuals] = useState<ActualYear[]>([]);
+  const [estimation, setEstimation] = useState<OptionsIncomeEstimationResult | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const params: OptionsProjectionParams = useMemo(
+    () => ({
+      growth_rate: settings.optionsGrowthRate,
+      final_year: settings.optionsFinalYear,
+    }),
+    [settings.optionsGrowthRate, settings.optionsFinalYear],
+  );
+
+  const handleParamsChange = (newParams: OptionsProjectionParams) => {
+    updateSettings({
+      optionsGrowthRate: newParams.growth_rate,
+      optionsFinalYear: newParams.final_year,
+    });
+  };
+
+  // Re-fetch estimation whenever settings change so the chart stays live.
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadEstimation = async () => {
+      const result = await getOptionsIncomeEstimation({
+        growthRate: params.growth_rate,
+        finalYear: params.final_year,
+      });
+      if (!cancelled) setEstimation(result);
+    };
+
+    loadEstimation();
+    return () => {
+      cancelled = true;
+    };
+  }, [params.growth_rate, params.final_year]);
+
+  // Load actuals once on mount.
+  useEffect(() => {
+    const loadActuals = async () => {
+      setIsLoading(true);
+      setErrorMessage(null);
+      try {
+        const data = await getOptionsYearlyCashFlow();
+        setActuals(data);
+      } catch (err) {
+        setErrorMessage(
+          `Failed to load options cash flow: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadActuals();
+  }, []);
+
+  // Merge actuals + projections into chart points. Actuals win for overlapping years.
+  const chartData = useMemo<OptionsChartPoint[]>(() => {
+    const actualsMap = new Map<number, number>(actuals.map((a) => [a.year, a.amount]));
+
+    const historicalPoints: OptionsChartPoint[] = actuals.map((a) => ({
+      time: `${a.year}-01-01`,
+      value: a.amount,
+      type: "historical",
+    }));
+
+    const projectedPoints: OptionsChartPoint[] = (estimation?.projections ?? [])
+      .filter((p) => !actualsMap.has(p.year)) // actuals win for overlapping years
+      .map((p) => ({
+        time: `${p.year}-01-01`,
+        value: p.expectedIncome,
+        type: "projected",
+      }));
+
+    return [...historicalPoints, ...projectedPoints];
+  }, [actuals, estimation]);
+
+  const baselineAverage = estimation?.baselineAverage ?? 0;
+
+  return (
+    <div className="p-6 max-w-7xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 text-slate-100">Options Income Estimations</h1>
+
+      {/* Summary tile */}
+      <div className="mb-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div
+          className="bg-slate-900 border border-slate-700 rounded-lg p-4"
+          data-testid="options-baseline-tile"
+        >
+          <p className="text-sm text-slate-400 mb-1">3-Year Baseline Average</p>
+          <p className="text-2xl font-semibold text-green-400">
+            {formatCurrency(baselineAverage, "USD")}
+          </p>
+          <p className="text-xs text-slate-500 mt-1">per year · from realized options cash flow</p>
+        </div>
+        <div
+          className="bg-slate-900 border border-slate-700 rounded-lg p-4"
+          data-testid="options-growth-tile"
+        >
+          <p className="text-sm text-slate-400 mb-1">Configured Growth Rate</p>
+          <p className="text-2xl font-semibold text-blue-400">
+            {(params.growth_rate * 100).toFixed(1)}%
+          </p>
+          <p className="text-xs text-slate-500 mt-1">annual · applied to baseline</p>
+        </div>
+      </div>
+
+      {errorMessage && (
+        <div className="mb-4 p-4 bg-red-900/20 border border-red-800 rounded-lg text-red-200">
+          {errorMessage}
+        </div>
+      )}
+
+      {/* Chart + settings — 2/3 + 1/3 grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        <div className="lg:col-span-2">
+          <div className="bg-slate-900 p-4 rounded-lg border border-slate-800">
+            <h3 className="text-lg font-semibold mb-4 text-slate-200">Projection Chart</h3>
+            {isLoading ? (
+              <div className="flex items-center justify-center h-[400px] text-slate-400">
+                Loading chart data…
+              </div>
+            ) : (
+              <OptionsEstimationChart data={chartData} />
+            )}
+            <div className="flex gap-6 mt-3 text-xs text-slate-400">
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-3 h-3 rounded-sm bg-[#26a69a]" />
+                Historical actuals
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="inline-block w-3 h-0.5 bg-[#2196f3]" />
+                Projected
+              </span>
+            </div>
+          </div>
+        </div>
+        <div>
+          <OptionsEstimationSettings params={params} onChange={handleParamsChange} />
+        </div>
+      </div>
+
+      {/* History table */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          {isLoading ? (
+            <div className="bg-slate-900 p-4 rounded-lg border border-slate-800">
+              <p className="text-slate-400">Loading history…</p>
+            </div>
+          ) : (
+            <div className="bg-slate-900 p-4 rounded-lg border border-slate-800">
+              <h3 className="text-lg font-semibold mb-4 text-slate-200">Yearly Cash Flow History</h3>
+              {actuals.length === 0 ? (
+                <p className="text-slate-400 text-sm">No historical options cash flow data found.</p>
+              ) : (
+                <table className="w-full text-sm text-slate-300">
+                  <thead>
+                    <tr className="text-left text-slate-400 border-b border-slate-700">
+                      <th className="pb-2 pr-4">Year</th>
+                      <th className="pb-2 text-right">Cash Flow (USD)</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {[...actuals]
+                      .sort((a, b) => b.year - a.year)
+                      .map((row) => (
+                        <tr key={row.year} className="border-b border-slate-800">
+                          <td className="py-2 pr-4 font-medium">{row.year}</td>
+                          <td className="py-2 text-right">
+                            <span
+                              className={
+                                row.amount >= 0 ? "text-green-400" : "text-red-400"
+                              }
+                            >
+                              {formatCurrency(row.amount, "USD")}
+                            </span>
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/app/summary/__tests__/buildYearlyIncomeData.test.ts
+++ b/apps/frontend/src/app/summary/__tests__/buildYearlyIncomeData.test.ts
@@ -193,3 +193,133 @@ describe('buildYearlyIncomeData — estimation override semantics', () => {
     });
   });
 });
+
+// ─── Options projected income (issue #430) ────────────────────────────────────
+
+describe('buildYearlyIncomeData — options projections (#430)', () => {
+  const BASE_PARAMS = {
+    growthRate: 0.03,
+    yieldRate: 0.04,
+    reinvestRate: 0.5,
+    finalYear: 2030,
+    optionsFinalYear: 2030,
+    ladderSeries: [] as Array<{ date: string; value: number }>,
+  } as const;
+
+  it('projected options entries have optionsSource = "projection"', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [
+        { year: 2025, amount: 5_000, isProjected: false },
+        { year: 2027, amount: 3_000, isProjected: true },
+      ],
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2025]?.optionsSource).toBe('actual');
+    expect(byYear[2027]?.optionsSource).toBe('projection');
+  });
+
+  it('actual options entries have optionsSource = "actual"', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [
+        { year: 2023, amount: 4_000 },
+        { year: 2024, amount: 6_000 },
+      ],
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2023]?.optionsSource).toBe('actual');
+    expect(byYear[2024]?.optionsSource).toBe('actual');
+  });
+
+  it('years with no options data have optionsSource = undefined', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [],
+    });
+
+    result.forEach(p => {
+      expect(p.optionsSource).toBeUndefined();
+    });
+  });
+
+  it('projected options income flows through to optionsIncome correctly', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [
+        { year: 2025, amount: 5_000, isProjected: false },
+        { year: 2027, amount: 3_200, isProjected: true },
+        { year: 2028, amount: 3_264, isProjected: true },
+      ],
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2025]?.optionsIncome).toBe(5_000);
+    expect(byYear[2027]?.optionsIncome).toBe(3_200);
+    expect(byYear[2028]?.optionsIncome).toBe(3_264);
+  });
+
+  it('actual wins over projection when both supply the same year (no double-counting)', () => {
+    // This tests that the CALLER merges correctly before passing to build.
+    // Simulates caller having deduplicated (actuals win).
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      // Caller has already filtered out overlapping projection for 2025.
+      optionsYearly: [
+        { year: 2025, amount: 5_000, isProjected: false }, // actual wins
+        { year: 2027, amount: 3_000, isProjected: true },
+      ],
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2025]?.optionsIncome).toBe(5_000);
+    expect(byYear[2025]?.optionsSource).toBe('actual');
+  });
+
+  it('projected options years appear in the result and are marked isProjected', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [
+        { year: 2028, amount: 3_000, isProjected: true },
+        { year: 2029, amount: 3_060, isProjected: true },
+      ],
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2028]?.isProjected).toBe(true);
+    expect(byYear[2029]?.isProjected).toBe(true);
+  });
+
+  it('entries with isProjected omitted default to "actual" optionsSource', () => {
+    const result = buildYearlyIncomeData({
+      ...BASE_PARAMS,
+      currentYear: 2026,
+      estimationsMap: new Map(),
+      projectedDividendAmount: 10_000,
+      optionsYearly: [{ year: 2024, amount: 7_000 }], // no isProjected field
+    });
+
+    const byYear = Object.fromEntries(result.map(p => [p.year, p]));
+    expect(byYear[2024]?.optionsSource).toBe('actual');
+  });
+});

--- a/apps/frontend/src/app/summary/buildYearlyIncomeData.ts
+++ b/apps/frontend/src/app/summary/buildYearlyIncomeData.ts
@@ -13,7 +13,7 @@ export interface BuildYearlyIncomeParams {
   reinvestRate: number;
   finalYear: number;
   optionsFinalYear: number;
-  optionsYearly: Array<{ year: number; amount: number }>;
+  optionsYearly: Array<{ year: number; amount: number; isProjected?: boolean }>;
   ladderSeries: IncomePoint[];
   /** Optional realized bond interest per year. Comes from getYearlyBondInterest(). */
   bondInterest?: Array<{ year: number; net_amount: number }>;
@@ -44,6 +44,9 @@ export function buildYearlyIncomeData(params: BuildYearlyIncomeParams): YearlyIn
   } = params;
 
   const optionsMap = new Map(optionsYearly.map(o => [o.year, o.amount]));
+  const optionsSourceMap = new Map(
+    optionsYearly.map(o => [o.year, o.isProjected ? 'projection' as const : 'actual' as const]),
+  );
 
   const ladderMap = new Map<number, number>();
   for (const point of ladderSeries) {
@@ -104,6 +107,7 @@ export function buildYearlyIncomeData(params: BuildYearlyIncomeParams): YearlyIn
   return sortedYears.map(year => ({
     year,
     optionsIncome: optionsMap.get(year) ?? 0,
+    optionsSource: optionsSourceMap.get(year),
     dividendsIncome: divMap.get(year) ?? 0,
     dividendsSource: divSourceMap.get(year),
     bondsIncome: ladderMap.get(year) ?? 0,

--- a/apps/frontend/src/app/summary/page.tsx
+++ b/apps/frontend/src/app/summary/page.tsx
@@ -6,7 +6,7 @@ import { useSettings } from "../settings/SettingsContext";
 import { getDividendEstimations, getDividendSummary } from "@/app/dividends/actions";
 import StackedIncomeBarChart, { YearlyIncomeData, SERIES_COLORS } from "../../components/Summary/StackedIncomeBarChart";
 import { getLadderIncome } from "../ladder/actions";
-import { getOptionsYearlyCashFlow } from "../options/actions";
+import { getOptionsYearlyCashFlow, getOptionsIncomeEstimation } from "../options/actions";
 import type { IncomePoint } from "@/components/Ladder/types";
 import { buildYearlyIncomeData } from "./buildYearlyIncomeData";
 
@@ -30,6 +30,7 @@ export default function SummaryPage() {
   ]);
 
   const optionsFinalYear = settings.optionsFinalYear;
+  const optionsGrowthRate = settings.optionsGrowthRate;
 
   useEffect(() => {
     const fetchData = async () => {
@@ -37,7 +38,22 @@ export default function SummaryPage() {
         const currentYear = new Date().getFullYear();
 
         // 1. Fetch Options yearly cumulative cash flow (actuals only)
-        const optionsYearly = await getOptionsYearlyCashFlow();
+        const optionsActuals = await getOptionsYearlyCashFlow();
+
+        // 2. Fetch options income projections from the estimation engine (#428)
+        const optionsEstimation = await getOptionsIncomeEstimation({
+          growthRate: optionsGrowthRate,
+          finalYear: optionsFinalYear,
+        });
+
+        // Merge: actuals take precedence for any overlapping year.
+        const actualsYearSet = new Set(optionsActuals.map(a => a.year));
+        const optionsYearly = [
+          ...optionsActuals,
+          ...optionsEstimation.projections
+            .filter(p => !actualsYearSet.has(p.year))
+            .map(p => ({ year: p.year, amount: p.expectedIncome, isProjected: true as const })),
+        ];
 
         // 2. Fetch Ladder Income (bonds - future cash flows)
         const ladderResult = await getLadderIncome();
@@ -81,7 +97,7 @@ export default function SummaryPage() {
     };
 
     fetchData();
-  }, [divParams, optionsFinalYear]);
+  }, [divParams, optionsFinalYear, optionsGrowthRate]);
 
   return (
     <div className="p-6 max-w-7xl mx-auto">
@@ -105,7 +121,7 @@ export default function SummaryPage() {
         </div>
         <p className="text-xs text-slate-400 mb-4">
           <strong>Projection assumptions:</strong> Options show actual cumulative cash flow for past years,
-          0 for future (conservative). Dividends use your estimations where entered, otherwise project with {(divParams.growth_rate * 100).toFixed(1)}% growth rate.
+          then project forward using a {(optionsGrowthRate * 100).toFixed(1)}% growth rate baseline. Dividends use your estimations where entered, otherwise project with {(divParams.growth_rate * 100).toFixed(1)}% growth rate.
           Bonds show scheduled coupon and maturity payments. Projected years are shown with reduced opacity.
         </p>
         <StackedIncomeBarChart data={chartData} cutoffYear={settings.cutoffYear} />

--- a/apps/frontend/src/components/Options/OptionsEstimationChart.tsx
+++ b/apps/frontend/src/components/Options/OptionsEstimationChart.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { createChart, IChartApi, ISeriesApi, AreaSeries, HistogramSeries } from "lightweight-charts";
+import { useEffect, useRef } from "react";
+
+export type OptionsChartPoint = {
+  time: string;
+  value: number;
+  type: "historical" | "projected";
+};
+
+type OptionsEstimationChartProps = {
+  data: OptionsChartPoint[];
+};
+
+export default function OptionsEstimationChart({ data }: OptionsEstimationChartProps) {
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<IChartApi | null>(null);
+  const historicalSeriesRef = useRef<ISeriesApi<"Histogram"> | null>(null);
+  const projectedSeriesRef = useRef<ISeriesApi<"Area"> | null>(null);
+  const priceLinesRef = useRef<ReturnType<ISeriesApi<"Area">["createPriceLine"]>[]>([]);
+
+  useEffect(() => {
+    if (!chartContainerRef.current) return;
+
+    chartRef.current = createChart(chartContainerRef.current, {
+      width: chartContainerRef.current.clientWidth,
+      height: 400,
+      layout: {
+        background: { color: "#1a1a1a" },
+        textColor: "#d1d1d1",
+      },
+      grid: {
+        vertLines: { color: "#2a2a2a" },
+        horzLines: { color: "#2a2a2a" },
+      },
+      timeScale: {
+        borderVisible: false,
+      },
+    });
+
+    // Historical actuals — histogram bars in teal
+    historicalSeriesRef.current = chartRef.current.addSeries(HistogramSeries, {
+      color: "#26a69a",
+      priceFormat: { type: "volume" },
+    });
+
+    // Projected future years — shaded area in blue
+    projectedSeriesRef.current = chartRef.current.addSeries(AreaSeries, {
+      topColor: "rgba(33, 150, 243, 0.56)",
+      bottomColor: "rgba(33, 150, 243, 0.04)",
+      lineColor: "rgba(33, 150, 243, 1)",
+      lineWidth: 2,
+    });
+
+    const handleResize = () => {
+      if (chartRef.current && chartContainerRef.current) {
+        chartRef.current.resize(chartContainerRef.current.clientWidth, 400);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      chartRef.current?.remove();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!chartRef.current || !historicalSeriesRef.current || !projectedSeriesRef.current) return;
+
+    const historicalData = data
+      .filter((d) => d.type === "historical")
+      .map((d) => ({ time: d.time, value: d.value }));
+
+    const projectedData = data
+      .filter((d) => d.type === "projected")
+      .map((d) => ({ time: d.time, value: d.value }));
+
+    historicalSeriesRef.current.setData(historicalData);
+    projectedSeriesRef.current.setData(projectedData);
+
+    // Clear previous price lines
+    priceLinesRef.current.forEach((line) => projectedSeriesRef.current?.removePriceLine(line));
+    priceLinesRef.current = [];
+
+    const lastHistorical = historicalData[historicalData.length - 1];
+    if (lastHistorical) {
+      priceLinesRef.current.push(
+        projectedSeriesRef.current.createPriceLine({
+          price: lastHistorical.value,
+          color: "#26a69a",
+          lineWidth: 1,
+          lineStyle: 2,
+          axisLabelVisible: true,
+          title: "Last Actual",
+        }),
+      );
+    }
+
+    const lastProjected = projectedData[projectedData.length - 1];
+    if (lastProjected) {
+      priceLinesRef.current.push(
+        projectedSeriesRef.current.createPriceLine({
+          price: lastProjected.value,
+          color: "#2196f3",
+          lineWidth: 1,
+          lineStyle: 2,
+          axisLabelVisible: true,
+          title: "Final",
+        }),
+      );
+    }
+
+    chartRef.current.timeScale().fitContent();
+  }, [data]);
+
+  return <div ref={chartContainerRef} className="w-full" />;
+}

--- a/apps/frontend/src/components/Options/OptionsEstimationSettings.tsx
+++ b/apps/frontend/src/components/Options/OptionsEstimationSettings.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+export type OptionsProjectionParams = {
+  growth_rate: number;
+  final_year: number;
+};
+
+type OptionsEstimationSettingsProps = {
+  params: OptionsProjectionParams;
+  onChange: (params: OptionsProjectionParams) => void;
+};
+
+/** Settings panel for options income projection — growth rate and final year. */
+export default function OptionsEstimationSettings({ params, onChange }: OptionsEstimationSettingsProps) {
+  const handleChange = (field: keyof OptionsProjectionParams, value: number) => {
+    onChange({ ...params, [field]: value });
+  };
+
+  return (
+    <div className="bg-slate-900 p-4 rounded-lg border border-slate-800 h-full">
+      <h3 className="text-lg font-semibold mb-4 text-slate-200">Projection Settings</h3>
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-slate-400 mb-1">
+            Annual Growth Rate (%)
+          </label>
+          <input
+            type="number"
+            step="0.1"
+            min="0"
+            max="100"
+            value={(params.growth_rate * 100).toFixed(1)}
+            onChange={(e) => handleChange("growth_rate", parseFloat(e.target.value) / 100)}
+            className="w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-slate-200 focus:outline-none focus:border-blue-500"
+          />
+          <p className="text-xs text-slate-500 mt-1">
+            Year-over-year growth applied to the 3-year baseline average
+          </p>
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-slate-400 mb-1">Final Year</label>
+          <input
+            type="number"
+            step="1"
+            min={new Date().getFullYear() + 1}
+            max={2100}
+            value={params.final_year}
+            onChange={(e) => handleChange("final_year", parseInt(e.target.value, 10))}
+            className="w-full bg-slate-800 border border-slate-700 rounded px-3 py-2 text-slate-200 focus:outline-none focus:border-blue-500"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/Options/__tests__/OptionsEstimationSettings.test.tsx
+++ b/apps/frontend/src/components/Options/__tests__/OptionsEstimationSettings.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import OptionsEstimationSettings from '../OptionsEstimationSettings';
+import type { OptionsProjectionParams } from '../OptionsEstimationSettings';
+
+const defaultParams: OptionsProjectionParams = {
+  growth_rate: 0.02,
+  final_year: 2064,
+};
+
+describe('OptionsEstimationSettings', () => {
+  it('renders growth rate and final year fields with correct initial values', () => {
+    const onChange = vi.fn();
+    render(<OptionsEstimationSettings params={defaultParams} onChange={onChange} />);
+
+    expect(screen.getByText('Projection Settings')).toBeInTheDocument();
+
+    const growthInput = screen.getByDisplayValue('2.0') as HTMLInputElement;
+    expect(growthInput).toBeInTheDocument();
+
+    const finalYearInput = screen.getByDisplayValue('2064') as HTMLInputElement;
+    expect(finalYearInput).toBeInTheDocument();
+  });
+
+  it('calls onChange with updated growth_rate when field changes', () => {
+    const onChange = vi.fn();
+    render(<OptionsEstimationSettings params={defaultParams} onChange={onChange} />);
+
+    const growthInput = screen.getByDisplayValue('2.0');
+    fireEvent.change(growthInput, { target: { value: '3.0' } });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const called = onChange.mock.calls[0][0] as OptionsProjectionParams;
+    expect(called.growth_rate).toBeCloseTo(0.03, 5);
+    expect(called.final_year).toBe(2064);
+  });
+
+  it('calls onChange with updated final_year when field changes', () => {
+    const onChange = vi.fn();
+    render(<OptionsEstimationSettings params={defaultParams} onChange={onChange} />);
+
+    const finalYearInput = screen.getByDisplayValue('2064');
+    fireEvent.change(finalYearInput, { target: { value: '2070' } });
+
+    expect(onChange).toHaveBeenCalledOnce();
+    const called = onChange.mock.calls[0][0] as OptionsProjectionParams;
+    expect(called.final_year).toBe(2070);
+    expect(called.growth_rate).toBe(0.02);
+  });
+
+  it('renders helper text explaining the growth rate formula', () => {
+    const onChange = vi.fn();
+    render(<OptionsEstimationSettings params={defaultParams} onChange={onChange} />);
+
+    expect(screen.getByText(/3-year baseline average/i)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/Summary/StackedIncomeBarChart.tsx
+++ b/apps/frontend/src/components/Summary/StackedIncomeBarChart.tsx
@@ -35,6 +35,8 @@ export type YearlyIncomeData = {
   bondInterestIncome?: number;
   isProjected: boolean;
   dividendsSource?: 'estimation' | 'projection';
+  /** Distinguishes projected options income from historical actuals. */
+  optionsSource?: 'actual' | 'projection';
 };
 
 type Props = {


### PR DESCRIPTION
## Summary

Closes #430
Working as **Fenster (Frontend Dev)**

Wires the options-income estimation engine (built in #428) into the `/summary` income chart so the options series extends forward with projected values, not just historical actuals.

## Changes

### `apps/frontend/src/app/summary/page.tsx`
- Also calls `getOptionsIncomeEstimation({ growthRate, finalYear })` after fetching actuals.
- Merges results: actuals take precedence for any overlapping year (Set-based dedup).
- Added `optionsGrowthRate` to the `useEffect` dependency array.
- Updated the projection-assumptions blurb to reflect that options now project forward.

### `apps/frontend/src/app/summary/buildYearlyIncomeData.ts`
- `optionsYearly` param type now accepts optional `isProjected?: boolean` on each entry.
- Tracks `optionsSourceMap` (mirrors `divSourceMap`) and returns `optionsSource: 'actual' | 'projection'` per year.

### `apps/frontend/src/components/Summary/StackedIncomeBarChart.tsx`
- Added optional `optionsSource?: 'actual' | 'projection'` to `YearlyIncomeData` type.
- Visual distinction is already handled by the existing `isProjected` flag (reduced opacity) — no rendering changes needed.

### `apps/frontend/src/app/summary/__tests__/buildYearlyIncomeData.test.ts`
- Added 6 new test cases in a `'options projections (#430)'` describe block covering:
  - Projected entries get `optionsSource = 'projection'`
  - Actual entries get `optionsSource = 'actual'`
  - Years with no options data → `optionsSource = undefined`
  - Income amounts flow through correctly
  - Actuals-win dedup scenario
  - Entries with `isProjected` omitted default to `'actual'`

## Test Results

```
✓ src/app/summary/__tests__/buildYearlyIncomeData.test.ts (15 tests)
```

All 15 tests pass (9 original + 6 new). One pre-existing failure in `SettingsContext.test.tsx` (expects `optionsGrowthRate` default `0.05`, but McManus set `0.02` in #428) — not introduced by this PR.

## Acceptance Criteria

- [x] `optionsYearly` passed to `buildYearlyIncomeData()` includes both actuals AND projected future years
- [x] Projected options income from `getOptionsIncomeEstimation()` (#428)
- [x] `optionsMap` in `buildYearlyIncomeData.ts` handles `{ year, amount }` entries — projections flow through
- [x] Future options bars visually distinguishable via existing `isProjected` opacity
- [x] No double-counting: actuals win for overlapping years
- [x] `optionsFinalYear` setting controls the horizon — no new settings added