### PR TITLE
test(options): regression coverage for options-income estimation feature (#432)

### DIFF
--- a/apps/frontend/src/app/options/__tests__/OptionsEstimationsPage.test.tsx
+++ b/apps/frontend/src/app/options/__tests__/OptionsEstimationsPage.test.tsx
@@ -8,7 +8,7 @@
  *  - Settings changes propagate to SettingsContext
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { ReactNode } from 'react';
 import { SettingsProvider } from '../../settings/SettingsContext';
@@ -124,5 +124,51 @@ describe('OptionsEstimationsPage (#429)', () => {
     await waitFor(() => {
       expect(screen.getByText(/No historical options cash flow data found/i)).toBeInTheDocument();
     });
+  });
+
+  it('displays loading indicators while actuals fetch is in flight', () => {
+    // Never-resolving promise keeps the component in the loading state indefinitely.
+    mockGetOptionsYearlyCashFlow.mockReturnValue(new Promise(() => {}));
+
+    // Do NOT wrap in act so we observe the synchronous initial render.
+    render(
+      <SettingsProvider>
+        <OptionsEstimationsPage />
+      </SettingsProvider>,
+    );
+
+    // Both placeholders are rendered while isLoading is true.
+    expect(screen.getByText(/Loading chart data/i)).toBeInTheDocument();
+    expect(screen.getByText(/Loading history/i)).toBeInTheDocument();
+    // The history table header must not appear yet.
+    expect(screen.queryByText('Yearly Cash Flow History')).not.toBeInTheDocument();
+  });
+
+  it('re-fetches estimation with updated params when growth rate setting changes', async () => {
+    await act(async () => { renderWithSettings(<OptionsEstimationsPage />); });
+
+    // Initial fetch uses default settings (2% growth, finalYear 2064).
+    expect(mockGetOptionsIncomeEstimation).toHaveBeenCalledTimes(1);
+    expect(mockGetOptionsIncomeEstimation).toHaveBeenCalledWith({
+      growthRate: 0.02,
+      finalYear: 2064,
+    });
+
+    // The mock settings panel fires onChange({ growth_rate: 0.05, final_year: 2070 }).
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('change-settings-btn'));
+    });
+
+    // A second estimation fetch must be triggered with the new params.
+    await waitFor(() => {
+      expect(mockGetOptionsIncomeEstimation).toHaveBeenCalledTimes(2);
+      expect(mockGetOptionsIncomeEstimation).toHaveBeenLastCalledWith({
+        growthRate: 0.05,
+        finalYear: 2070,
+      });
+    });
+
+    // Growth tile must reflect the new rate immediately.
+    expect(screen.getByTestId('options-growth-tile')).toHaveTextContent('5.0%');
   });
 });

--- a/apps/frontend/src/app/options/actions.test.ts
+++ b/apps/frontend/src/app/options/actions.test.ts
@@ -242,4 +242,48 @@ describe('getOptionsIncomeEstimation', () => {
     expect(result.projections[0].year).toBe(currentYear + 1);
     expect(result.projections[result.projections.length - 1].year).toBe(2064);
   });
+
+  // ── Growth rate edge cases ────────────────────────────────────────────────
+
+  it('100% growth rate: each projection year doubles the previous year income', async () => {
+    // 3 equal years → baseline = 10 000
+    makeEstimationClient([
+      { period_start: '2022-01-01', cash_flow_total: '10000' },
+      { period_start: '2023-01-01', cash_flow_total: '10000' },
+      { period_start: '2024-01-01', cash_flow_total: '10000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 1.0, finalYear: currentYear + 3 });
+
+    expect(result.baselineAverage).toBeCloseTo(10_000, 5);
+    expect(result.growthRate).toBe(1.0);
+
+    // baseline × 2^1 = 20 000
+    expect(result.projections[0].expectedIncome).toBeCloseTo(20_000, 4);
+    // baseline × 2^2 = 40 000
+    expect(result.projections[1].expectedIncome).toBeCloseTo(40_000, 4);
+    // baseline × 2^3 = 80 000
+    expect(result.projections[2].expectedIncome).toBeCloseTo(80_000, 4);
+    expect(result.projections[0].isProjected).toBe(true);
+  });
+
+  it('0.001% growth rate: compound effect is negligible over one year', async () => {
+    // 0.001% = 0.00001 as a decimal fraction
+    makeEstimationClient([
+      { period_start: '2022-01-01', cash_flow_total: '10000' },
+      { period_start: '2023-01-01', cash_flow_total: '10000' },
+      { period_start: '2024-01-01', cash_flow_total: '10000' },
+    ]);
+
+    const currentYear = new Date().getFullYear();
+    const result = await getOptionsIncomeEstimation({ growthRate: 0.00001, finalYear: currentYear + 2 });
+
+    expect(result.baselineAverage).toBeCloseTo(10_000, 5);
+    // 10 000 × 1.00001^1 = 10 000.1 — only a 10-cent difference from baseline
+    expect(result.projections[0].expectedIncome).toBeCloseTo(10_000.1, 3);
+    // 10 000 × 1.00001^2 ≈ 10 000.2 — still nearly identical to baseline
+    expect(result.projections[1].expectedIncome).toBeGreaterThan(10_000);
+    expect(result.projections[1].expectedIncome).toBeLessThan(10_001);
+  });
 });


### PR DESCRIPTION
Closes #432
Working as Redfoot (Tester)

## What this PR adds

Fills the coverage gaps identified in #432 after auditing existing tests written by McManus and Fenster across the four implementation PRs (#428–#431).

### Audit summary

| Area | Already covered | Added by this PR |
|---|---|---|
| `getOptionsIncomeEstimation` — projection math | 3-yr avg, <3-yr fallback, 0% growth, negative baseline, empty history, unauthenticated, defaults | **100% growth**, **0.001% growth** |
| `/options/estimations` page | heading, tiles, history table, chart, error on actuals fetch, empty state | **loading state**, **settings change re-fetch** |
| `buildYearlyIncomeData` options projections | 7 tests (added by Fenster in #430) | — |
| `runPlanSimulation` options wiring | 3 tests (added by Fenster in #431) | — |

### New tests (4)

**`actions.test.ts` — growth rate edge cases**
- `100% growth rate: each projection year doubles the previous year income` — verifies exponential doubling: 10 000 → 20 000 → 40 000 → 80 000. Guards against capping or linearizing high rates.
- `0.001% growth rate: compound effect is negligible over one year` — verifies 10 000 × 1.00001 ≈ 10 000.1 and stays below 10 001 for year 2. Guards against accidental integer truncation of tiny growth.

**`OptionsEstimationsPage.test.tsx` — page behaviour**
- `displays loading indicators while actuals fetch is in flight` — mounts with a never-resolving actuals promise and asserts both "Loading chart data…" and "Loading history…" are in the DOM on the synchronous first render.
- `re-fetches estimation with updated params when growth rate setting changes` — clicks the mock settings panel, verifies `getOptionsIncomeEstimation` is called a second time with `growthRate: 0.05, finalYear: 2070`, and confirms the growth tile updates to `5.0%`.

## Quality gate

| Metric | Value |
|---|---|
| Total tests (4 files) | **50** |
| Passing | **50** |
| New tests added | **4** |
| Pass rate | **100%** |

Test run: `vitest run` on all four test files — zero failures, zero skips.