### PR TITLE
fix(/plan): add now() defaults to plans audit columns (closes silent NOT NULL violation)

### DIFF
--- a/supabase/migrations/20260513000811_fix_plans_audit_column_defaults.sql
+++ b/supabase/migrations/20260513000811_fix_plans_audit_column_defaults.sql
@@ -1,0 +1,45 @@
+-- Migration: 20260513000811_fix_plans_audit_column_defaults
+-- Created: 2026-05-13
+-- Author: Hockney (Backend Dev) — GH #440
+-- Purpose: Add missing DEFAULT now() to plans.created_at and plans.updated_at,
+--          and extend the tg_update_timestamp trigger to fire on INSERT as well
+--          as UPDATE so updated_at is always DB-managed.
+--
+-- Root cause: 20260430115000_baseline_legacy_schema.sql created plans with
+--   created_at timestamptz NOT NULL  (no DEFAULT)
+--   updated_at timestamptz NOT NULL  (no DEFAULT)
+--
+-- 20260430130000_add_audit_columns.sql then attempted:
+--   ALTER TABLE public.plans
+--     ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
+--     ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+--
+-- Postgres silently no-ops the entire ADD COLUMN when the column already exists —
+-- INCLUDING the DEFAULT clause. The column default was never applied.
+-- Confirmed via pg_attrdef: column_default IS NULL for both columns.
+-- Result: every INSERT via createPlan() threw a NOT NULL violation; plans table
+-- stayed at 0 rows; /cash-flow (which derives all data from getLatestPlan())
+-- rendered blank.
+--
+-- Fix:
+--   1. SET DEFAULT now() on both columns (idempotent — safe to run twice).
+--   2. Recreate trg_plans_updated_at to fire on BEFORE INSERT OR UPDATE
+--      so updated_at is always set by the DB, preventing the same class of bug.
+--
+-- Worker rebuild: NOT required.
+-- Downstream: /cash-flow will recover automatically once plans can be inserted.
+
+-- ----------------------------------------------------------------
+-- 1. Add missing column defaults
+-- ----------------------------------------------------------------
+alter table public.plans alter column created_at set default now();
+alter table public.plans alter column updated_at set default now();
+
+-- ----------------------------------------------------------------
+-- 2. Extend trigger to fire on INSERT OR UPDATE
+--    (was: BEFORE UPDATE only — created_at/updated_at were never touched on INSERT)
+-- ----------------------------------------------------------------
+drop trigger if exists trg_plans_updated_at on public.plans;
+create trigger trg_plans_updated_at
+  before insert or update on public.plans
+  for each row execute function public.tg_update_timestamp();


### PR DESCRIPTION
## Root cause

`plans.created_at` and `plans.updated_at` were declared `NOT NULL` in the baseline migration (`20260430115000`) but with **no DEFAULT**. Migration `20260430130000_add_audit_columns.sql` attempted to fix this with:

```sql
ALTER TABLE public.plans
  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now(),
  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
```

Postgres silently no-ops `ADD COLUMN IF NOT EXISTS` when the column already exists — **including the DEFAULT clause**. The column defaults were never applied. Confirmed via `pg_attrdef`: `column_default IS NULL` for both columns.

Every `createPlan()` INSERT failed with a NOT NULL constraint violation. The server action swallowed the error silently. The `plans` table stayed at 0 rows. `/cash-flow` (which derives 100% of its data from `getLatestPlan()`) rendered blank.

## Changes

**Migration: `20260513000811_fix_plans_audit_column_defaults.sql`**

1. **`ALTER COLUMN ... SET DEFAULT now()`** on both `created_at` and `updated_at` — the correct fix for pre-existing columns (idempotent, safe to run multiple times).

2. **Extend `trg_plans_updated_at` trigger** from `BEFORE UPDATE` → `BEFORE INSERT OR UPDATE` so `updated_at` is always DB-managed and a future silent-skip bug can't leave it null on INSERT.

## No worker rebuild needed

No `apps/backend/app/worker/**` files touched. Container is unchanged.

## Verification

After applying, `pg_attrdef` will show `column_default = 'now()'` for both columns. First `createPlan()` call will succeed and `/cash-flow` will recover automatically.

---

Closes #440
Working as Hockney (Backend Dev)