### PR TITLE
fix(/plan + /cash-flow): surface save errors + empty-state CTA

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -1,3 +1,15 @@
+## 2026-05-13 — PR #443 squad/440-error-surfacing
+
+Shipped P0 frontend fixes: error surfacing in `/plan` handleUpdatePlanData + empty-state CTA in `/cash-flow`.
+
+- `/plan`: captures `previousPlan` before optimistic write; on `result.ok === false` rolls back state, fires `toast.error()` via sonner, and `console.error`s for devtools. Installed sonner + added `<Toaster>` to root layout.
+- `/cash-flow`: replaced silent `return;` with a proper empty-state component (heading + copy + CTA link to `/plan`) when no plan exists post-load.
+- `CashFlowSankey`: updated zero-nodes message to include a navigable link to `/plan`.
+
+P1 income-stream wiring (dividends + bonds) pending Keaton architectural synthesis.
+
+---
+
 ## 2026-05-09 — #340 follow-up: account label rename
 
 Renamed tab display labels to match Jony's finalized directive:

--- a/.squad/skills/optimistic-ui-error-surfacing/SKILL.md
+++ b/.squad/skills/optimistic-ui-error-surfacing/SKILL.md
@@ -1,0 +1,84 @@
+# Skill: Optimistic UI Error Surfacing
+
+**Author:** Fenster (Frontend Dev)
+**Created:** 2026-05-13
+**Related PR:** #443
+
+---
+
+## Problem
+
+Optimistic UI patterns update local state immediately before a server call completes, giving users instant feedback. But when the server action returns `{ ok: false }`, the standard pattern silently leaves the stale optimistic state in place. Users see phantom "saved" data that disappears on next page load, with no indication anything went wrong.
+
+This is especially dangerous for financial data where silent failures masquerade as successful saves.
+
+---
+
+## Pattern
+
+Always capture `previousState` before the optimistic write, then rollback + toast on failure:
+
+```ts
+const handleUpdate = async (newData: T) => {
+  if (!entity) return;
+
+  // 1. Capture snapshot before optimistic write
+  const previousEntity = entity;
+
+  // 2. Apply optimistic update immediately
+  setEntity({ ...entity, data: newData });
+
+  // 3. Call server action
+  const result = await serverAction(entity.id, { data: newData });
+
+  if (result.ok) {
+    // Confirm with server-returned value (may differ from optimistic)
+    setEntity(result.entity);
+  } else {
+    // 4. Rollback + surface error
+    setEntity(previousEntity);
+    const message = result.error ?? 'Save failed. Please try again.';
+    console.error('[context] action failed:', message);
+    toast.error('Not saved', { description: message });
+  }
+};
+```
+
+---
+
+## Toast Setup (sonner)
+
+This project uses **sonner** for toasts. Ensure `<Toaster>` is mounted in the root layout:
+
+```tsx
+// apps/frontend/src/app/layout.tsx
+import { Toaster } from 'sonner';
+
+// Inside <body>:
+<Toaster theme="dark" position="bottom-right" richColors />
+```
+
+Usage in any client component:
+
+```ts
+import { toast } from 'sonner';
+
+toast.error('Plan not saved', { description: result.error });
+toast.success('Plan saved');
+```
+
+---
+
+## Checklist
+
+- [ ] Capture `previousState` before the optimistic `setState` call
+- [ ] On `result.ok === false`: call `setState(previousState)` to rollback
+- [ ] Call `console.error('[scope] action:', message)` for devtools visibility
+- [ ] Show `toast.error(title, { description: message })` for user visibility
+- [ ] Use `result.error` as the description when the server action provides it
+
+---
+
+## Applied In
+
+- `apps/frontend/src/app/plan/page.tsx` — `handleUpdatePlanData` (PR #443)

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -22,7 +22,8 @@
         "next": "^15.5.15",
         "react": "^19.0.0",
         "react-calendar": "^6.0.1",
-        "react-dom": "^19.2.5"
+        "react-dom": "^19.2.5",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -8421,6 +8422,16 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -36,7 +36,8 @@
     "next": "^15.5.15",
     "react": "^19.0.0",
     "react-calendar": "^6.0.1",
-    "react-dom": "^19.2.5"
+    "react-dom": "^19.2.5",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/apps/frontend/src/app/cash-flow/page.tsx
+++ b/apps/frontend/src/app/cash-flow/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 export const dynamic = 'force-dynamic';
 import React, { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
 import { useSettings } from '../settings/SettingsContext';
 import { CashFlowSankey } from '@/components/CashFlow/CashFlowSankey';
 import { PlanData } from '@/components/Plan/types';
@@ -72,6 +73,26 @@ export default function CashFlowPage() {
     const spouseAge = spouseBirthYear ? selectedYear - spouseBirthYear : null;
 
     if (loading) return <div className="min-h-screen bg-slate-950 p-8 text-slate-400">Loading cash flow data...</div>;
+
+    if (!plan || !plan.data) {
+        return (
+            <div className="min-h-screen bg-slate-950 flex items-center justify-center">
+                <div className="text-center max-w-md px-6">
+                    <div className="text-5xl mb-6">📊</div>
+                    <h2 className="text-2xl font-bold text-slate-100 mb-3">No financial plan yet</h2>
+                    <p className="text-slate-400 mb-8">
+                        Cash flow projections appear once you create your financial plan. Add your income, expenses, and accounts to see the full picture.
+                    </p>
+                    <Link
+                        href="/plan"
+                        className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-emerald-600 hover:bg-emerald-500 text-white font-semibold transition-colors"
+                    >
+                        Create your plan →
+                    </Link>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="flex h-screen bg-slate-950 text-slate-100 overflow-hidden flex-col">

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./globals.css";
 import { type Metadata } from "next";
 import { type ReactNode } from "react";
+import { Toaster } from "sonner";
 import { SettingsProvider } from "./settings/SettingsContext";
 import MainLayout from "@/components/Layout/MainLayout";
 import PageLoadMetrics from "@/components/Telemetry/PageLoadMetrics";
@@ -24,6 +25,7 @@ export default function RootLayout({
             {children}
           </MainLayout>
         </SettingsProvider>
+        <Toaster theme="dark" position="bottom-right" richColors />
       </body>
     </html>
   );

--- a/apps/frontend/src/app/plan/page.tsx
+++ b/apps/frontend/src/app/plan/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 export const dynamic = 'force-dynamic';
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { toast } from 'sonner';
 import { PlanChart } from '@/components/Plan/PlanChart';
 import { PlanEditor } from '@/components/Plan/PlanEditor';
 import { PlanDetailsPane } from '@/components/Plan/PlanDetailsPane';
@@ -42,15 +43,32 @@ export default function PlanPage() {
     const handleUpdatePlanData = async (newData: PlanData) => {
         if (!plan) return;
 
+        const previousPlan = plan;
         const updatedPlan = { ...plan, data: newData };
         setPlan(updatedPlan); // Optimistic Update
 
         if (plan.id) {
             const result = await updatePlan(plan.id, { data: newData });
-            if (result.ok) setPlan(result.plan);
+            if (result.ok) {
+                setPlan(result.plan);
+            } else {
+                // Rollback and surface the error
+                setPlan(previousPlan);
+                const message = result.error ?? 'Failed to save plan. Please try again.';
+                console.error('[plan] updatePlan failed:', message);
+                toast.error('Plan not saved', { description: message });
+            }
         } else {
             const result = await createPlan(newData);
-            if (result.ok) setPlan(result.plan);
+            if (result.ok) {
+                setPlan(result.plan);
+            } else {
+                // Rollback and surface the error
+                setPlan(previousPlan);
+                const message = result.error ?? 'Failed to create plan. Please try again.';
+                console.error('[plan] createPlan failed:', message);
+                toast.error('Plan not saved', { description: message });
+            }
         }
     };
 

--- a/apps/frontend/src/components/CashFlow/CashFlowSankey.tsx
+++ b/apps/frontend/src/components/CashFlow/CashFlowSankey.tsx
@@ -1,5 +1,6 @@
 'use client';
 import React, { useMemo } from 'react';
+import Link from 'next/link';
 import { ResponsiveSankey } from '@nivo/sankey';
 
 interface Props {
@@ -87,7 +88,7 @@ export const CashFlowSankey: React.FC<Props> = ({ data, currency }) => {
 
         safeWithdrawalDetails.forEach((item: any) => {
             const rawName = item.name || 'Withdrawal';
-            // const rawType = item.type || 'Inflow'; 
+            // const rawType = item.type || 'Inflow';
             // Map all withdrawals to "Investment Income" type so they get grouped on the right side of the left block
             const rawType = 'Investment Income';
 
@@ -197,7 +198,14 @@ export const CashFlowSankey: React.FC<Props> = ({ data, currency }) => {
     })();
 
     if (!data) return <div className="text-slate-500 text-center p-10">No data available for this year</div>;
-    if (nodes.length === 0) return <div className="text-slate-500 text-center p-10">Use the Plan Editor to add Income and Expenses</div>;
+    if (nodes.length === 0) return (
+        <div className="text-slate-500 text-center p-10">
+            <p className="mb-3">No income or expenses found for this year.</p>
+            <Link href="/plan" className="text-emerald-400 hover:text-emerald-300 underline underline-offset-2">
+                Open the Plan Editor to add Income and Expenses →
+            </Link>
+        </div>
+    );
 
     return (
         <div className="h-[600px] w-full bg-slate-900/50 rounded-xl border border-slate-800 p-4 transition-all duration-500">


### PR DESCRIPTION
## Summary

Working as **Fenster** (Frontend Dev)

This is a **P0 fix** delivering two high-visibility bug fixes for #440 and #441. P1 (income-stream wiring for dividends + bonds) is pending Keaton's architectural synthesis and is explicitly out of scope here.

---

## Changes

### 1.  — Surface server-action errors (Part of #440)

**Before:**  performed an optimistic update and silently discarded the result when  / `updatePlan` returned `{ ok: false }`. The UI showed the edit as saved; on refresh the data was gone.

**After:**
- Captures `previousPlan` before the optimistic write
- On `result.ok === false`: rolls back state to `previousPlan`, calls `console.error` (devtools visible), and fires a `toast.error('Plan not saved', { description: result.error })`
- Users now immediately see a red toast explaining what went wrong instead of a silent phantom save

**File:** `apps/frontend/src/app/plan/page.tsx` (lines 42–65)

### 2. `/cash-flow` — Empty-state CTA instead of blank page (Partial #441)


**After:** After the loading spinner resolves, if `plan` is null/missing, renders a proper empty-state:
- Clear heading: «No financial plan yet»
- Explanatory copy
- CTA button linking to `/plan` using Next.js `Link`

**File:** `apps/frontend/src/app/cash-flow/page.tsx`

### 3. `CashFlowSankey` — Empty-state link (Partial #441)

Updated the «Use the Plan Editor» fallback message (line 200) to include a clickable link to `/plan` rather than plain unactionable text.

**File:** `apps/frontend/src/components/CashFlow/CashFlowSankey.tsx`

### 4. Toast infrastructure

Installed **sonner** (v2, standard with Next.js/shadcn) and mounted `<Toaster theme="dark" richColors />` in the root layout. No existing toast library was present.

---

## What's NOT here (P1)

- Income-stream wiring: dividends + bonds into `/plan` simulation (awaiting Keaton's architectural call on whether to use the `optionsMap` pattern or PlanItem injection)
- `simulation.ts` untouched per spec

---

## Testing

- TypeScript: no new errors introduced (pre-existing failures in `src/test/setup.ts` and `e2e/` are unrelated to these changes)
- Lint: no new errors in changed files
- Manual: verify toast appears when server action fails, verify empty-state renders when DB has no plan

Part of #440, partial #441