### PR TITLE
fix(plan): surface real Supabase error from createPlan to browser devtools

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -1,3 +1,17 @@
+## 2026-05-13 — Regression diagnostic: "Plan not saved. Failed to create plan." (PR #443 follow-up)
+
+**Triggered by:** jocohe report — toast fires but save fails for any expense on `/plan`.
+
+**Trace summary:**
+
+- **Toast source:** `apps/frontend/src/app/plan/page.tsx:98` — `handleUpdatePlanData` falls into the `else` (create) branch because `plan.id` is `undefined` on a brand-new plan. `createPlan` returns `{ ok: false, error: '...' }`, triggering rollback + toast.
+- **createPlan:** `apps/frontend/src/app/plan/actions.ts:170-173` — the Supabase INSERT fails; the real error (`error.message`) was only logged **server-side** via `console.error`. The returned error was a sanitized generic string — **invisible to browser devtools**. This is the critical logging gap.
+- **household_id:** Resolved cleanly via `resolveHouseholdId()` → `household_members` lookup. A null here returns a distinct `'Not authenticated or no active household'` message; the user saw `'Failed to create plan'`, confirming `household_id` was resolving but the INSERT failed.
+- **data serialization:** `PlanData` passed as flat object (no `data` envelope). `normalizeCreatePayload` correctly takes the raw-PlanData path. No `undefined` values; valid jsonb shape.
+- **Root cause hypothesis (ranked):** 1) `plans` table missing / migration not applied on target DB; 2) RLS policy blocking INSERT for the user's `household_id`; 3) NOT NULL constraint on an unset column.
+- **Logging gap patched:** One-line fix in `createPlan` to propagate `error.message` to the returned error payload, so the existing `console.error` on `page.tsx:97` surfaces the real Supabase error in the browser console. Shipped as draft PR on branch `squad/440-followup-error-logging`.
+- **Open for Hockney:** Confirm whether `plans` table exists + migration status; check RLS policy on `plans` INSERT; check for NOT NULL columns without defaults.
+
 ## 2026-05-13 — PR #443 squad/440-error-surfacing
 
 Shipped P0 frontend fixes: error surfacing in `/plan` handleUpdatePlanData + empty-state CTA in `/cash-flow`.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -114,6 +114,25 @@ end $$;
 
 **Worker status:** Round 5 yield + Round 5 LSE/100 fixes now shipping correctly in production DB. UI surfaces (frontend display-layer fixes) are catching up (Round 7 dividend display).
 
+## 2026-05-13 — P0 regression: plan creation still broken post-#442
+
+**Issue:** Plan creation still failing with "Plan not saved. Failed to create plan. Please try again." despite PR #442 being merged and Vercel deploying `bdf568f`.
+
+**Root cause:** Migration `20260513000811_fix_plans_audit_column_defaults.sql` was merged into source tree but was **never applied to the prod Supabase project**. `list_migrations` confirmed latest prod migration was `20260512115546`. `created_at` and `updated_at` on `plans` still had `column_default: null` with `is_nullable: NO` — every `createPlan()` INSERT threw a NOT NULL violation.
+
+**Evidence:**
+- Migration absent from `supabase_migrations.schema_migrations`
+- `information_schema.columns`: `plans.created_at` → `column_default: null`, `plans.updated_at` → `column_default: null`
+- RLS policies: correct (`plans_insert` exists with `is_household_writer` check) — NOT the cause
+- Action code (`createPlan`): correct, `household_id` resolved from session — NOT the cause
+- Smoke-test INSERT after fix: succeeded (`id=10`, timestamps auto-populated), rolled back
+
+**Fix applied:** `supabase-apply_migration` (MCP) directly executed the migration SQL against prod. Verified columns now have `DEFAULT now()` and trigger is `BEFORE INSERT OR UPDATE`.
+
+**Lesson:** Merging a migration PR ≠ deploying the migration. Must run `list_migrations` after every migration PR merges to confirm it landed. Added post-merge checklist to `.squad/skills/migration-idempotency-gotchas/SKILL.md`.
+
+**No PR needed** — fix applied directly via MCP to prod Supabase.
+
 ## 2026-05-13 — Plan persistence + cashflow sprint (Round 9, Issues #440 + #441)
 
 Backend recon (sonnet-4.6): root-caused NOT NULL without defaults on plans.created_at / updated_at; confirmed migration 20260430130000 silent-skip of DEFAULT due to ADD COLUMN IF NOT EXISTS footgun. PR #442: `ALTER COLUMN SET DEFAULT now()` ×2 + trigger extended to BEFORE INSERT OR UPDATE. Decision: migration idempotency footgun pattern documented in `.squad/skills/migration-idempotency-gotchas/SKILL.md`. Verified Vercel green post-merge, no worker redeploy needed.

--- a/.squad/skills/migration-idempotency-gotchas/SKILL.md
+++ b/.squad/skills/migration-idempotency-gotchas/SKILL.md
@@ -88,9 +88,53 @@ Fix: `20260513000811_fix_plans_audit_column_defaults.sql` — `ALTER COLUMN ... 
 
 ---
 
+## Critical: migration file in source ≠ migration applied in prod
+
+**Lesson (from GH #440 regression, 2026-05-13):**
+Merging a PR that includes a new `.sql` file under `supabase/migrations/` moves the file into the source tree but does **NOT** run it against the production Supabase project. Supabase migrations are deployed via a separate step: the Supabase CLI (`supabase db push`), a GitHub Action, the MCP `apply_migration` tool, or the dashboard — not by Vercel or the Netlify/Vercel build step.
+
+### How to verify
+
+Always check `supabase_migrations.schema_migrations` (or via the MCP `list_migrations` tool) against the deployed environment **after every migration PR merges**:
+
+```sql
+-- In prod Supabase: is my migration there?
+SELECT * FROM supabase_migrations.schema_migrations
+WHERE version = '20260513000811';
+-- Zero rows → migration file merged into main but NEVER executed in prod.
+```
+
+Via MCP:
+```
+supabase-list_migrations  →  confirm your version appears in the list
+```
+
+### Prevention
+
+Add a post-merge checklist item or CI step that compares `supabase/migrations/*.sql` filenames against `supabase_migrations.schema_migrations` and alerts on drift.
+
+---
+
+## Real incident: GH #440 regression, 2026-05-13
+
+PR #442 merged `20260513000811_fix_plans_audit_column_defaults.sql` into `main`. Vercel deployed `bdf568f`. But the Supabase migration was never applied — `list_migrations` showed latest as `20260512115546`. Prod DB still had `created_at`/`updated_at` with no DEFAULT. Every `createPlan()` INSERT continued to throw NOT NULL violation. `/plan` showed "Plan not saved. Failed to create plan. Please try again." unchanged.
+
+Fix: applied migration directly via MCP `supabase-apply_migration`. Smoke-test INSERT succeeded. Symptom resolved.
+
+**Time between merge and resolution: ~0 if we'd run `list_migrations` post-merge.**
+
+---
+
 ## Checklist before merging a migration
 
 - [ ] Any `ADD COLUMN IF NOT EXISTS` with `DEFAULT`? If the column might pre-exist, use `ALTER COLUMN ... SET DEFAULT` separately.
 - [ ] Run `pg_attrdef` check after applying locally to confirm defaults landed.
 - [ ] Use `DROP TRIGGER IF EXISTS` before `CREATE TRIGGER`.
 - [ ] Wrap `supabase_realtime` publication changes in a DO block.
+
+## Checklist after merging a migration PR
+
+- [ ] Run `supabase-list_migrations` (or `supabase db push` output) and confirm the new version appears.
+- [ ] If deploying via GitHub Action: verify the Action succeeded — check the workflow run, not just the PR merge.
+- [ ] If manual deploy needed: `supabase db push --linked` or apply via MCP immediately after merge.
+- [ ] Do a smoke-test INSERT/SELECT on the affected table before closing the issue.

--- a/apps/frontend/src/app/plan/actions.ts
+++ b/apps/frontend/src/app/plan/actions.ts
@@ -169,7 +169,7 @@ export async function createPlan(
 
   if (error || !data) {
     console.error('[createPlan] insert error:', error?.message ?? 'No row returned');
-    return { ok: false, error: 'Failed to create plan. Please try again.' };
+    return { ok: false, error: error?.message ?? 'Failed to create plan. Please try again.' };
   }
 
   return { ok: true, plan: data as unknown as Plan };


### PR DESCRIPTION
## Summary

Regression diagnostic follow-up to PR #443.

**Problem:** `createPlan` catches the Supabase error, logs it server-side only (`console.error`), then returns a sanitized generic string. The real DB error (RLS violation / missing table / NOT NULL) is invisible to the browser.

**Change:** One-liner — propagate `error.message` in the returned `{ ok: false, error }` payload so the existing `console.error('[plan] createPlan failed:', message)` in `page.tsx` actually prints the real Supabase error to browser devtools on the next failure.

```diff
- return { ok: false, error: 'Failed to create plan. Please try again.' };
+ return { ok: false, error: error?.message ?? 'Failed to create plan. Please try again.' };
```

## Context

This is a **diagnostics patch only** — no UX change. The toast the user sees will change from the generic fallback to the actual Supabase error message, which may be slightly more technical, but that's acceptable for an authenticated user hitting a save failure. It also helps us see the real error without needing server log access.

**Root cause is almost certainly DB-side** (Hockney is investigating): missing `plans` table migration, RLS policy blocking INSERT, or NOT NULL constraint without a default. This patch ensures the next save attempt reveals exactly which one.

Working as Fenster (Frontend Dev)
⚠️ Draft — waiting for jocohe synthesis with Hockney's DB findings before merging.