### PR TITLE
fix: unblock IBKR Flex sync (orphan FK violation) + update Accounts last_synced from Flex path

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -1,3 +1,50 @@
+## 2026-05-19 — Flex Query Worker Diagnostic
+
+**Task:** Read-only diagnostic of IBKR Flex Query worker for Jony's 5 questions.
+
+**Learnings:**
+
+- **Two completely separate sync paths, two separate "last synced" fields.** The Accounts page reads `trading_account_config.last_synced` (written only by live IB Gateway path). The Options page reads `options_flex_sync_state.last_sync_at` (written by Flex XML path). These are decoupled — one can be stale while the other is fresh. The Accounts page will ALWAYS show "Never" while IB Gateway is offline, regardless of Flex health.
+
+- **Orphaned E2E test rows in production are silent P0s.** An E2E test account config (`E2E_TRADING_*`) was left in `trading_account_config` with a `household_id` that no longer exists in `households`. `_load_accounts()` has no join guard against orphaned households. This caused 7 consecutive silent nightly failures (May 13–19) before being discovered. Always clean up E2E test data in teardown, and add a join guard in `_load_accounts()`.
+
+- **APScheduler logs errors but raises no alerts.** 7 nights of P0 failures, zero team notification. The nightly-backup workflow has a GitHub-issue alert pattern we should copy for the Flex sync. Log monitoring ≠ alerting.
+
+- **Flex API fetch succeeds even when DB write fails.** IBKR Flex token and query IDs are valid and the live API responds correctly each night. The failure is entirely in the local DB write step. So the Flex integration with IBKR itself is healthy — only our DB has the orphaned row problem.
+
+- **`IBKR_FLEX_TOKEN` absent from `docker-compose.backend.yml` env block.** It's passed via `.env` auto-read. New developers missing this will get synthetic data silently. Should be documented in `.env.example` and optionally validated at worker startup.
+
+- **Container started May 13 per `docker ps` output.** The `docker ps` "X days ago" field is a reliable way to date the current container's birth. Cross-reference with `git log` to identify what code the container is running.
+
+**Report:** `.squad/decisions/inbox/hockney-flex-query-diagnosis-2026-05-19.md`
+**Bugs found:** 2 bugs (P0 FK violation, P1 misleading "Never"), 2 smells (no alerting, missing env doc)
+
+---
+
+## 2026-05-19 — Round 1 Implementation: Flex sync fixes (PR squad/flex-sync-fixes)
+
+**Task:** Implement Bug #1 + Bug #2 from the Flex Query diagnostic.
+
+**Bug #1 (P0) — Orphan E2E account crashes nightly Flex sync:**
+- **Migration** `supabase/migrations/20260518211744_cleanup_orphaned_e2e_trading_account_config.sql`: idempotent soft-delete of any `trading_account_config` row whose `household_id` is absent from `households`. Predicate: `WHERE household_id NOT IN (SELECT id FROM households) AND deleted_at IS NULL`.
+- **Guard in `_load_accounts()`**: rewrote the query to LEFT JOIN `households` and include `(h.id is not null) as household_exists`. Rows with `household_exists=False` are excluded and logged at WARNING level with account_id + household_id for visibility.
+
+**Bug #2 (P1) — Accounts page shows "Never" even when Flex is healthy:**
+- Added `_update_config_last_synced(session, config_id)` helper that stamps `trading_account_config.last_synced` and `last_synced_at` to `now()`.
+- Called in `run_flex_options_sync()` after each per-account ingest pipeline completes successfully. Skipped on failure paths (exception propagates naturally before the call).
+
+**Tests added (4 new in `tests/worker/test_options_sync.py`):**
+- `test_load_accounts_filters_orphaned_household` — orphan row excluded + WARNING logged
+- `test_load_accounts_returns_valid_config` — valid config returned with correct fields
+- `test_successful_flex_sync_updates_last_synced` — last_synced stamped after synthetic sync
+- `test_failed_flex_sync_does_not_update_last_synced_for_failing_account` — last_synced skipped for the failing account, written for the successful one
+
+**Also updated:** `household_exists: True` added to FakeSession account rows in `test_backfill_options.py`, `test_options_grouping.py`, `test_options_margin_sync.py` to match the updated query.
+
+**Results:** 632/632 backend tests pass. Lint clean.
+
+---
+
 ## 2026-05-12 — Round 8 Phase 2.5: Worker Redeploy Skill + Rebuild Script
 
 **Task:** Codify the Round 8 root cause as an enforced protocol to prevent recurrence.

--- a/apps/backend/app/worker/handlers/options_sync.py
+++ b/apps/backend/app/worker/handlers/options_sync.py
@@ -213,6 +213,8 @@ def run_flex_options_sync(
             bond_count = _sync_bond_positions(
                 session, account.household_id, account.config_id, parsed_account_id, scoped
             )
+            # Write last_synced only after the full per-account pipeline succeeds.
+            _update_config_last_synced(session, account.config_id)
             total_trades += counts["trade_count"]
             total_cash += counts["cash_event_count"]
             total_positions += counts["position_count"]
@@ -773,31 +775,54 @@ def _seed_security_reference_from_positions(
 
 
 def _load_accounts(session: Session, *, account_id: str | None) -> list[OptionsAccount]:
+    """Load trading account configs that are eligible for Flex options sync.
+
+    Configs whose household_id is not present in the households table (or whose
+    household has been soft-deleted) are excluded.  Each excluded row is logged
+    at WARNING level so future orphans are visible without crashing the sync.
+    """
     params: dict[str, Any] = {}
-    filters = ["coalesce(compute_options_income, true) = true", "deleted_at is null"]
+    filters = ["coalesce(c.compute_options_income, true) = true", "c.deleted_at is null"]
     if account_id:
-        filters.append("account_id = :account_id")
+        filters.append("c.account_id = :account_id")
         params["account_id"] = account_id
     rows = session.execute(
         text(
             f"""
-            select id, household_id::text as household_id, account_id
-              from public.trading_account_config
+            select c.id,
+                   c.household_id::text as household_id,
+                   c.account_id,
+                   (h.id is not null) as household_exists
+              from public.trading_account_config c
+              left join public.households h
+                     on h.id = c.household_id
+                    and h.deleted_at is null
              where {" and ".join(filters)}
-             order by id
+             order by c.id
             """
         ),
         params,
     ).mappings()
-    return [
-        OptionsAccount(
-            household_id=str(row["household_id"]),
-            account_id=str(row["account_id"]) if row["account_id"] else None,
-            config_id=int(row["id"]),
+    accounts: list[OptionsAccount] = []
+    for row in rows:
+        if not row["household_id"]:
+            continue
+        if not row["household_exists"]:
+            logger.warning(
+                "_load_accounts: skipping orphaned config — account_id=%r household_id=%r "
+                "(household missing or soft-deleted); soft-delete this config to silence",
+                row["account_id"],
+                row["household_id"],
+            )
+            continue
+        accounts.append(
+            OptionsAccount(
+                household_id=str(row["household_id"]),
+                account_id=str(row["account_id"]) if row["account_id"] else None,
+                config_id=int(row["id"]),
+            )
         )
-        for row in rows
-        if row["household_id"]
-    ]
+    return accounts
 
 
 def _select_flex_source(
@@ -1292,6 +1317,28 @@ def _upsert_sync_state(
             "row_counts": _json(counts),
             "metadata": _json({"accountInformation": [row.raw_payload for row in parsed.account_information]}),
         },
+    )
+
+
+def _update_config_last_synced(session: Session, config_id: int | None) -> None:
+    """Stamp trading_account_config.last_synced / last_synced_at to UTC now.
+
+    Called only after a successful per-account Flex ingest so the Accounts page
+    reflects the real last-sync time.  No-ops when config_id is None (account
+    matched without a config row, e.g. wildcard mode).
+    """
+    if config_id is None:
+        return
+    session.execute(
+        text(
+            """
+            update public.trading_account_config
+               set last_synced    = now(),
+                   last_synced_at = now()
+             where id = :config_id
+            """
+        ),
+        {"config_id": config_id},
     )
 
 

--- a/apps/backend/tests/test_backfill_options.py
+++ b/apps/backend/tests/test_backfill_options.py
@@ -88,6 +88,7 @@ class InMemoryOptionsSession:
                         "id": 1,
                         "household_id": HOUSEHOLD_ID,
                         "account_id": ACCOUNT_ID,
+                        "household_exists": True,
                     }
                 ]
             )

--- a/apps/backend/tests/worker/test_options_grouping.py
+++ b/apps/backend/tests/worker/test_options_grouping.py
@@ -42,6 +42,7 @@ class FakeSession:
                         "household_id": "10000000-0000-0000-0000-000000000001",
                         "account_id": "U1234567",
                         "name": "IBKR Synthetic",
+                        "household_exists": True,
                     }
                 ]
             )
@@ -145,7 +146,14 @@ class FakeSessionBackfill:
         params = params or {}
         if "from public.trading_account_config" in sql:
             return FakeMappings(
-                [{"id": 1, "household_id": "10000000-0000-0000-0000-000000000001", "account_id": "U2515365"}]
+                [
+                    {
+                        "id": 1,
+                        "household_id": "10000000-0000-0000-0000-000000000001",
+                        "account_id": "U2515365",
+                        "household_exists": True,
+                    }
+                ]
             )
         if "from public.options_trades t" in sql:
             return FakeMappings(_backfill_trade_rows())
@@ -229,7 +237,9 @@ def test_backfill_expired_trade_sets_group_status_to_expired() -> None:
         def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
             sql = str(statement)
             if "from public.trading_account_config" in sql:
-                return FakeMappings([{"id": 1, "household_id": household_id, "account_id": "U2515365"}])
+                return FakeMappings(
+                    [{"id": 1, "household_id": household_id, "account_id": "U2515365", "household_exists": True}]
+                )
             if "from public.options_trades t" in sql:
                 return FakeMappings(
                     [

--- a/apps/backend/tests/worker/test_options_margin_sync.py
+++ b/apps/backend/tests/worker/test_options_margin_sync.py
@@ -56,6 +56,7 @@ class FakeSession:
                         "id": 1,
                         "household_id": "10000000-0000-0000-0000-000000000001",
                         "account_id": "U123",
+                        "household_exists": True,
                     }
                 ]
             )

--- a/apps/backend/tests/worker/test_options_sync.py
+++ b/apps/backend/tests/worker/test_options_sync.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
 from datetime import date
 from decimal import Decimal
 from typing import Any
+
+import pytest
 
 from app.services.options.flex_parser import OptionLegKey
 from app.worker.handlers.options_sync import _load_accounts, _source_conid_for_insert, run_flex_options_sync
@@ -54,6 +57,7 @@ class FakeSession:
         self.cash_events: list[Mapping[str, Any]] = []
         self.positions: list[Mapping[str, Any]] = []
         self.sync_states = 0
+        self.last_synced_updates: list[int] = []
 
     def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeScalar | FakeMappings:
         sql = str(statement)
@@ -66,9 +70,14 @@ class FakeSession:
                         "id": 1,
                         "household_id": "10000000-0000-0000-0000-000000000001",
                         "account_id": "U1234567",
+                        "household_exists": True,
                     }
                 ]
             )
+        if "update public.trading_account_config" in sql:
+            if "last_synced" in sql:
+                self.last_synced_updates.append(params.get("config_id"))
+            return FakeMappings([])
         if "insert into public.options_legs" in sql:
             key = (
                 params["account_id"],
@@ -203,3 +212,127 @@ def test_select_flex_source_synthetic_when_no_token_and_unset(monkeypatch) -> No
     monkeypatch.setattr(mod, "_synthetic_files", lambda: sentinel)
     paths = mod._select_flex_source(from_date=None, to_date=None, synthetic=False)
     assert paths is sentinel
+
+
+# ---------------------------------------------------------------------------
+# Bug #1B — _load_accounts orphan-filter tests
+# ---------------------------------------------------------------------------
+
+
+class _OrphanMixedSession:
+    """Returns one valid config row and one orphaned config row (no matching household)."""
+
+    def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+        sql = str(statement)
+        if "from public.trading_account_config" in sql:
+            return FakeMappings(
+                [
+                    {
+                        "id": 1,
+                        "household_id": "aaaabbbb-0000-0000-0000-000000000001",
+                        "account_id": "U_VALID",
+                        "household_exists": True,
+                    },
+                    {
+                        "id": 2,
+                        "household_id": "649510c1-9695-4ff6-928c-b10f78b30942",
+                        "account_id": "E2E_TRADING_1778493037442-7fkxg",
+                        "household_exists": False,
+                    },
+                ]
+            )
+        return FakeMappings([])
+
+
+def test_load_accounts_filters_orphaned_household(caplog: pytest.LogCaptureFixture) -> None:
+    """Configs whose household is missing from households are excluded with a WARNING."""
+    with caplog.at_level(logging.WARNING, logger="app.worker.handlers.options_sync"):
+        accounts = _load_accounts(_OrphanMixedSession(), account_id=None)  # type: ignore[arg-type]
+
+    account_ids = [a.account_id for a in accounts]
+    assert "U_VALID" in account_ids
+    assert "E2E_TRADING_1778493037442-7fkxg" not in account_ids
+
+    orphan_warnings = [r for r in caplog.records if "E2E_TRADING_1778493037442-7fkxg" in r.message]
+    assert orphan_warnings, "expected a WARNING log naming the orphaned account_id"
+    assert all(r.levelno == logging.WARNING for r in orphan_warnings)
+
+
+def test_load_accounts_returns_valid_config() -> None:
+    """A config whose household exists is included in the returned list."""
+    accounts = _load_accounts(_OrphanMixedSession(), account_id=None)  # type: ignore[arg-type]
+
+    assert len(accounts) == 1
+    assert accounts[0].account_id == "U_VALID"
+    assert accounts[0].config_id == 1
+    assert accounts[0].household_id == "aaaabbbb-0000-0000-0000-000000000001"
+
+
+# ---------------------------------------------------------------------------
+# Bug #2 — last_synced write-through tests
+# ---------------------------------------------------------------------------
+
+
+def test_successful_flex_sync_updates_last_synced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After a successful per-account Flex ingest, trading_account_config.last_synced is stamped."""
+    monkeypatch.setenv("OPTIONS_FLEX_SOURCE", "synthetic")
+    session = FakeSession()
+    run_flex_options_sync(session)  # type: ignore[arg-type]
+    assert session.last_synced_updates, "expected last_synced to be updated for at least one account"
+    assert 1 in session.last_synced_updates, "config_id=1 should have been stamped after successful sync"
+
+
+def test_failed_flex_sync_does_not_update_last_synced_for_failing_account(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_update_config_last_synced is skipped for an account whose ingest raises."""
+    from app.worker.handlers import options_sync as mod
+
+    last_synced_updates: list[int] = []
+
+    class _TwoAccountSession:
+        """Returns two valid configs; records last_synced update calls by config_id."""
+
+        def execute(self, statement: object, params: dict[str, Any] | None = None) -> FakeMappings:
+            sql = str(statement)
+            params = params or {}
+            if "from public.trading_account_config" in sql:
+                return FakeMappings(
+                    [
+                        {
+                            "id": 10,
+                            "household_id": "aaaabbbb-0000-0000-0000-000000000001",
+                            "account_id": "A_GOOD",
+                            "household_exists": True,
+                        },
+                        {
+                            "id": 20,
+                            "household_id": "aaaabbbb-0000-0000-0000-000000000002",
+                            "account_id": "B_FAIL",
+                            "household_exists": True,
+                        },
+                    ]
+                )
+            if "update public.trading_account_config" in sql and "last_synced" in sql:
+                last_synced_updates.append(params.get("config_id"))
+            return FakeMappings([])
+
+    original_ingest = mod._ingest_account
+
+    def patched_ingest(
+        session: Any, household_id: str, account_id: str, parsed: Any, from_date: Any, to_date: Any
+    ) -> Any:  # noqa: ANN401
+        if account_id == "B_FAIL":
+            raise RuntimeError("simulated ingest failure for B_FAIL")
+        return original_ingest(session, household_id, account_id, parsed, from_date, to_date)
+
+    monkeypatch.setattr(mod, "_ingest_account", patched_ingest)
+    monkeypatch.setattr(mod, "_sync_stock_positions", lambda *a, **kw: 0)
+    monkeypatch.setattr(mod, "_sync_bond_positions", lambda *a, **kw: 0)
+
+    session = _TwoAccountSession()
+    with pytest.raises(RuntimeError, match="simulated ingest failure"):
+        run_flex_options_sync(session, pre_fetched_paths=[])  # type: ignore[arg-type]
+
+    assert 10 in last_synced_updates, "config 10 (A_GOOD) should have been stamped before the failure"
+    assert 20 not in last_synced_updates, "config 20 (B_FAIL) must NOT be stamped when ingest raises"

--- a/supabase/migrations/20260518211744_cleanup_orphaned_e2e_trading_account_config.sql
+++ b/supabase/migrations/20260518211744_cleanup_orphaned_e2e_trading_account_config.sql
@@ -1,0 +1,13 @@
+-- Soft-delete any trading_account_config rows whose household_id does not
+-- exist in the households table.  The canonical case is the E2E test account
+-- E2E_TRADING_1778493037442-7fkxg (household 649510c1-...) whose household was
+-- hard-deleted but whose config row was never cleaned up, causing a nightly
+-- FK violation on options_flex_sync_state_household_id_fkey since 2026-05-13.
+--
+-- Idempotent: the WHERE clause targets only rows that are not yet soft-deleted,
+-- so re-running this migration is safe.
+
+update public.trading_account_config
+set deleted_at = now()
+where household_id not in (select id from public.households)
+  and deleted_at is null;


### PR DESCRIPTION
## Problem
- **P0:** Every nightly Flex options sync since May 13 has crashed with `psycopg2.errors.ForeignKeyViolation` on `options_flex_sync_state_household_id_fkey`. Root cause: orphaned E2E test account `E2E_TRADING_1778493037442-7fkxg` in `trading_account_config` with `household_id=649510c1-9695-4ff6-928c-b10f78b30942` (household deleted but config not cleaned up). `_load_accounts()` picks it up → session rollback → no data written for any account. 9 days of stale options/bond data.
- **P1:** `/trading/accounts` page shows "Last Synced: Never" because `trading_account_config.last_synced` is only written by the live IB Gateway path. The Flex sync writes a different column. Misleading UX — even when Flex is healthy, the Accounts page is wrong.

## Fix
1. **Migration** (`supabase/migrations/20260518211744_cleanup_orphaned_e2e_trading_account_config.sql`): idempotent soft-delete of any `trading_account_config` row whose `household_id` is not present in `households`.
2. **Guard** in `_load_accounts()`: filter out configs whose `household_id` is missing from `households`. WARNING-log each filtered orphan for visibility.
3. **`last_synced` write-through**: on successful per-account Flex ingest, update `trading_account_config.last_synced` and `last_synced_at` to UTC now. Failure paths do not write.

## Tests
- `_load_accounts` filters orphans + warning logged
- `_load_accounts` returns valid configs
- Successful Flex sync updates `last_synced` per account
- Failed Flex sync does NOT update `last_synced` (for the failing account)

## Verification (post-merge, manual)
- Tonight's 22:30 IDT (19:30 UTC) Flex sync should succeed without FK violation
- `/trading/accounts` "Last Synced" should populate after first successful run
- Bond/option positions should refresh

## Out of scope
- IB Gateway container restart (separate Kujan task, not in this PR)
- Sentry alerting on nightly sync failures (Smell #3, follow-up PR)
- Documenting `IBKR_FLEX_TOKEN` in `.env.example` (Smell #4, follow-up PR)

Working as Hockney (Backend Dev)
Closes / addresses Flex sync investigation diagnostic 2026-05-19

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>