### PR TITLE
feat(refresh): frontend - wire Refresh button to new backend endpoint

### DIFF
--- a/apps/frontend/src/app/trading/actions.ts
+++ b/apps/frontend/src/app/trading/actions.ts
@@ -826,18 +826,85 @@ export async function getTickerSymbols(): Promise<string[]> {
   return tickers;
 }
 
+// ── Account refresh types ─────────────────────────────────────────────────────
+
+/** Discriminated union returned by `triggerIBKRSync`. */
+export type AccountRefreshResult =
+  | { ok: true; status: 'queued'; last_synced_at: string | null; next_eligible_at: null }
+  | { ok: true; status: 'throttled'; last_synced_at: string | null; next_eligible_at: string }
+  | { ok: false; status: 'error'; error: string };
+
 /**
- * Triggers an IBKR Flex re-sync for the specified account.
- * Returns ok:true if the sync was accepted; errors degrade gracefully.
+ * Triggers a manual IBKR Flex refresh for the specified account config.
+ *
+ * Calls `POST /api/trading/accounts/{configId}/refresh` on the FastAPI
+ * backend and returns a discriminated union so callers can branch on the
+ * `status` field ("queued" | "throttled" | "error").
+ *
+ * HTTP 200 is used for both queued and throttled responses per the backend
+ * contract (Section B of the refresh-button design doc).
  */
-export async function triggerIBKRSync(accountId: number): Promise<{ ok: boolean; error?: string }> {
+export async function triggerIBKRSync(configId: number): Promise<AccountRefreshResult> {
   try {
-    const res = await fetch(`/api/accounts/${accountId}/sync`, { method: 'POST' });
-    if (!res.ok) return { ok: false, error: `Sync request failed (${res.status})` };
-    return { ok: true };
+    const supabase = await createClient();
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+
+    if (!session?.access_token) {
+      return { ok: false, status: 'error', error: 'Not authenticated' };
+    }
+
+    const backendUrl = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8000';
+    const res = await fetch(`${backendUrl}/api/trading/accounts/${configId}/refresh`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session.access_token}`,
+      },
+    });
+
+    if (res.status === 403) {
+      return { ok: false, status: 'error', error: 'You do not have permission to refresh this account.' };
+    }
+    if (res.status === 404) {
+      return { ok: false, status: 'error', error: 'Account not found.' };
+    }
+    if (!res.ok) {
+      return { ok: false, status: 'error', error: `Refresh request failed (${res.status})` };
+    }
+
+    const json = await res.json() as unknown;
+
+    if (
+      typeof json === 'object' &&
+      json !== null &&
+      'status' in json
+    ) {
+      const body = json as Record<string, unknown>;
+
+      if (body.status === 'queued') {
+        return {
+          ok: true,
+          status: 'queued',
+          last_synced_at: typeof body.last_synced_at === 'string' ? body.last_synced_at : null,
+          next_eligible_at: null,
+        };
+      }
+
+      if (body.status === 'throttled' && typeof body.next_eligible_at === 'string') {
+        return {
+          ok: true,
+          status: 'throttled',
+          last_synced_at: typeof body.last_synced_at === 'string' ? body.last_synced_at : null,
+          next_eligible_at: body.next_eligible_at,
+        };
+      }
+    }
+
+    return { ok: false, status: 'error', error: 'Unexpected response from refresh endpoint' };
   } catch (err) {
     console.error('[triggerIBKRSync] fetch error:', err);
-    return { ok: false, error: 'Unable to reach sync endpoint' };
+    return { ok: false, status: 'error', error: 'Unable to reach refresh endpoint' };
   }
 }
 

--- a/apps/frontend/src/components/trading/accounts/AccountHeader.tsx
+++ b/apps/frontend/src/components/trading/accounts/AccountHeader.tsx
@@ -92,6 +92,10 @@ export default function AccountHeader({
 
   // Refs so polling callbacks always read the latest values without stale closures
   const lastSyncedRef = useRef<string | null>(config.last_synced ?? null);
+  // INTENTIONAL: no dependency array — refresh every render so the polling
+  // callback (in a setInterval closure) sees the latest config.last_synced
+  // after router.refresh(). Do NOT add [] or [config.last_synced] —
+  // it will break the completion-detection path.
   useEffect(() => {
     lastSyncedRef.current = config.last_synced ?? null;
   });

--- a/apps/frontend/src/components/trading/accounts/AccountHeader.tsx
+++ b/apps/frontend/src/components/trading/accounts/AccountHeader.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import React, { useState } from "react";
-import type { TradingAccountConfig } from "@/app/trading/actions";
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { TradingAccountConfig, AccountRefreshResult } from "@/app/trading/actions";
 import { triggerIBKRSync } from "@/app/trading/actions";
 import CSVImportButton from "@/components/trading/accounts/CSVImportButton";
 
@@ -11,6 +13,22 @@ export interface AccountHeaderProps {
   onRefreshComplete?: () => void;
   onImportSuccess?: (imported: number) => void;
 }
+
+// ── State machine ─────────────────────────────────────────────────────────────
+
+type RefreshState =
+  | { status: "IDLE" }
+  | { status: "SUBMITTING" }
+  | { status: "QUEUED"; preSyncTimestamp: string | null }
+  | { status: "THROTTLED"; nextEligibleAt: string; minutesRemaining: number }
+  | { status: "COMPLETED" }
+  | { status: "ERROR"; message: string }
+  | { status: "TIMEOUT" };
+
+const POLL_INTERVAL_MS = 30_000;
+const MAX_POLL_ITERATIONS = 20; // 30s × 20 = 10 min
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
 
 const TYPE_LABELS: Record<string, { label: string; badgeClass: string }> = {
   ibkr: { label: "Flex", badgeClass: "bg-blue-900/40 text-blue-300 border-blue-700/50" },
@@ -37,14 +55,29 @@ function isIBKRAccount(accountType: string): boolean {
   return accountType.toLowerCase() === "ibkr";
 }
 
+/** Minutes until `isoTimestamp` from now, minimum 0. */
+function minutesUntil(isoTimestamp: string): number {
+  const diff = new Date(isoTimestamp).getTime() - Date.now();
+  return Math.max(0, Math.ceil(diff / 60_000));
+}
+
+/** Minutes since `isoTimestamp` from now, minimum 0. */
+function minutesSince(isoTimestamp: string | null): number {
+  if (!isoTimestamp) return 0;
+  const diff = Date.now() - new Date(isoTimestamp).getTime();
+  return Math.max(0, Math.floor(diff / 60_000));
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
 export default function AccountHeader({
   config,
   onAddPosition,
   onRefreshComplete,
   onImportSuccess,
 }: AccountHeaderProps) {
-  const [syncing, setSyncing] = useState(false);
-  const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const router = useRouter();
+  const [refreshState, setRefreshState] = useState<RefreshState>({ status: "IDLE" });
 
   const typeKey = config.account_type ?? "ibkr";
   const typeInfo = TYPE_LABELS[typeKey] ?? {
@@ -57,18 +90,127 @@ export default function AccountHeader({
   const lastDate = config.last_synced;
   const dateLabel = isIBKR ? "Last synced" : "Last updated";
 
-  const handleRefresh = async () => {
-    setSyncing(true);
-    setSyncMessage(null);
-    const result = await triggerIBKRSync(config.id);
-    setSyncing(false);
-    if (result.ok) {
-      setSyncMessage("Sync triggered — data will refresh shortly.");
-      onRefreshComplete?.();
-    } else {
-      setSyncMessage(result.error ?? "Sync failed");
+  // Refs so polling callbacks always read the latest values without stale closures
+  const lastSyncedRef = useRef<string | null>(config.last_synced ?? null);
+  useEffect(() => {
+    lastSyncedRef.current = config.last_synced ?? null;
+  });
+
+  const preSyncTimestampRef = useRef<string | null>(null);
+
+  const onRefreshCompleteRef = useRef(onRefreshComplete);
+  useEffect(() => {
+    onRefreshCompleteRef.current = onRefreshComplete;
+  }, [onRefreshComplete]);
+
+  // ── Polling interval while QUEUED ────────────────────────────────────────────
+  useEffect(() => {
+    if (refreshState.status !== "QUEUED") return;
+
+    let iterations = 0;
+
+    const interval = setInterval(() => {
+      // Detect completion: last_synced changed from pre-request snapshot
+      if (lastSyncedRef.current !== preSyncTimestampRef.current) {
+        clearInterval(interval);
+        setRefreshState({ status: "COMPLETED" });
+        toast.success("Data refreshed!");
+        onRefreshCompleteRef.current?.();
+        return;
+      }
+
+      iterations += 1;
+      if (iterations >= MAX_POLL_ITERATIONS) {
+        clearInterval(interval);
+        setRefreshState({ status: "TIMEOUT" });
+        toast.error("Refresh may have failed. Check back later.");
+        return;
+      }
+
+      router.refresh();
+    }, POLL_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [refreshState.status, router]);
+
+  // ── Throttle countdown ───────────────────────────────────────────────────────
+  const throttledNextEligibleAt =
+    refreshState.status === "THROTTLED" ? refreshState.nextEligibleAt : null;
+
+  useEffect(() => {
+    if (!throttledNextEligibleAt) return;
+
+    const interval = setInterval(() => {
+      const remaining = minutesUntil(throttledNextEligibleAt);
+
+      if (remaining <= 0) {
+        clearInterval(interval);
+        setRefreshState({ status: "IDLE" });
+        return;
+      }
+
+      setRefreshState((prev) => {
+        if (prev.status !== "THROTTLED") return prev;
+        return { ...prev, minutesRemaining: remaining };
+      });
+    }, 60_000);
+
+    return () => clearInterval(interval);
+  }, [throttledNextEligibleAt]);
+
+  // ── Click handler ────────────────────────────────────────────────────────────
+  const handleRefresh = useCallback(async () => {
+    preSyncTimestampRef.current = config.last_synced ?? null;
+    setRefreshState({ status: "SUBMITTING" });
+
+    const result: AccountRefreshResult = await triggerIBKRSync(config.id);
+
+    if (!result.ok) {
+      setRefreshState({ status: "ERROR", message: result.error });
+      toast.error(`Refresh failed: ${result.error}`);
+      return;
     }
-  };
+
+    if (result.status === "queued") {
+      setRefreshState({ status: "QUEUED", preSyncTimestamp: preSyncTimestampRef.current });
+      toast.info("Refresh queued. Data will update within 5 minutes.");
+      return;
+    }
+
+    if (result.status === "throttled") {
+      const minutesAgo = minutesSince(result.last_synced_at);
+      const minutesLeft = minutesUntil(result.next_eligible_at);
+      setRefreshState({
+        status: "THROTTLED",
+        nextEligibleAt: result.next_eligible_at,
+        minutesRemaining: minutesLeft,
+      });
+      toast.warning(
+        `Last sync was ${minutesAgo} min ago. Try again in ${minutesLeft} min.`,
+      );
+    }
+  }, [config.id, config.last_synced]);
+
+  // ── Derived button state ─────────────────────────────────────────────────────
+  const isButtonDisabled =
+    refreshState.status === "SUBMITTING" ||
+    refreshState.status === "QUEUED" ||
+    refreshState.status === "THROTTLED";
+
+  function getButtonLabel(): string {
+    switch (refreshState.status) {
+      case "SUBMITTING":
+        return "Syncing…";
+      case "QUEUED":
+        return "Queued…";
+      case "THROTTLED":
+        return `Try in ${refreshState.minutesRemaining}m`;
+      default:
+        return "↻ Refresh";
+    }
+  }
+
+  const isSpinning = refreshState.status === "SUBMITTING" || refreshState.status === "QUEUED";
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-4 bg-slate-900/50 rounded-lg border border-slate-800 mb-4">
@@ -94,7 +236,7 @@ export default function AccountHeader({
         {isIBKR ? (
           <button
             onClick={handleRefresh}
-            disabled={syncing}
+            disabled={isButtonDisabled}
             className="flex items-center gap-2 px-3 py-1.5 rounded-lg border border-slate-700 bg-slate-800 text-slate-300 hover:text-white hover:border-slate-600 transition-all text-sm disabled:opacity-50"
             data-testid="refresh-button"
           >
@@ -108,13 +250,14 @@ export default function AccountHeader({
               strokeWidth="2"
               strokeLinecap="round"
               strokeLinejoin="round"
-              className={syncing ? "animate-spin" : ""}
+              className={isSpinning ? "animate-spin" : ""}
+              aria-hidden="true"
             >
               <path d="M23 4v6h-6" />
               <path d="M1 20v-6h6" />
               <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
             </svg>
-            {syncing ? "Syncing…" : "↻ Refresh"}
+            {getButtonLabel()}
           </button>
         ) : (
           <>
@@ -149,12 +292,6 @@ export default function AccountHeader({
           </>
         )}
       </div>
-
-      {syncMessage && (
-        <p className="text-xs text-slate-400 w-full sm:w-auto" data-testid="sync-message">
-          {syncMessage}
-        </p>
-      )}
     </div>
   );
 }

--- a/apps/frontend/src/components/trading/accounts/__tests__/AccountHeader.refresh.test.tsx
+++ b/apps/frontend/src/components/trading/accounts/__tests__/AccountHeader.refresh.test.tsx
@@ -161,12 +161,16 @@ describe("AccountHeader — Refresh button (G11-G14)", () => {
     // Button should be disabled in QUEUED state
     expect(button).toBeDisabled();
 
-    // Advance one 30-second poll tick — router.refresh should fire
+    // Advance TWO 30-second poll ticks — confirms setInterval (not one-shot setTimeout)
     await act(async () => {
       vi.advanceTimersByTime(30_000);
     });
-
     expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(2);
   });
 
   // ── G13: Throttled response → toast with countdown ──────────────────────────
@@ -225,6 +229,13 @@ describe("AccountHeader — Refresh button (G11-G14)", () => {
       "Refresh may have failed. Check back later.",
     );
     expect(button).not.toBeDisabled();
+
+    // Verify interval was cleared — one extra tick must NOT increment the call count
+    const refreshCountAtTimeout = mockRouterRefresh.mock.calls.length;
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(refreshCountAtTimeout);
   });
 
   // ── Bonus: Error response ────────────────────────────────────────────────────
@@ -284,5 +295,39 @@ describe("AccountHeader — Refresh button (G11-G14)", () => {
     expect(toast.success).toHaveBeenCalledWith("Data refreshed!");
     expect(onRefreshComplete).toHaveBeenCalledTimes(1);
     expect(button).not.toBeDisabled();
+  });
+
+  // ── Unmount cleanup: polling stops after unmount ────────────────────────────
+  it("stops polling and does not call router.refresh after unmount", async () => {
+    vi.useFakeTimers();
+
+    mockTriggerIBKRSync.mockResolvedValue(QUEUED_RESULT);
+
+    const { unmount } = renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Confirm polling started
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+
+    // Unmount — clearInterval in the useEffect cleanup should fire
+    act(() => {
+      unmount();
+    });
+
+    const refreshCountAtUnmount = mockRouterRefresh.mock.calls.length;
+
+    // Advance two more intervals (60s) — interval must be dead
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+    });
+
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(refreshCountAtUnmount);
   });
 });

--- a/apps/frontend/src/components/trading/accounts/__tests__/AccountHeader.refresh.test.tsx
+++ b/apps/frontend/src/components/trading/accounts/__tests__/AccountHeader.refresh.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * AccountHeader — Refresh button state machine tests (Section G items 11-14)
+ *
+ * Covers:
+ *  11. Button disabled during submit
+ *  12. Queued response → toast shown + polling interval starts
+ *  13. Throttled response → toast shows "try again in X min" with countdown
+ *  14. Timeout after 10 min polling → timeout message shown, button re-enabled
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import * as TradingActions from "@/app/trading/actions";
+import AccountHeader from "../AccountHeader";
+import type { TradingAccountConfig } from "@/app/trading/actions";
+import { toast } from "sonner";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Override the global next/navigation mock to add `refresh`
+const mockRouterRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    prefetch: vi.fn(),
+    refresh: mockRouterRefresh,
+  })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+// Mock CSVImportButton so we don't need its deps
+vi.mock("@/components/trading/accounts/CSVImportButton", () => ({
+  default: () => <button data-testid="csv-import-button">Import CSV</button>,
+}));
+
+// Mock triggerIBKRSync — tests control its resolved value
+const mockTriggerIBKRSync = vi.fn();
+vi.mock("@/app/trading/actions", async (importOriginal) => {
+  const actual = await importOriginal<typeof TradingActions>();
+  return {
+    ...actual,
+    triggerIBKRSync: (...args: unknown[]) => mockTriggerIBKRSync(...args),
+  };
+});
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const IBKR_CONFIG: TradingAccountConfig = {
+  id: 42,
+  name: "IBKR Main",
+  account_type: "IBKR",
+  host: "127.0.0.1",
+  port: 4001,
+  client_id: 1,
+  linked_account_id: null,
+  account_id: "U12345",
+  last_synced: "2026-05-19T06:30:00Z",
+  compute_options_income: false,
+};
+
+const QUEUED_RESULT: TradingActions.AccountRefreshResult = {
+  ok: true,
+  status: "queued",
+  last_synced_at: IBKR_CONFIG.last_synced,
+  next_eligible_at: null,
+};
+
+function renderHeader(
+  overrides: Partial<TradingAccountConfig> = {},
+  callbacks: { onRefreshComplete?: () => void } = {},
+) {
+  const config = { ...IBKR_CONFIG, ...overrides };
+  return render(
+    <AccountHeader
+      config={config}
+      onRefreshComplete={callbacks.onRefreshComplete}
+    />,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("AccountHeader — Refresh button (G11-G14)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouterRefresh.mockClear();
+  });
+
+  afterEach(() => {
+    // Restore real timers in case a test used fake ones
+    vi.useRealTimers();
+  });
+
+  // ── G11: Button disabled during submit ──────────────────────────────────────
+  it("G11: disables the refresh button while a submit is in-flight", async () => {
+    // Controlled promise: we decide when it resolves
+    let resolveRefresh!: (v: TradingActions.AccountRefreshResult) => void;
+    mockTriggerIBKRSync.mockReturnValue(
+      new Promise<TradingActions.AccountRefreshResult>((res) => {
+        resolveRefresh = res;
+      }),
+    );
+
+    renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    expect(button).not.toBeDisabled();
+
+    // Synchronous act flushes the SUBMITTING setState that fires before the
+    // first await inside handleRefresh.
+    act(() => {
+      fireEvent.click(button);
+    });
+
+    expect(button).toBeDisabled();
+
+    // Resolve to prevent dangling promise warnings
+    await act(async () => {
+      resolveRefresh({ ok: false, status: "error", error: "cancelled" });
+    });
+  });
+
+  // ── G12: Queued response → toast shown + polling starts ─────────────────────
+  it("G12: shows queued toast and starts polling interval on queued response", async () => {
+    vi.useFakeTimers();
+
+    mockTriggerIBKRSync.mockResolvedValue(QUEUED_RESULT);
+
+    renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(toast.info).toHaveBeenCalledWith(
+      "Refresh queued. Data will update within 5 minutes.",
+    );
+
+    // Button should be disabled in QUEUED state
+    expect(button).toBeDisabled();
+
+    // Advance one 30-second poll tick — router.refresh should fire
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(mockRouterRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  // ── G13: Throttled response → toast with countdown ──────────────────────────
+  it("G13: shows throttled toast with 'try again in X min' message", async () => {
+    // next_eligible_at is 45 minutes from now
+    const nextEligibleAt = new Date(Date.now() + 45 * 60_000).toISOString();
+
+    mockTriggerIBKRSync.mockResolvedValue({
+      ok: true,
+      status: "throttled",
+      last_synced_at: "2026-05-19T09:05:00Z",
+      next_eligible_at: nextEligibleAt,
+    } satisfies TradingActions.AccountRefreshResult);
+
+    renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Warning toast should appear with the countdown
+    expect(toast.warning).toHaveBeenCalledTimes(1);
+    const warningCall = (toast.warning as Mock).mock.calls[0][0] as string;
+    expect(warningCall).toMatch(/try again in \d+ min/i);
+
+    // Button should be disabled showing countdown text
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent(/try in \d+m/i);
+  });
+
+  // ── G14: Timeout after 10 min polling ───────────────────────────────────────
+  it("G14: shows timeout toast and re-enables button after 20 poll iterations (10 min)", async () => {
+    vi.useFakeTimers();
+
+    mockTriggerIBKRSync.mockResolvedValue(QUEUED_RESULT);
+
+    renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    // Button is disabled in QUEUED state
+    expect(button).toBeDisabled();
+
+    // Advance through all 20 × 30s = 600s intervals
+    for (let i = 0; i < 20; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(30_000);
+      });
+    }
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Refresh may have failed. Check back later.",
+    );
+    expect(button).not.toBeDisabled();
+  });
+
+  // ── Bonus: Error response ────────────────────────────────────────────────────
+  it("shows error toast and re-enables button on error response", async () => {
+    mockTriggerIBKRSync.mockResolvedValue({
+      ok: false,
+      status: "error",
+      error: "Account not found.",
+    } satisfies TradingActions.AccountRefreshResult);
+
+    renderHeader();
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(toast.error).toHaveBeenCalledWith(
+      "Refresh failed: Account not found.",
+    );
+    expect(button).not.toBeDisabled();
+  });
+
+  // ── Bonus: COMPLETED when config.last_synced changes during polling ──────────
+  it("transitions to COMPLETED when last_synced prop changes during polling", async () => {
+    vi.useFakeTimers();
+
+    mockTriggerIBKRSync.mockResolvedValue(QUEUED_RESULT);
+
+    const onRefreshComplete = vi.fn();
+    const { rerender } = renderHeader({}, { onRefreshComplete });
+    const button = screen.getByTestId("refresh-button");
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(button).toBeDisabled();
+
+    // Simulate the server reflecting the new timestamp (router.refresh caused
+    // the server component to pass a fresh config prop down)
+    const newTimestamp = "2026-05-19T10:00:00Z";
+    await act(async () => {
+      rerender(
+        <AccountHeader
+          config={{ ...IBKR_CONFIG, last_synced: newTimestamp }}
+          onRefreshComplete={onRefreshComplete}
+        />,
+      );
+    });
+
+    // Advance one polling tick so the interval callback reads the updated ref
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(toast.success).toHaveBeenCalledWith("Data refreshed!");
+    expect(onRefreshComplete).toHaveBeenCalledTimes(1);
+    expect(button).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
Implements the frontend half of the manual "Refresh" button feature on the Accounts page. Backend endpoint lands in parallel PR #463 (`squad/refresh-button-backend`).

## What this PR does
- **`actions.ts`:** Rewrites `triggerIBKRSync` to call the new `POST /api/trading/accounts/{config_id}/refresh` endpoint. Returns an `AccountRefreshResult` discriminated union (`status: "queued" | "throttled"`). Calls FastAPI directly using Supabase Bearer token (no proxy route needed).
- **`AccountHeader.tsx`:** Full state machine `IDLE → SUBMITTING → QUEUED/THROTTLED/ERROR → COMPLETED/TIMEOUT` with:
  - Queued toast + 30-second polling loop watching `last_synced`
  - Throttled toast with live countdown computed from `next_eligible_at`
  - 10-minute polling timeout fallback
  - sonner toasts (existing project pattern)
- **Tests:** 6 component tests (4 required + 2 bonus: error response, completion detection)

## Design reference
`.squad/decisions/inbox/keaton-refresh-button-design-2026-05-19.md` (Sections E + G items 11-14)

## Contract
Backend returns HTTP 200 OK in all success cases with a `status` discriminator (per design Section B). This PR is hard-coded to that contract.

## Notable design deviation
Completion detection uses `useRef` + polling callback (not a separate `useEffect` on `config.last_synced`) — the project's `react-hooks/set-state-in-effect` lint rule forbids `setState` in effect body. Functionally identical: detection fires on the next 30s tick after `router.refresh()` delivers fresh props.

## Dependency
Requires PR #463 (backend) merged + deployed for end-to-end manual testing. Unit tests pass against mocks regardless.

## Out of scope
- Schema migration / API endpoint / worker poll (Hockney's PR #463)

Closes #393 (partial — frontend half)
Refs #459

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>