### PR TITLE
fix(expenses): port 6 API endpoints to Next.js Route Handlers (prod fix)

### DIFF
--- a/.squad/decisions/inbox/hockney-expenses-handlers-2026-05-29.md
+++ b/.squad/decisions/inbox/hockney-expenses-handlers-2026-05-29.md
@@ -1,0 +1,26 @@
+# Hockney — Expenses Route Handlers Production Fix (2026-05-29)
+
+## Decision
+
+Port the production-facing `/api/expenses/*` surface from FastAPI-only endpoints to Next.js Route Handlers under `apps/frontend/src/app/api/expenses/`.
+
+## Rationale
+
+- Production Vercel resolves `apiFetch('/api/expenses/...')` relative to the frontend origin.
+- The FastAPI expense endpoints are only available in local Docker and are not deployed publicly.
+- Adding Route Handlers fixes the immediate 404 failure mode without changing the existing frontend client.
+- Handlers query Supabase directly, authenticate with the request-scoped server client, resolve the active household, and explicitly scope household tables by `household_id`.
+- The resolve write path can use the server-only service-role client when configured, because the current expense migration grants writes to `service_role`; all write queries still carry explicit household filters.
+
+## Scope
+
+Implemented Route Handlers for:
+
+- `GET /api/expenses/categories`
+- `GET /api/expenses/monthly-summary`
+- `GET /api/expenses/unresolved`
+- `GET /api/expenses/by-category/[slug]`
+- `GET /api/expenses/statements`
+- `POST /api/expenses/resolve`
+
+Kujan owns the separate production migration application/fix. This change fixes the missing-handler 404s; data availability still depends on the production expense tables and seed data existing.

--- a/apps/frontend/src/app/api/expenses/_lib/expenses-route-helpers.test.ts
+++ b/apps/frontend/src/app/api/expenses/_lib/expenses-route-helpers.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCategoryTree,
+  normalizeMerchant,
+  numericToNumber,
+  parseBooleanParam,
+  parseMonthRange,
+  parsePagination,
+  parseResolvePayload,
+  type ExpenseCategoryRow,
+} from "./expenses-route-helpers";
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+const UUID_C = "33333333-3333-4333-8333-333333333333";
+
+describe("expenses route helpers", () => {
+  it("builds the category taxonomy with typed subcategories", () => {
+    const rows: ExpenseCategoryRow[] = [
+      categoryRow({ id: UUID_B, parent_id: UUID_A, slug: "restaurants-delivery", display_order: 2 }),
+      categoryRow({ id: UUID_A, parent_id: null, slug: "restaurants", display_order: 1 }),
+      categoryRow({ id: UUID_C, parent_id: UUID_A, slug: "restaurants-dine-in", display_order: 1 }),
+    ];
+
+    const categories = buildCategoryTree(rows);
+
+    expect(categories).toHaveLength(1);
+    expect(categories[0]).toMatchObject({
+      id: UUID_A,
+      slug: "restaurants",
+      color: "#BDBDBD",
+      subcategories: [
+        { id: UUID_C, slug: "restaurants-dine-in", parent_slug: "restaurants" },
+        { id: UUID_B, slug: "restaurants-delivery", parent_slug: "restaurants" },
+      ],
+    });
+  });
+
+  it("normalizes Supabase numeric values without throwing", () => {
+    expect(numericToNumber("12.34")).toBe(12.34);
+    expect(numericToNumber(null)).toBeNull();
+    expect(numericToNumber("not-a-number")).toBeNull();
+  });
+
+  it("parses pagination and clamps page size", () => {
+    const params = new URLSearchParams({ page: "2", page_size: "999" });
+
+    expect(parsePagination(params, 50)).toEqual({ page: 2, pageSize: 200, offset: 200 });
+  });
+
+  it("parses booleans and month ranges", () => {
+    expect(parseBooleanParam("false", true)).toBe(false);
+    expect(parseBooleanParam(null, true)).toBe(true);
+    expect(parseMonthRange("2026-12", "2027-01")).toEqual({
+      fromDate: "2026-12-01",
+      toExclusiveDate: "2027-02-01",
+    });
+    expect(parseMonthRange("2026-13", null)).toBeNull();
+  });
+
+  it("accepts legacy and batch resolve payloads", () => {
+    expect(
+      parseResolvePayload({
+        transaction_id: UUID_A,
+        category_id: UUID_B,
+        subcategory_id: null,
+        apply_to_all_matching: true,
+      }),
+    ).toEqual({
+      ok: true,
+      payload: {
+        transactionIds: [UUID_A],
+        categoryId: UUID_B,
+        subcategoryId: null,
+        applyToAllMatching: true,
+        saveMapping: true,
+      },
+    });
+
+    expect(
+      parseResolvePayload({
+        transaction_ids: [UUID_A, UUID_B],
+        category_id: UUID_C,
+        save_mapping: false,
+      }),
+    ).toEqual({
+      ok: true,
+      payload: {
+        transactionIds: [UUID_A, UUID_B],
+        categoryId: UUID_C,
+        subcategoryId: null,
+        applyToAllMatching: false,
+        saveMapping: false,
+      },
+    });
+  });
+
+  it("normalizes raw merchant text when stored normalized text is unavailable", () => {
+    expect(normalizeMerchant("  Café  דוגמה!! 123 ")).toBe("CAFÉ דוגמה 123");
+  });
+});
+
+function categoryRow(overrides: Partial<ExpenseCategoryRow>): ExpenseCategoryRow {
+  return {
+    id: UUID_A,
+    parent_id: null,
+    slug: "restaurants",
+    name: "Restaurants",
+    name_he: "מסעדות",
+    icon: null,
+    color: null,
+    display_order: 1,
+    is_transfer: false,
+    ...overrides,
+  };
+}

--- a/apps/frontend/src/app/api/expenses/_lib/expenses-route-helpers.ts
+++ b/apps/frontend/src/app/api/expenses/_lib/expenses-route-helpers.ts
@@ -1,0 +1,269 @@
+import type {
+  ExpenseCategory,
+  ExpenseSubcategory,
+  ResolveRequest,
+} from "@/types/expenses";
+
+export const MAX_PAGE_SIZE = 200;
+export const DEFAULT_UNRESOLVED_PAGE_SIZE = 50;
+export const DEFAULT_STATEMENTS_PAGE_SIZE = 20;
+
+export interface ExpenseCategoryRow {
+  id: string;
+  parent_id: string | null;
+  slug: string;
+  name: string;
+  name_he: string;
+  icon: string | null;
+  color: string | null;
+  display_order: number;
+  is_transfer: boolean;
+}
+
+export interface Pagination {
+  page: number;
+  pageSize: number;
+  offset: number;
+}
+
+export interface MonthRange {
+  fromDate?: string;
+  toExclusiveDate?: string;
+}
+
+export interface ResolvePayload {
+  transactionIds: string[];
+  categoryId: string;
+  subcategoryId: string | null;
+  applyToAllMatching: boolean;
+  saveMapping: boolean;
+}
+
+export type ResolvePayloadResult =
+  | { ok: true; payload: ResolvePayload }
+  | { ok: false; error: string };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const MONTH_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+/** Build the category taxonomy returned by GET /api/expenses/categories. */
+export function buildCategoryTree(rows: ExpenseCategoryRow[]): ExpenseCategory[] {
+  const sortedRows = [...rows].sort((left, right) => {
+    const byParent = (left.parent_id ?? "").localeCompare(right.parent_id ?? "");
+    if (byParent !== 0) return byParent;
+    const byOrder = left.display_order - right.display_order;
+    if (byOrder !== 0) return byOrder;
+    return left.slug.localeCompare(right.slug);
+  });
+
+  const rowsById = new Map(sortedRows.map((row) => [row.id, row]));
+  const parents = new Map<string, ExpenseCategory>();
+
+  for (const row of sortedRows) {
+    if (row.parent_id !== null) continue;
+
+    parents.set(row.id, {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      name_he: row.name_he,
+      color: row.color ?? "#BDBDBD",
+      ...(row.icon ? { icon: row.icon } : {}),
+      is_transfer: row.is_transfer,
+      subcategories: [],
+    });
+  }
+
+  for (const row of sortedRows) {
+    if (row.parent_id === null) continue;
+
+    const parent = parents.get(row.parent_id);
+    const parentRow = rowsById.get(row.parent_id);
+    if (!parent || !parentRow) continue;
+
+    const subcategory: ExpenseSubcategory = {
+      id: row.id,
+      slug: row.slug,
+      name: row.name,
+      name_he: row.name_he,
+      parent_slug: parentRow.slug,
+    };
+    parent.subcategories.push(subcategory);
+  }
+
+  return [...parents.values()].sort((left, right) => {
+    const leftRow = rowsById.get(left.id);
+    const rightRow = rowsById.get(right.id);
+    const byOrder = (leftRow?.display_order ?? 0) - (rightRow?.display_order ?? 0);
+    if (byOrder !== 0) return byOrder;
+    return left.slug.localeCompare(right.slug);
+  });
+}
+
+/** Convert Supabase NUMERIC strings to JSON numbers, preserving nulls. */
+export function numericToNumber(value: string | number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  const numericValue = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+export function numericToRequiredNumber(value: string | number | null | undefined): number {
+  return numericToNumber(value) ?? 0;
+}
+
+export function parsePagination(
+  searchParams: URLSearchParams,
+  defaultPageSize: number,
+): Pagination {
+  const page = clampInteger(searchParams.get("page"), 1, Number.MAX_SAFE_INTEGER, 1);
+  const pageSize = clampInteger(
+    searchParams.get("page_size"),
+    1,
+    MAX_PAGE_SIZE,
+    defaultPageSize,
+  );
+
+  return {
+    page,
+    pageSize,
+    offset: (page - 1) * pageSize,
+  };
+}
+
+export function parseBooleanParam(value: string | null, defaultValue: boolean): boolean {
+  if (value === null) return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  return defaultValue;
+}
+
+export function parseMonthRange(from: string | null, to: string | null): MonthRange | null {
+  const fromDate = from ? monthStart(from) : undefined;
+  const toExclusiveDate = to ? nextMonthStart(to) : undefined;
+
+  if ((from && !fromDate) || (to && !toExclusiveDate)) return null;
+
+  return { fromDate, toExclusiveDate };
+}
+
+export function normalizeSearch(value: string | null): string | null {
+  const normalized = value?.trim();
+  if (!normalized) return null;
+  return normalized.slice(0, 100);
+}
+
+export function normalizeMerchant(raw: string): string {
+  return raw
+    .normalize("NFKC")
+    .toUpperCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim()
+    .replace(/\s+/g, " ");
+}
+
+export function parseResolvePayload(input: unknown): ResolvePayloadResult {
+  if (!isRecord(input)) {
+    return { ok: false, error: "Invalid request body" };
+  }
+
+  const transactionIds = readTransactionIds(input);
+  const categoryId = readString(input.category_id);
+  const subcategoryId = readNullableString(input.subcategory_id);
+  const applyToAllMatching = readBoolean(input.apply_to_all_matching, false);
+  const saveMapping = readBoolean(input.save_mapping, transactionIds.source === "legacy");
+
+  if (transactionIds.values.length === 0) {
+    return { ok: false, error: "transaction_ids is required" };
+  }
+  if (!categoryId) {
+    return { ok: false, error: "category_id is required" };
+  }
+  if (!transactionIds.values.every(isUuid)) {
+    return { ok: false, error: "transaction_ids must be UUIDs" };
+  }
+  if (!isUuid(categoryId)) {
+    return { ok: false, error: "category_id must be a UUID" };
+  }
+  if (subcategoryId !== null && !isUuid(subcategoryId)) {
+    return { ok: false, error: "subcategory_id must be a UUID" };
+  }
+
+  return {
+    ok: true,
+    payload: {
+      transactionIds: transactionIds.values,
+      categoryId,
+      subcategoryId,
+      applyToAllMatching,
+      saveMapping,
+    },
+  };
+}
+
+function clampInteger(
+  value: string | null,
+  min: number,
+  max: number,
+  defaultValue: number,
+): number {
+  if (value === null) return defaultValue;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return defaultValue;
+  return Math.min(Math.max(parsed, min), max);
+}
+
+function monthStart(month: string): string | undefined {
+  if (!MONTH_PATTERN.test(month)) return undefined;
+  return `${month}-01`;
+}
+
+function nextMonthStart(month: string): string | undefined {
+  if (!MONTH_PATTERN.test(month)) return undefined;
+  const [yearPart, monthPart] = month.split("-");
+  const year = Number(yearPart);
+  const monthIndex = Number(monthPart) - 1;
+  const date = new Date(Date.UTC(year, monthIndex + 1, 1));
+  const nextYear = date.getUTCFullYear();
+  const nextMonth = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${nextYear}-${nextMonth}-01`;
+}
+
+function readTransactionIds(input: Record<string, unknown>): {
+  values: string[];
+  source: "batch" | "legacy";
+} {
+  if (Array.isArray(input.transaction_ids)) {
+    return {
+      values: input.transaction_ids.filter((value): value is string => typeof value === "string"),
+      source: "batch",
+    };
+  }
+
+  const legacyRequest = input as Partial<ResolveRequest>;
+  return {
+    values: typeof legacyRequest.transaction_id === "string" ? [legacyRequest.transaction_id] : [],
+    source: "legacy",
+  };
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readNullableString(value: unknown): string | null {
+  return value === null || value === undefined ? null : readString(value);
+}
+
+function readBoolean(value: unknown, defaultValue: boolean): boolean {
+  return typeof value === "boolean" ? value : defaultValue;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isUuid(value: string): boolean {
+  return UUID_PATTERN.test(value);
+}

--- a/apps/frontend/src/app/api/expenses/_lib/expenses-server.ts
+++ b/apps/frontend/src/app/api/expenses/_lib/expenses-server.ts
@@ -1,0 +1,81 @@
+import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+import { createClient } from "@/lib/supabase/server";
+import type { Database } from "@/types/database";
+
+export type ExpensesSupabaseClient = SupabaseClient<Database>;
+
+let cachedWriteClient: ExpensesSupabaseClient | null = null;
+
+export type ExpensesAuthResult =
+  | {
+      ok: true;
+      supabase: ExpensesSupabaseClient;
+      userId: string;
+      householdId: string;
+    }
+  | { ok: false; response: NextResponse };
+
+/** Create a server-only service-role client for writes covered by explicit household filters. */
+export function createExpensesWriteClient(): ExpensesSupabaseClient | null {
+  if (cachedWriteClient) return cachedWriteClient;
+
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return null;
+
+  cachedWriteClient = createSupabaseClient<Database>(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  return cachedWriteClient;
+}
+
+/** Authenticate the caller and resolve their active household membership. */
+export async function requireExpensesAuth(): Promise<ExpensesAuthResult> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser();
+
+  if (userError || !user) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    };
+  }
+
+  const { data: membership, error: membershipError } = await supabase
+    .from("household_members")
+    .select("household_id")
+    .eq("user_id", user.id)
+    .is("left_at", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (membershipError) {
+    console.error("[expenses] household lookup failed", membershipError.message);
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Failed to resolve household" }, { status: 500 }),
+    };
+  }
+
+  const householdId = typeof membership?.household_id === "string" ? membership.household_id : null;
+  if (!householdId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "User not associated with any household" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { ok: true, supabase, userId: user.id, householdId };
+}

--- a/apps/frontend/src/app/api/expenses/by-category/[slug]/route.ts
+++ b/apps/frontend/src/app/api/expenses/by-category/[slug]/route.ts
@@ -1,0 +1,185 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import type { TransactionDetail } from "@/types/expenses";
+
+import {
+  DEFAULT_UNRESOLVED_PAGE_SIZE,
+  numericToNumber,
+  numericToRequiredNumber,
+  parsePagination,
+} from "../../_lib/expenses-route-helpers";
+import { requireExpensesAuth, type ExpensesSupabaseClient } from "../../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+const BATCH_SIZE = 1000;
+
+interface CategoryLookupRow {
+  id: string;
+  slug: string;
+}
+
+interface TransactionDetailRow {
+  id: string;
+  txn_date: string;
+  merchant_raw: string;
+  merchant_normalized: string;
+  amount_ils: string | number;
+  original_currency: string | null;
+  amount_original: string | number | null;
+  resolution_status: string;
+  resolution_source: string | null;
+  statement_id: string;
+}
+
+interface AmountRow {
+  amount_ils: string | number;
+}
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ slug: string }> },
+): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  const { slug } = await context.params;
+  const searchParams = request.nextUrl.searchParams;
+  const pagination = parsePagination(searchParams, DEFAULT_UNRESOLVED_PAGE_SIZE);
+  const fromDate = searchParams.get("from");
+  const toDate = searchParams.get("to");
+  const subcategorySlug = searchParams.get("subcategory_slug");
+
+  const { data: category, error: categoryError } = await auth.supabase
+    .from("expense_categories")
+    .select("id,slug")
+    .eq("slug", slug)
+    .maybeSingle();
+
+  if (categoryError) {
+    console.error("[expenses] category lookup failed", categoryError.message);
+    return NextResponse.json({ error: "Failed to load category" }, { status: 500 });
+  }
+  if (!category) {
+    return NextResponse.json({ error: "Category not found" }, { status: 404 });
+  }
+
+  let subcategoryId: string | null = null;
+  if (subcategorySlug) {
+    const { data: subcategory, error: subcategoryError } = await auth.supabase
+      .from("expense_categories")
+      .select("id,slug")
+      .eq("slug", subcategorySlug)
+      .maybeSingle();
+
+    if (subcategoryError) {
+      console.error("[expenses] subcategory lookup failed", subcategoryError.message);
+      return NextResponse.json({ error: "Failed to load subcategory" }, { status: 500 });
+    }
+    subcategoryId = ((subcategory as CategoryLookupRow | null)?.id as string | undefined) ?? null;
+  }
+
+  const categoryId = (category as CategoryLookupRow).id;
+
+  let countQuery = auth.supabase
+    .from("credit_card_transactions")
+    .select("id", { count: "exact", head: true })
+    .eq("household_id", auth.householdId)
+    .eq("category_id", categoryId);
+  if (fromDate) countQuery = countQuery.gte("txn_date", fromDate);
+  if (toDate) countQuery = countQuery.lte("txn_date", toDate);
+  if (subcategoryId) countQuery = countQuery.eq("subcategory_id", subcategoryId);
+
+  const { count, error: countError } = await countQuery;
+  if (countError) {
+    console.error("[expenses] by-category count query failed", countError.message);
+    return NextResponse.json({ error: "Failed to load category transactions" }, { status: 500 });
+  }
+
+  const subtotal = await loadSubtotal(auth.supabase, auth.householdId, categoryId, fromDate, toDate, subcategoryId);
+  if (subtotal === null) {
+    return NextResponse.json({ error: "Failed to load category subtotal" }, { status: 500 });
+  }
+
+  let rowsQuery = auth.supabase
+    .from("credit_card_transactions")
+    .select(
+      "id,txn_date,merchant_raw,merchant_normalized,amount_ils,original_currency,amount_original,resolution_status,resolution_source,statement_id",
+    )
+    .eq("household_id", auth.householdId)
+    .eq("category_id", categoryId);
+  if (fromDate) rowsQuery = rowsQuery.gte("txn_date", fromDate);
+  if (toDate) rowsQuery = rowsQuery.lte("txn_date", toDate);
+  if (subcategoryId) rowsQuery = rowsQuery.eq("subcategory_id", subcategoryId);
+
+  const { data, error } = await rowsQuery
+    .order("txn_date", { ascending: false })
+    .order("id", { ascending: false })
+    .range(pagination.offset, pagination.offset + pagination.pageSize - 1);
+
+  if (error) {
+    console.error("[expenses] by-category rows query failed", error.message);
+    return NextResponse.json({ error: "Failed to load category transactions" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    items: ((data ?? []) as TransactionDetailRow[]).map(toTransactionDetail),
+    total: count ?? 0,
+    page: pagination.page,
+    page_size: pagination.pageSize,
+    category_slug: slug,
+    subtotal_ils: subtotal,
+  });
+}
+
+async function loadSubtotal(
+  supabase: ExpensesSupabaseClient,
+  householdId: string,
+  categoryId: string,
+  fromDate: string | null,
+  toDate: string | null,
+  subcategoryId: string | null,
+): Promise<number | null> {
+  let subtotal = 0;
+
+  for (let offset = 0; ; offset += BATCH_SIZE) {
+    let query = supabase
+      .from("credit_card_transactions")
+      .select("amount_ils")
+      .eq("household_id", householdId)
+      .eq("category_id", categoryId);
+    if (fromDate) query = query.gte("txn_date", fromDate);
+    if (toDate) query = query.lte("txn_date", toDate);
+    if (subcategoryId) query = query.eq("subcategory_id", subcategoryId);
+
+    const { data, error } = await query.range(offset, offset + BATCH_SIZE - 1);
+    if (error) {
+      console.error("[expenses] by-category subtotal query failed", error.message);
+      return null;
+    }
+
+    const rows = (data ?? []) as AmountRow[];
+    subtotal += rows.reduce(
+      (sum, row) => sum + numericToRequiredNumber(row.amount_ils),
+      0,
+    );
+    if (rows.length < BATCH_SIZE) break;
+  }
+
+  return subtotal;
+}
+
+function toTransactionDetail(row: TransactionDetailRow): TransactionDetail {
+  return {
+    id: row.id,
+    txn_date: row.txn_date,
+    merchant_raw: row.merchant_raw,
+    merchant_normalized: row.merchant_normalized,
+    amount_ils: numericToRequiredNumber(row.amount_ils),
+    original_currency: row.original_currency,
+    amount_original: numericToNumber(row.amount_original),
+    resolution_status: row.resolution_status,
+    resolution_source: row.resolution_source,
+    statement_id: row.statement_id,
+  };
+}

--- a/apps/frontend/src/app/api/expenses/categories/route.ts
+++ b/apps/frontend/src/app/api/expenses/categories/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { buildCategoryTree, type ExpenseCategoryRow } from "../_lib/expenses-route-helpers";
+import { requireExpensesAuth } from "../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  const { data, error } = await auth.supabase
+    .from("expense_categories")
+    .select("id,parent_id,slug,name,name_he,icon,color,display_order,is_transfer")
+    .order("display_order", { ascending: true })
+    .order("slug", { ascending: true });
+
+  if (error) {
+    console.error("[expenses] categories query failed", error.message);
+    return NextResponse.json({ error: "Failed to load expense categories" }, { status: 500 });
+  }
+
+  return NextResponse.json({ categories: buildCategoryTree((data ?? []) as ExpenseCategoryRow[]) });
+}

--- a/apps/frontend/src/app/api/expenses/monthly-summary/route.ts
+++ b/apps/frontend/src/app/api/expenses/monthly-summary/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import type { MonthlySummaryRow } from "@/types/expenses";
+
+import {
+  numericToRequiredNumber,
+  parseBooleanParam,
+  parseMonthRange,
+  type ExpenseCategoryRow,
+} from "../_lib/expenses-route-helpers";
+import { requireExpensesAuth } from "../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+const BATCH_SIZE = 1000;
+
+interface SummaryTransactionRow {
+  txn_date: string;
+  amount_ils: string | number;
+  category_id: string | null;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  const searchParams = request.nextUrl.searchParams;
+  const monthRange = parseMonthRange(searchParams.get("from"), searchParams.get("to"));
+  if (!monthRange) {
+    return NextResponse.json({ error: "Invalid month filter" }, { status: 400 });
+  }
+
+  const excludeTransfers = parseBooleanParam(searchParams.get("exclude_transfers"), true);
+
+  const { data: categoriesData, error: categoriesError } = await auth.supabase
+    .from("expense_categories")
+    .select("id,parent_id,slug,name,name_he,icon,color,display_order,is_transfer")
+    .order("display_order", { ascending: true })
+    .order("slug", { ascending: true });
+
+  if (categoriesError) {
+    console.error("[expenses] summary categories query failed", categoriesError.message);
+    return NextResponse.json({ error: "Failed to load expense categories" }, { status: 500 });
+  }
+
+  const categoriesById = new Map(
+    ((categoriesData ?? []) as ExpenseCategoryRow[]).map((category) => [category.id, category]),
+  );
+  const summaryByKey = new Map<string, MonthlySummaryRow>();
+
+  for (let offset = 0; ; offset += BATCH_SIZE) {
+    let query = auth.supabase
+      .from("credit_card_transactions")
+      .select("txn_date,amount_ils,category_id")
+      .eq("household_id", auth.householdId)
+      .not("category_id", "is", null);
+
+    if (monthRange.fromDate) query = query.gte("txn_date", monthRange.fromDate);
+    if (monthRange.toExclusiveDate) query = query.lt("txn_date", monthRange.toExclusiveDate);
+
+    const { data, error } = await query
+      .order("txn_date", { ascending: false })
+      .range(offset, offset + BATCH_SIZE - 1);
+    if (error) {
+      console.error("[expenses] monthly summary query failed", error.message);
+      return NextResponse.json({ error: "Failed to load monthly summary" }, { status: 500 });
+    }
+
+    const rows = (data ?? []) as SummaryTransactionRow[];
+    for (const row of rows) {
+      if (!row.category_id) continue;
+      const category = categoriesById.get(row.category_id);
+      if (!category || (excludeTransfers && category.is_transfer)) continue;
+
+      const month = row.txn_date.slice(0, 7);
+      const key = `${month}:${category.id}`;
+      const existing = summaryByKey.get(key);
+      if (existing) {
+        existing.amount_ils += numericToRequiredNumber(row.amount_ils);
+        existing.txn_count += 1;
+      } else {
+        summaryByKey.set(key, {
+          month,
+          category_slug: category.slug,
+          category_name: category.name,
+          category_name_he: category.name_he,
+          amount_ils: numericToRequiredNumber(row.amount_ils),
+          txn_count: 1,
+        });
+      }
+    }
+
+    if (rows.length < BATCH_SIZE) break;
+  }
+
+  const summary = [...summaryByKey.values()].sort(
+    (left, right) =>
+      right.month.localeCompare(left.month) || right.amount_ils - left.amount_ils,
+  );
+
+  return NextResponse.json(summary);
+}

--- a/apps/frontend/src/app/api/expenses/resolve/route.ts
+++ b/apps/frontend/src/app/api/expenses/resolve/route.ts
@@ -1,0 +1,311 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { normalizeMerchant, parseResolvePayload, type ResolvePayload } from "../_lib/expenses-route-helpers";
+import {
+  createExpensesWriteClient,
+  requireExpensesAuth,
+  type ExpensesSupabaseClient,
+} from "../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+interface TransactionResolveRow {
+  id: string;
+  merchant_raw: string;
+  merchant_normalized: string;
+  statement_id: string;
+}
+
+interface IdRow {
+  id: string;
+}
+
+interface MappingRow {
+  id: string;
+}
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  // TODO(CC-13): rate-limit POST /resolve to 10 req/sec per authenticated user.
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const parsed = parseResolvePayload(body);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const payload = {
+    ...parsed.payload,
+    transactionIds: [...new Set(parsed.payload.transactionIds)],
+  } satisfies ResolvePayload;
+  const writeSupabase = createExpensesWriteClient() ?? auth.supabase;
+
+  const categoryValidation = await validateCategories(auth.supabase, payload);
+  if (!categoryValidation.ok) return categoryValidation.response;
+
+  const { data: transactionsData, error: transactionsError } = await auth.supabase
+    .from("credit_card_transactions")
+    .select("id,merchant_raw,merchant_normalized,statement_id")
+    .eq("household_id", auth.householdId)
+    .in("id", payload.transactionIds);
+
+  if (transactionsError) {
+    console.error("[expenses] resolve transaction lookup failed", transactionsError.message);
+    return NextResponse.json({ error: "Failed to resolve transaction" }, { status: 500 });
+  }
+
+  const transactions = (transactionsData ?? []) as TransactionResolveRow[];
+  if (transactions.length !== payload.transactionIds.length) {
+    return NextResponse.json({ error: "Transaction not found" }, { status: 404 });
+  }
+
+  const firstStatementId = transactions[0]?.statement_id;
+
+  let mappingId = "";
+  if (payload.saveMapping) {
+    const merchants = distinctMerchants(transactions);
+    for (const merchant of merchants) {
+      const result = await upsertMerchantMapping(
+        writeSupabase,
+        auth.householdId,
+        auth.userId,
+        merchant,
+        payload,
+      );
+      if (!result.ok) {
+        return NextResponse.json(
+          { error: "Failed to save merchant mapping", statement_id: firstStatementId },
+          { status: 500 },
+        );
+      }
+      mappingId ||= result.mappingId;
+    }
+  }
+
+  const { data: updatedTargets, error: updateError } = await writeSupabase
+    .from("credit_card_transactions")
+    .update({
+      category_id: payload.categoryId,
+      subcategory_id: payload.subcategoryId,
+      resolution_status: "user_confirmed",
+      resolution_source: "user",
+    })
+    .eq("household_id", auth.householdId)
+    .in("id", payload.transactionIds)
+    .select("id");
+
+  if (updateError) {
+    console.error("[expenses] resolve target update failed", updateError.message);
+    return NextResponse.json(
+      { error: "Failed to resolve transaction", statement_id: firstStatementId },
+      { status: 500 },
+    );
+  }
+
+  let updatedCount = ((updatedTargets ?? []) as IdRow[]).length;
+  if (updatedCount !== payload.transactionIds.length) {
+    return NextResponse.json(
+      { error: "Failed to resolve transaction", statement_id: firstStatementId },
+      { status: 500 },
+    );
+  }
+
+  if (payload.applyToAllMatching && transactions.length === 1) {
+    const merchant = distinctMerchants(transactions)[0];
+    if (merchant) {
+      const matchingResult = await updateMatchingTransactions(
+        writeSupabase,
+        auth.householdId,
+        payload,
+        transactions[0].id,
+        merchant,
+      );
+      if (!matchingResult.ok) {
+        return NextResponse.json(
+          { error: "Failed to resolve matching transactions", statement_id: firstStatementId },
+          { status: 500 },
+        );
+      }
+      updatedCount += matchingResult.updatedCount;
+    }
+  }
+
+  return NextResponse.json({ updated_count: updatedCount, mapping_id: mappingId });
+}
+
+async function validateCategories(
+  supabase: ExpensesSupabaseClient,
+  payload: ResolvePayload,
+): Promise<{ ok: true } | { ok: false; response: NextResponse<{ error: string }> }> {
+  const { data: category, error: categoryError } = await supabase
+    .from("expense_categories")
+    .select("id")
+    .eq("id", payload.categoryId)
+    .maybeSingle();
+
+  if (categoryError) {
+    console.error("[expenses] resolve category lookup failed", categoryError.message);
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Failed to load category" }, { status: 500 }),
+    };
+  }
+  if (!category) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Category not found" }, { status: 404 }),
+    };
+  }
+
+  if (!payload.subcategoryId) return { ok: true };
+
+  const { data: subcategory, error: subcategoryError } = await supabase
+    .from("expense_categories")
+    .select("id")
+    .eq("id", payload.subcategoryId)
+    .maybeSingle();
+
+  if (subcategoryError) {
+    console.error("[expenses] resolve subcategory lookup failed", subcategoryError.message);
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Failed to load subcategory" }, { status: 500 }),
+    };
+  }
+  if (!subcategory) {
+    return {
+      ok: false,
+      response: NextResponse.json({ error: "Subcategory not found" }, { status: 404 }),
+    };
+  }
+
+  return { ok: true };
+}
+
+async function upsertMerchantMapping(
+  supabase: ExpensesSupabaseClient,
+  householdId: string,
+  userId: string,
+  merchantNormalized: string,
+  payload: ResolvePayload,
+): Promise<{ ok: true; mappingId: string } | { ok: false }> {
+  const { data: existingMapping, error: existingError } = await supabase
+    .from("merchant_category_mappings")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("merchant_normalized", merchantNormalized)
+    .eq("source", "user")
+    .maybeSingle();
+
+  if (existingError) {
+    console.error("[expenses] mapping lookup failed", existingError.message);
+    return { ok: false };
+  }
+
+  if (existingMapping) {
+    const { data, error } = await supabase
+      .from("merchant_category_mappings")
+      .update({
+        category_id: payload.categoryId,
+        subcategory_id: payload.subcategoryId,
+        created_by: userId,
+      })
+      .eq("household_id", householdId)
+      .eq("id", (existingMapping as MappingRow).id)
+      .select("id")
+      .maybeSingle();
+
+    if (error || !data) {
+      if (error) console.error("[expenses] mapping update failed", error.message);
+      return { ok: false };
+    }
+    return { ok: true, mappingId: (data as MappingRow).id };
+  }
+
+  const { data, error } = await supabase
+    .from("merchant_category_mappings")
+    .insert({
+      merchant_normalized: merchantNormalized,
+      household_id: householdId,
+      category_id: payload.categoryId,
+      subcategory_id: payload.subcategoryId,
+      confidence: 1,
+      source: "user",
+      created_by: userId,
+      match_count: 0,
+    })
+    .select("id")
+    .maybeSingle();
+
+  if (error || !data) {
+    if (error) console.error("[expenses] mapping insert failed", error.message);
+    return { ok: false };
+  }
+
+  return { ok: true, mappingId: (data as MappingRow).id };
+}
+
+async function updateMatchingTransactions(
+  supabase: ExpensesSupabaseClient,
+  householdId: string,
+  payload: ResolvePayload,
+  targetTransactionId: string,
+  merchantNormalized: string,
+): Promise<{ ok: true; updatedCount: number } | { ok: false }> {
+  const { data: matchingRows, error: matchingError } = await supabase
+    .from("credit_card_transactions")
+    .select("id")
+    .eq("household_id", householdId)
+    .eq("merchant_normalized", merchantNormalized)
+    .eq("resolution_status", "unresolved")
+    .is("category_id", null)
+    .neq("id", targetTransactionId);
+
+  if (matchingError) {
+    console.error("[expenses] matching transaction lookup failed", matchingError.message);
+    return { ok: false };
+  }
+
+  const matchingIds = ((matchingRows ?? []) as IdRow[]).map((row) => row.id);
+  if (matchingIds.length === 0) return { ok: true, updatedCount: 0 };
+
+  const { data: updatedRows, error: updateError } = await supabase
+    .from("credit_card_transactions")
+    .update({
+      category_id: payload.categoryId,
+      subcategory_id: payload.subcategoryId,
+      resolution_status: "user_confirmed",
+      resolution_source: "mapping",
+    })
+    .eq("household_id", householdId)
+    .in("id", matchingIds)
+    .select("id");
+
+  if (updateError) {
+    console.error("[expenses] matching transaction update failed", updateError.message);
+    return { ok: false };
+  }
+
+  return { ok: true, updatedCount: ((updatedRows ?? []) as IdRow[]).length };
+}
+
+function distinctMerchants(transactions: TransactionResolveRow[]): string[] {
+  return [
+    ...new Set(
+      transactions
+        .map((transaction) =>
+          transaction.merchant_normalized || normalizeMerchant(transaction.merchant_raw),
+        )
+        .filter((merchant) => merchant.length > 0),
+    ),
+  ];
+}

--- a/apps/frontend/src/app/api/expenses/statements/route.ts
+++ b/apps/frontend/src/app/api/expenses/statements/route.ts
@@ -1,0 +1,100 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import type { Statement } from "@/types/expenses";
+
+import {
+  DEFAULT_STATEMENTS_PAGE_SIZE,
+  normalizeSearch,
+  numericToNumber,
+  parseMonthRange,
+  parsePagination,
+} from "../_lib/expenses-route-helpers";
+import { requireExpensesAuth } from "../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+interface StatementRow {
+  id: string;
+  issuer: string;
+  cardholder_name: string;
+  card_last4: string;
+  period_from: string;
+  period_to: string;
+  total_amount_ils: string | number | null;
+  txn_count: number | null;
+  parse_warnings: unknown;
+  ingested_at: string;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  const searchParams = request.nextUrl.searchParams;
+  const pagination = parsePagination(searchParams, DEFAULT_STATEMENTS_PAGE_SIZE);
+  const monthRange = parseMonthRange(searchParams.get("from"), searchParams.get("to"));
+  if (!monthRange) {
+    return NextResponse.json({ error: "Invalid month filter" }, { status: 400 });
+  }
+
+  const cardholder = normalizeSearch(searchParams.get("cardholder"));
+  const issuer = normalizeSearch(searchParams.get("issuer"));
+
+  let countQuery = auth.supabase
+    .from("credit_card_statements")
+    .select("id", { count: "exact", head: true })
+    .eq("household_id", auth.householdId);
+  if (cardholder) countQuery = countQuery.ilike("cardholder_name", `%${cardholder}%`);
+  if (issuer) countQuery = countQuery.eq("issuer", issuer);
+  if (monthRange.fromDate) countQuery = countQuery.gte("period_from", monthRange.fromDate);
+  if (monthRange.toExclusiveDate) countQuery = countQuery.lt("period_from", monthRange.toExclusiveDate);
+
+  const { count, error: countError } = await countQuery;
+  if (countError) {
+    console.error("[expenses] statements count query failed", countError.message);
+    return NextResponse.json({ error: "Failed to load statements" }, { status: 500 });
+  }
+
+  let rowsQuery = auth.supabase
+    .from("credit_card_statements")
+    .select(
+      "id,issuer,cardholder_name,card_last4,period_from,period_to,total_amount_ils,txn_count,parse_warnings,ingested_at",
+    )
+    .eq("household_id", auth.householdId);
+  if (cardholder) rowsQuery = rowsQuery.ilike("cardholder_name", `%${cardholder}%`);
+  if (issuer) rowsQuery = rowsQuery.eq("issuer", issuer);
+  if (monthRange.fromDate) rowsQuery = rowsQuery.gte("period_from", monthRange.fromDate);
+  if (monthRange.toExclusiveDate) rowsQuery = rowsQuery.lt("period_from", monthRange.toExclusiveDate);
+
+  const { data, error } = await rowsQuery
+    .order("period_from", { ascending: false })
+    .order("id", { ascending: false })
+    .range(pagination.offset, pagination.offset + pagination.pageSize - 1);
+
+  if (error) {
+    console.error("[expenses] statements rows query failed", error.message);
+    return NextResponse.json({ error: "Failed to load statements" }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    items: ((data ?? []) as StatementRow[]).map(toStatement),
+    total: count ?? 0,
+    page: pagination.page,
+    page_size: pagination.pageSize,
+  });
+}
+
+function toStatement(row: StatementRow): Statement {
+  return {
+    id: row.id,
+    issuer: row.issuer,
+    cardholder_name: row.cardholder_name,
+    card_last4: row.card_last4,
+    period_from: row.period_from,
+    period_to: row.period_to,
+    total_amount_ils: numericToNumber(row.total_amount_ils),
+    txn_count: row.txn_count,
+    parse_warnings_count: Array.isArray(row.parse_warnings) ? row.parse_warnings.length : 0,
+    ingested_at: row.ingested_at,
+  };
+}

--- a/apps/frontend/src/app/api/expenses/unresolved/route.ts
+++ b/apps/frontend/src/app/api/expenses/unresolved/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import type { UnresolvedTransaction } from "@/types/expenses";
+
+import {
+  DEFAULT_UNRESOLVED_PAGE_SIZE,
+  normalizeSearch,
+  numericToNumber,
+  numericToRequiredNumber,
+  parsePagination,
+} from "../_lib/expenses-route-helpers";
+import { requireExpensesAuth } from "../_lib/expenses-server";
+
+export const dynamic = "force-dynamic";
+
+interface UnresolvedTransactionRow {
+  id: string;
+  txn_date: string;
+  merchant_raw: string;
+  merchant_normalized: string;
+  amount_ils: string | number;
+  original_currency: string | null;
+  amount_original: string | number | null;
+  sector_raw: string | null;
+  statement_id: string;
+}
+
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireExpensesAuth();
+  if (!auth.ok) return auth.response;
+
+  const searchParams = request.nextUrl.searchParams;
+  const pagination = parsePagination(searchParams, DEFAULT_UNRESOLVED_PAGE_SIZE);
+  const search = normalizeSearch(searchParams.get("search"));
+
+  let countQuery = auth.supabase
+    .from("credit_card_transactions")
+    .select("id", { count: "exact", head: true })
+    .eq("household_id", auth.householdId)
+    .is("category_id", null);
+
+  if (search) countQuery = countQuery.ilike("merchant_raw", `%${search}%`);
+
+  const { count, error: countError } = await countQuery;
+  if (countError) {
+    console.error("[expenses] unresolved count query failed", countError.message);
+    return NextResponse.json({ error: "Failed to load unresolved transactions" }, { status: 500 });
+  }
+
+  let rowsQuery = auth.supabase
+    .from("credit_card_transactions")
+    .select(
+      "id,txn_date,merchant_raw,merchant_normalized,amount_ils,original_currency,amount_original,sector_raw,statement_id",
+    )
+    .eq("household_id", auth.householdId)
+    .is("category_id", null);
+
+  if (search) rowsQuery = rowsQuery.ilike("merchant_raw", `%${search}%`);
+
+  const { data, error } = await rowsQuery
+    .order("txn_date", { ascending: false })
+    .order("id", { ascending: false })
+    .range(pagination.offset, pagination.offset + pagination.pageSize - 1);
+  if (error) {
+    console.error("[expenses] unresolved rows query failed", error.message);
+    return NextResponse.json({ error: "Failed to load unresolved transactions" }, { status: 500 });
+  }
+
+  const items = ((data ?? []) as UnresolvedTransactionRow[]).map(toUnresolvedTransaction);
+
+  return NextResponse.json({
+    items,
+    total: count ?? 0,
+    page: pagination.page,
+    page_size: pagination.pageSize,
+  });
+}
+
+function toUnresolvedTransaction(row: UnresolvedTransactionRow): UnresolvedTransaction {
+  return {
+    id: row.id,
+    txn_date: row.txn_date,
+    merchant_raw: row.merchant_raw,
+    merchant_normalized: row.merchant_normalized,
+    amount_ils: numericToRequiredNumber(row.amount_ils),
+    original_currency: row.original_currency,
+    amount_original: numericToNumber(row.amount_original),
+    sector_raw: row.sector_raw,
+    statement_id: row.statement_id,
+  };
+}


### PR DESCRIPTION
## Summary

Production `/finances/expenses` was down because the frontend calls `/api/expenses/...` relative to the Vercel origin, but no Next.js Route Handlers existed there. The FastAPI implementation owns the canonical behavior but is only deployed locally via Docker, so production received 404s.

This PR ports the six FastAPI expense endpoints to Supabase-direct Next.js Route Handlers:

- `GET /api/expenses/categories` → category taxonomy tree from `expense_categories`
- `GET /api/expenses/monthly-summary` → month × category aggregation, defaulting to transfer exclusion
- `GET /api/expenses/unresolved` → paginated unresolved transaction queue
- `GET /api/expenses/by-category/[slug]` → category drill-down with subtotal
- `GET /api/expenses/statements` → paginated statement list
- `POST /api/expenses/resolve` → categorize selected transactions and optionally save/apply merchant mappings

Each handler authenticates with the request-scoped Supabase server client, resolves the active household via `household_members`, and keeps explicit `household_id` filters on household-scoped queries. Decimal NUMERIC values are converted to JSON numbers to match the existing frontend contracts.

Working as Hockney (Backend Developer).

## Notes

Kujan is fixing the production migration story in a separate PR (`SUPABASE_PROD_DB_URL` workflow fix + applying credit-card migrations). This PR fixes the missing-handler 404 cause; the page can still 500 until the expense tables/seed data exist in production.

## Validation

- `cd apps/frontend && npm test -- --run src/app/finances/expenses src/app/api/expenses/_lib/expenses-route-helpers.test.ts` ✅ 37 tests passed
- `cd apps/frontend && npx eslint src/app/api/expenses` ✅
- `cd apps/frontend && npx tsc --noEmit 2>&1 | grep 'src/app/api/expenses' || true` ✅ no expense-route type errors\n- `cd apps/frontend && npm test` ⚠️ fails in unrelated existing suites: dividend TTM expectations and SettingsContext default optionsGrowthRate\n- `cd apps/frontend && npx tsc --noEmit` ⚠️ fails in unrelated pre-existing e2e/test/component type errors; no errors under `src/app/api/expenses`\n\n## Decision note\n\nAdded `.squad/decisions/inbox/hockney-expenses-handlers-2026-05-29.md` documenting Supabase-direct Route Handlers over a FastAPI proxy.