### PR TITLE
feat(expenses): add Transportation taxonomy (fuel, insurance, maintenance, registration, public transit)

### DIFF
--- a/.squad/decisions/inbox/mcmanus-transportation-taxonomy-2026-05-30.md
+++ b/.squad/decisions/inbox/mcmanus-transportation-taxonomy-2026-05-30.md
@@ -1,0 +1,26 @@
+# Transportation taxonomy split — 2026-05-30
+
+## Decision
+
+Split Transportation / תחבורה (daily commute and vehicle costs) from Travel (vacations, flights, hotels) as a top-level expense concern.
+
+## Rationale
+
+Israeli household budgeting treats commute, fuel, car insurance, maintenance, vehicle registration, and public transport as recurring daily-life costs. Those planning signals are distinct from vacation/travel spend such as flights and hotels.
+
+## UUID-preserving reparenting
+
+- `fuel` → `transportation-fuel`
+- `travel-transit` → `transportation-public-transit`
+
+The migration updates existing rows instead of deleting/reinserting them, preserving category UUIDs for historical transactions and merchant mappings.
+
+## Added categories
+
+- `transportation-insurance`
+- `transportation-maintenance`
+- `transportation-registration`
+
+## Migration workflow
+
+The PR commit includes `[apply-migrations]`, so Kujan's Supabase migration workflow auto-applies the data migration after merge.

--- a/apps/backend/app/services/expenses/categorize.py
+++ b/apps/backend/app/services/expenses/categorize.py
@@ -60,7 +60,10 @@ _DEFAULT_RULE_WEIGHT = 0.5
 # Cal and Isracard include a Hebrew ענף (sector) field on domestic transactions.
 # These strings are matched as substrings (case-insensitive) against sector_raw.
 # ~18 entries covering all common Israeli CC sectors.
-_SECTOR_TO_SLUG: dict[str, str] = {
+CategoryTarget = str | tuple[str, str]
+
+
+_SECTOR_TO_SLUG: dict[str, CategoryTarget] = {
     # Insurance (ביטוח → extracted חוטיב)
     "חוטיב": "financial-insurance",
     # Food / Groceries (מזון → ןוזמ; אוכל → לכוא)
@@ -69,8 +72,8 @@ _SECTOR_TO_SLUG: dict[str, str] = {
     # Restaurants / Cafés (מסעדות → תודעסמ; קפה → הפק)
     "תודעסמ": "restaurants",
     "הפק": "restaurants",
-    # Fuel (דלק → קלד)
-    "קלד": "fuel",
+    # MIGRATED: fuel → transportation-fuel (2026-05-30)
+    "קלד": ("transportation", "transportation-fuel"),
     # Communications / Utilities (תקשורת → תרושקת)
     "תרושקת": "utilities",
     # Clothing (הלבשה → השבלה)
@@ -83,7 +86,7 @@ _SECTOR_TO_SLUG: dict[str, str] = {
     # Leisure / Entertainment (פנאי → יאנפ)
     "יאנפ": "travel",
     # Auto / Garage (מכונאית → תיאנוכמ)
-    "תיאנוכמ": "travel",
+    "תיאנוכמ": ("transportation", "transportation-maintenance"),
     # Education (חינוך → ךוניח)
     "ךוניח": "kids-education",
     # Shopping (קניות → תויינק)
@@ -431,20 +434,25 @@ class CategoryResolver:
         order = Hebrew common-sector priority order).
         """
         sector_lower = sector_raw.lower()
-        for sector_key, slug in _SECTOR_TO_SLUG.items():
+        for sector_key, target in _SECTOR_TO_SLUG.items():
             if sector_key.lower() in sector_lower:
-                cat_id = slug_map.get(slug)
-                if cat_id is None:
+                if isinstance(target, tuple):
+                    category_slug, subcategory_slug = target
+                else:
+                    category_slug, subcategory_slug = target, None
+                cat_id = slug_map.get(category_slug)
+                subcat_id = slug_map.get(subcategory_slug) if subcategory_slug is not None else None
+                if cat_id is None or (subcategory_slug is not None and subcat_id is None):
                     # Slug not in DB yet — skip this sector hit
                     logger.debug(
                         "Sector key '%s' → slug '%s' not found in DB categories",
                         sector_key,
-                        slug,
+                        target,
                     )
                     continue
                 return CategoryAssignment(
                     category_id=cat_id,
-                    subcategory_id=None,
+                    subcategory_id=subcat_id,
                     resolution_status="auto",
                     resolution_source="sector",
                     is_transfer=False,

--- a/apps/backend/app/services/expenses/category_rules.yaml
+++ b/apps/backend/app/services/expenses/category_rules.yaml
@@ -328,19 +328,6 @@ categories:
           - pattern: "לדז|ןוינח"
             weight: 0.85
 
-      - slug: travel-transit
-        name: Public Transit & Licensing
-        name_he: תחבורה ציבורית ורישוי
-        display_order: 4
-        rules:
-          # Ministry of Transport — license renewal (₪1,770 seen on Jony's card)
-          # Extracted: הרובחתה דרשמ (reversed משרד התחבורה)
-          - pattern: "הרובחתה\\s*דרשמ"
-            weight: 0.9
-          # Israeli train / bus
-          - pattern: "לארשי\\s*תבכר|רכבת|אגד|רב.קו|metrodan|hopon"
-            weight: 0.8
-
   # ── 6. SHOPPING ────────────────────────────────────────────────────────────
   - slug: shopping
     name: Shopping
@@ -494,12 +481,9 @@ categories:
       # Apple subscription charges
       - pattern: "apple\\.com/bill|apple.*subscription"
         weight: 0.8
-      # Klemobil insurance agency (כלמוביל → reversed ליבומלכ). Recurring installments.
-      - pattern: "ליבומלכ"
-        weight: 0.85
-      # Generic insurance sector marker (ביטוח → reversed חוטיב)
+      # Generic insurance sector marker (ביטוח → reversed חוטיב); vehicle-specific insurance is Transportation.
       - pattern: "חוטיב"
-        weight: 0.6
+        weight: 0.45
       # Bank fee generic
       - pattern: "(הלמע|bank.*fee|card.*fee)"
         weight: 0.5
@@ -509,19 +493,9 @@ categories:
         name_he: ביטוח
         display_order: 1
         rules:
-          # Klemobil insurance agency — recurring 5-installment policies
-          - pattern: "ליבומלכ"
-            weight: 0.95
-          # Alon insurance (ביטוח אילון → reversed ןולייא חוטיב)
-          - pattern: "ןולייא\\s*חוטיב|חוטיב\\s*ןולייא"
-            weight: 0.9
-          # Mandatory vehicle insurance (רכב חובה → reversed הבוח בכר)
-          - pattern: "הבוח\\s*בכר|יאלקח\\s*חוטיב|ירטנמלא\\s*חוטיב"
-            weight: 0.9
-          # Generic insurance
-          - pattern: "חוטיב|insurance|harel|הראל|migdal|לדגמ|menorah|הרונמ|clal|ללכ|phoenix|סינקפ"
-            weight: 0.6
-
+          # Generic non-vehicle insurance. Car insurance lives under Transportation.
+          - pattern: "חוטיב|insurance|life\\s*insurance|health\\s*insurance|home\\s*insurance|יאלקח\\s*חוטיב|ירטנמלא\\s*חוטיב"
+            weight: 0.7
       - slug: financial-government
         name: Government & Municipal
         name_he: ממשלה ועירייה
@@ -533,9 +507,9 @@ categories:
           # Municipality
           - pattern: "תייריע|arnona|ארנונה"
             weight: 0.85
-          # Ministry of Transport (already in travel.transit but can cross-match)
-          - pattern: "הרובחתה\\s*דרשמ"
-            weight: 0.5
+          # Government payments not otherwise classified by Transportation Registration.
+          - pattern: "gov\\.il|government"
+            weight: 0.35
 
       - slug: financial-fees
         name: Bank & Card Fees
@@ -545,32 +519,88 @@ categories:
           - pattern: "(הלמע|bank.*charge|card.*fee|annual.*fee)"
             weight: 0.8
 
-  # ── 9. FUEL ────────────────────────────────────────────────────────────────
-  - slug: fuel
-    name: Fuel
-    name_he: דלק
-    icon: gas-pump
-    color: "#F44336"
+  # ── 9. TRANSPORTATION ──────────────────────────────────────────────────────
+  # Daily commute and vehicle costs. Vacations stay under Travel.
+  # MIGRATED: fuel → transportation-fuel; travel-transit → transportation-public-transit (2026-05-30)
+  - slug: transportation
+    name: Transportation
+    name_he: תחבורה
+    icon: car
+    color: "#FF5722"
     display_order: 9
     rules:
-      # Naimi fuel station — seen on Jony's Isracard (₪20 and ₪286 charges)
-      # Extracted: הקימ קלד תנחת דיינ (reversed ניד תחנת דלק מיקה)
-      # "קלד" = reversed "דלק" (fuel) — reliable marker for fuel stations in extracted text
-      - pattern: "קלד\\s*תנחת|דיינ.*קלד"
-        weight: 0.9
-      # Dor Alon (דור אלון → reversed ןולא רוד)
-      - pattern: "ןולא\\s*רוד|dor.alon"
-        weight: 0.9
-      # Paz (פז → reversed זפ)
-      - pattern: "\\bזפ\\b|\\bpaz\\b"
-        weight: 0.9
-      # Sonol (סונול → reversed לונוס)
-      - pattern: "לונוס|sonol"
-        weight: 0.9
-      # Delek (דלק → reversed קלד) — general fuel marker
-      - pattern: "\\bקלד\\b|\\bdelek\\b|gas\\s*station|fuel"
-        weight: 0.7
-    subcategories: []
+      # Generic commute / vehicle fallback. Hebrew RTL: תחבורה → הרובחת; רכב → בכר.
+      - pattern: "transport|commute|vehicle|car|תחבורה|הרובחת|רכב|בכר"
+        weight: 0.55
+    subcategories:
+      - slug: transportation-fuel
+        name: Fuel
+        name_he: דלק
+        display_order: 1
+        rules:
+          # Naimi fuel station — seen on Jony's Isracard (₪20 and ₪286 charges)
+          # Extracted: הקימ קלד תנחת דיינ (reversed ניד תחנת דלק מיקה)
+          # "קלד" = reversed "דלק" (fuel) — reliable marker for fuel stations in extracted text
+          - pattern: "קלד\\s*תנחת|דיינ.*קלד"
+            weight: 0.96
+          # Dor Alon (דור אלון → reversed ןולא רוד)
+          - pattern: "ןולא\\s*רוד|dor.alon"
+            weight: 0.95
+          # Paz (פז → reversed זפ)
+          - pattern: "\\bזפ\\b|\\bpaz\\b"
+            weight: 0.95
+          # Sonol (סונול → reversed לונוס)
+          - pattern: "לונוס|sonol"
+            weight: 0.95
+          # Delek (דלק → reversed קלד) — general fuel marker
+          - pattern: "\\bקלד\\b|\\bdelek\\b|gas\\s*station|fuel"
+            weight: 0.85
+
+      - slug: transportation-public-transit
+        name: Public Transport
+        name_he: תחבורה ציבורית
+        display_order: 2
+        rules:
+          # Hebrew RTL: רב-קו → וק-בר; אגד → דגא; רכבת ישראל → לארשי תבכר
+          - pattern: "rav\\s*kav|וק\\s*-?\\s*בר|egg?ed|דגא|dan\\s*bus|אוטובוס|סובוטוא|bus|rail|train|תבכר|לארשי\\s*תבכר|metrodan|hopon"
+            weight: 0.95
+
+      - slug: transportation-insurance
+        name: Car Insurance
+        name_he: ביטוח רכב
+        display_order: 3
+        rules:
+          # Hebrew RTL: ביטוח רכב → בכר חוטיב; רכב חובה → הבוח בכר
+          - pattern: "car\\s*insurance|vehicle\\s*insurance|auto\\s*insurance|בכר\\s*חוטיב|הבוח\\s*בכר"
+            weight: 0.97
+          # Hebrew RTL: מגדל → לדגמ; הראל → לארה; הפניקס → סקינפה; כלל → ללכ
+          - pattern: "migdal|לדגמ|harel|לארה|phoenix|סקינפה|clal|ללכ"
+            weight: 0.88
+          # Hebrew RTL: מנורה → הרונמ; שומרה → הרמוש; כלמוביל → ליבומלכ; אילון → ןולייא
+          - pattern: "menora|menorah|הרונמ|aig|shomera|הרמוש|klemobil|ליבומלכ|ayalon|ןולייא"
+            weight: 0.88
+
+      - slug: transportation-maintenance
+        name: Car Maintenance
+        name_he: תחזוקת רכב
+        display_order: 4
+        rules:
+          # Hebrew RTL: מוסך → כסומ; מר צמיג → גימצ רמ; סיכה → הכיס
+          - pattern: "garage|mechanic|auto\\s*repair|car\\s*service|כסומ|גימצ\\s*רמ|הכיס"
+            weight: 0.96
+          - pattern: "esco|universal\\s*motors|mr\\s*tire|goodyear|mobileye|oil\\s*change|lubrication"
+            weight: 0.9
+
+      - slug: transportation-registration
+        name: Vehicle Registration
+        name_he: רישוי רכב
+        display_order: 5
+        rules:
+          # Hebrew RTL: משרד הרישוי → יושירה דרשמ; משרד התחבורה → הרובחתה דרשמ
+          - pattern: "יושירה\\s*דרשמ|הרובחתה\\s*דרשמ|רישוי|יושיר|ןוישיר|מבחן\\s*רכב|בכר\\s*ןחבמ"
+            weight: 0.97
+          - pattern: "vehicle\\s*registration|car\\s*registration|licen[cs]e|mot\\b|rishui|transport.*gov\\.il|vehicle.*gov\\.il|rechev.*gov\\.il|רכב\\.gov\\.il"
+            weight: 0.92
 
   # ── 10. TRANSFERS ──────────────────────────────────────────────────────────
   - slug: transfers

--- a/apps/backend/tests/credit_card_pipeline/helpers.py
+++ b/apps/backend/tests/credit_card_pipeline/helpers.py
@@ -53,7 +53,8 @@ _CATEGORY_SEED = [
     ("shopping", None, False),
     ("kids-education", None, False),
     ("financial", None, False),
-    ("fuel", None, False),
+    # MIGRATED: fuel → transportation-fuel (2026-05-30)
+    ("transportation", None, False),
     ("transfers", None, True),
     ("other", None, False),
     # health subcategories
@@ -76,7 +77,12 @@ _CATEGORY_SEED = [
     ("travel-flights", "travel", False),
     ("travel-hotels", "travel", False),
     ("travel-parking", "travel", False),
-    ("travel-transit", "travel", False),
+    # transportation subcategories
+    ("transportation-fuel", "transportation", False),
+    ("transportation-public-transit", "transportation", False),
+    ("transportation-insurance", "transportation", False),
+    ("transportation-maintenance", "transportation", False),
+    ("transportation-registration", "transportation", False),
     # shopping subcategories
     ("shopping-clothing", "shopping", False),
     ("shopping-electronics", "shopping", False),
@@ -88,7 +94,6 @@ _CATEGORY_SEED = [
     # transfers subcategories
     ("transfers-paybox", "transfers", True),
     ("transfers-family", "transfers", True),
-    # fuel has no subcategories
     # groceries has no subcategories
 ]
 

--- a/apps/backend/tests/credit_card_pipeline/test_plan_scaffold.py
+++ b/apps/backend/tests/credit_card_pipeline/test_plan_scaffold.py
@@ -473,6 +473,55 @@ def test_categorization_no_sector_yaml_rule_fires(
     assert result.is_transfer is False
 
 
+def test_categorization_transportation_fuel_sector_resolves_subcategory(
+    seeded_session: tuple,
+) -> None:
+    """Transportation regression: sector דלק (extracted קלד) → Fuel.
+
+    MIGRATED: fuel → transportation-fuel (2026-05-30). Fuel sector matches now
+    populate the top-level Transportation category and the Fuel subcategory.
+    """
+    session, slug_map = seeded_session
+    txn = _SyntheticTxn(merchant_normalized="UNKNOWN", sector_raw="קלד")
+    resolver = CategoryResolver()
+    from uuid import UUID
+
+    hh_id = UUID("00000000-0000-0000-0000-000000000101")
+    result = resolver.resolve(txn, session, hh_id)
+
+    assert result.resolution_status == "auto"
+    assert result.resolution_source == "sector"
+    assert result.category_id == slug_map["transportation"]
+    assert result.subcategory_id == slug_map["transportation-fuel"]
+
+
+def test_categorization_transportation_yaml_rules_split_commute_from_travel(
+    seeded_session: tuple,
+) -> None:
+    """Transportation regression: commute merchants classify outside Travel."""
+    session, slug_map = seeded_session
+    resolver = CategoryResolver()
+    from uuid import UUID
+
+    hh_id = UUID("00000000-0000-0000-0000-000000000101")
+
+    public_transit = resolver.resolve(
+        _SyntheticTxn(merchant_normalized="לארשי תבכר", sector_raw=None),
+        session,
+        hh_id,
+    )
+    registration = resolver.resolve(
+        _SyntheticTxn(merchant_normalized="הרובחתה דרשמ", sector_raw=None),
+        session,
+        hh_id,
+    )
+
+    assert public_transit.category_id == slug_map["transportation"]
+    assert public_transit.subcategory_id == slug_map["transportation-public-transit"]
+    assert registration.category_id == slug_map["transportation"]
+    assert registration.subcategory_id == slug_map["transportation-registration"]
+
+
 def test_categorization_both_fail_lands_unresolved(
     seeded_session: tuple,
 ) -> None:
@@ -1466,8 +1515,9 @@ def test_api_by_category_month_filter(client: TestClient, seeded_session: tuple)
 # COVERED-BY-E2E: e2e/expenses/08-empty-states.spec.ts — "by-category empty for selected month → 'אין נתונים לחודש זה'"
 def test_api_by_category_empty_category_returns_zero_subtotal(client: TestClient, seeded_session: tuple) -> None:
     """A-CAT-3: Category with no transactions → empty list, subtotal=0.0, no crash."""
-    # 'fuel' is seeded but no transactions added for it
-    resp = client.get("/api/expenses/by-category/fuel")
+    # MIGRATED: fuel → transportation-fuel (2026-05-30)
+    # 'transportation' is seeded but no transactions added for it
+    resp = client.get("/api/expenses/by-category/transportation")
     assert resp.status_code == 200
 
     body = resp.json()

--- a/apps/frontend/e2e/expenses/03-by-category.spec.ts
+++ b/apps/frontend/e2e/expenses/03-by-category.spec.ts
@@ -62,7 +62,7 @@ authTest.describe('@expenses 03 — By Category tab', () => {
     const categoryList = page.getByRole('list', { name: 'רשימת קטגוריות' });
     await expect(categoryList).toBeVisible({ timeout: 10_000 });
 
-    // The fixture has groceries, restaurants, health, fuel, shopping for 2026-05
+    // The fixture has groceries, restaurants, health, transportation, and shopping across months.
     // The page defaults to current month (2026-05 hardcoded in the component)
     const listItems = categoryList.getByRole('listitem');
     const count = await listItems.count();

--- a/apps/frontend/e2e/fixtures/expenses.ts
+++ b/apps/frontend/e2e/fixtures/expenses.ts
@@ -29,7 +29,8 @@ export const monthlySummaryFixture: MonthlySummaryRow[] = [
   // 2026-04
   { month: '2026-04', category_slug: 'groceries',   category_name: 'Groceries',   category_name_he: 'מזון וסופרמרקט',      amount_ils: 2100.75, txn_count: 14 },
   { month: '2026-04', category_slug: 'restaurants',  category_name: 'Restaurants', category_name_he: 'מסעדות ומשלוחים',     amount_ils: 480.00,  txn_count: 4  },
-  { month: '2026-04', category_slug: 'fuel',         category_name: 'Fuel',        category_name_he: 'דלק',                 amount_ils: 390.00,  txn_count: 2  },
+  // MIGRATED: fuel → transportation-fuel (2026-05-30)
+  { month: '2026-04', category_slug: 'transportation', category_name: 'Transportation', category_name_he: 'תחבורה',                 amount_ils: 390.00,  txn_count: 2  },
 
   // 2026-05
   { month: '2026-05', category_slug: 'groceries',   category_name: 'Groceries',   category_name_he: 'מזון וסופרמרקט',      amount_ils: 1990.25, txn_count: 13 },

--- a/apps/frontend/src/types/expenses.ts
+++ b/apps/frontend/src/types/expenses.ts
@@ -185,7 +185,6 @@ export const EXPENSE_CATEGORIES: ExpenseCategory[] = [
       { id: "cat-travel-flights", slug: "travel-flights", name: "Flights", name_he: "טיסות", parent_slug: "travel" },
       { id: "cat-travel-hotels", slug: "travel-hotels", name: "Hotels", name_he: "מלונות ולינה", parent_slug: "travel" },
       { id: "cat-travel-parking", slug: "travel-parking", name: "Parking", name_he: "חניון ופנגו", parent_slug: "travel" },
-      { id: "cat-travel-transit", slug: "travel-transit", name: "Transit", name_he: "תחבורה ציבורית ורישוי", parent_slug: "travel" },
     ],
   },
   {
@@ -228,15 +227,22 @@ export const EXPENSE_CATEGORIES: ExpenseCategory[] = [
       { id: "cat-financial-insurance", slug: "financial-insurance", name: "Insurance", name_he: "ביטוח", parent_slug: "financial" },
     ],
   },
+  // MIGRATED: fuel → transportation-fuel; travel-transit → transportation-public-transit (2026-05-30)
   {
-    id: "cat-fuel",
-    slug: "fuel",
-    name: "Fuel",
-    name_he: "דלק",
-    color: "#F44336",
-    icon: "fuel",
+    id: "cat-transportation",
+    slug: "transportation",
+    name: "Transportation",
+    name_he: "תחבורה",
+    color: "#FF5722",
+    icon: "car",
     is_transfer: false,
-    subcategories: [],
+    subcategories: [
+      { id: "cat-transportation-fuel", slug: "transportation-fuel", name: "Fuel", name_he: "דלק", parent_slug: "transportation" },
+      { id: "cat-transportation-public-transit", slug: "transportation-public-transit", name: "Public Transport", name_he: "תחבורה ציבורית", parent_slug: "transportation" },
+      { id: "cat-transportation-insurance", slug: "transportation-insurance", name: "Car Insurance", name_he: "ביטוח רכב", parent_slug: "transportation" },
+      { id: "cat-transportation-maintenance", slug: "transportation-maintenance", name: "Car Maintenance", name_he: "תחזוקת רכב", parent_slug: "transportation" },
+      { id: "cat-transportation-registration", slug: "transportation-registration", name: "Vehicle Registration", name_he: "רישוי רכב", parent_slug: "transportation" },
+    ],
   },
   {
     id: "cat-transfers",

--- a/supabase/migrations/20260530055800_add_transportation_category.sql
+++ b/supabase/migrations/20260530055800_add_transportation_category.sql
@@ -1,0 +1,222 @@
+-- =============================================================================
+-- Add Transportation expense taxonomy
+-- =============================================================================
+-- Split daily commute / vehicle costs from Travel (vacations, flights, hotels).
+-- UUID-preserving restructure:
+--   - fuel -> transportation-fuel
+--   - travel-transit -> transportation-public-transit
+-- Also backfills existing transaction / merchant mappings so historical rows now
+-- resolve to Transportation > Fuel or Transportation > Public Transport.
+
+begin;
+
+-- New top-level Transportation parent (occupies the display slot formerly held by Fuel).
+insert into public.expense_categories (
+    id,
+    parent_id,
+    slug,
+    name,
+    name_he,
+    icon,
+    color,
+    display_order
+)
+values (
+    gen_random_uuid(),
+    null,
+    'transportation',
+    'Transportation',
+    'תחבורה',
+    'car',
+    '#FF5722',
+    9
+)
+on conflict (slug) do nothing;
+
+update public.expense_categories
+set
+    parent_id = null,
+    name = 'Transportation',
+    name_he = 'תחבורה',
+    icon = 'car',
+    color = '#FF5722',
+    display_order = 9
+where slug = 'transportation';
+
+-- MIGRATED: fuel → transportation-fuel (2026-05-30)
+-- Preserve the existing Fuel UUID so prior categorizations remain attached.
+update public.expense_categories
+set
+    parent_id = (select id from public.expense_categories where slug = 'transportation'),
+    slug = 'transportation-fuel',
+    name = 'Fuel',
+    name_he = 'דלק',
+    icon = 'gas-pump',
+    color = '#FF5722',
+    display_order = 1
+where slug = 'fuel'
+  and not exists (
+      select 1
+      from public.expense_categories
+      where slug = 'transportation-fuel'
+  );
+
+update public.expense_categories
+set
+    parent_id = (select id from public.expense_categories where slug = 'transportation'),
+    name = 'Fuel',
+    name_he = 'דלק',
+    icon = 'gas-pump',
+    color = '#FF5722',
+    display_order = 1
+where slug = 'transportation-fuel';
+
+-- MIGRATED: travel-transit → transportation-public-transit (2026-05-30)
+-- Preserve the existing Public Transit UUID while moving licensing to Registration.
+update public.expense_categories
+set
+    parent_id = (select id from public.expense_categories where slug = 'transportation'),
+    slug = 'transportation-public-transit',
+    name = 'Public Transport',
+    name_he = 'תחבורה ציבורית',
+    icon = 'bus',
+    color = '#FF5722',
+    display_order = 2
+where slug = 'travel-transit'
+  and not exists (
+      select 1
+      from public.expense_categories
+      where slug = 'transportation-public-transit'
+  );
+
+update public.expense_categories
+set
+    parent_id = (select id from public.expense_categories where slug = 'transportation'),
+    name = 'Public Transport',
+    name_he = 'תחבורה ציבורית',
+    icon = 'bus',
+    color = '#FF5722',
+    display_order = 2
+where slug = 'transportation-public-transit';
+
+-- New Transportation subcategories.
+insert into public.expense_categories (
+    id,
+    parent_id,
+    slug,
+    name,
+    name_he,
+    icon,
+    color,
+    display_order
+)
+select
+    gen_random_uuid(),
+    parent.id,
+    new_category.slug,
+    new_category.name,
+    new_category.name_he,
+    new_category.icon,
+    '#FF5722',
+    new_category.display_order
+from public.expense_categories parent
+cross join (
+    values
+        ('transportation-insurance', 'Car Insurance', 'ביטוח רכב', 'shield', 3),
+        ('transportation-maintenance', 'Car Maintenance', 'תחזוקת רכב', 'wrench', 4),
+        ('transportation-registration', 'Vehicle Registration', 'רישוי רכב', 'clipboard-check', 5)
+) as new_category(slug, name, name_he, icon, display_order)
+where parent.slug = 'transportation'
+on conflict (slug) do nothing;
+
+update public.expense_categories category
+set
+    parent_id = parent.id,
+    name = new_category.name,
+    name_he = new_category.name_he,
+    icon = new_category.icon,
+    color = '#FF5722',
+    display_order = new_category.display_order
+from public.expense_categories parent
+join (
+    values
+        ('transportation-insurance', 'Car Insurance', 'ביטוח רכב', 'shield', 3),
+        ('transportation-maintenance', 'Car Maintenance', 'תחזוקת רכב', 'wrench', 4),
+        ('transportation-registration', 'Vehicle Registration', 'רישוי רכב', 'clipboard-check', 5)
+) as new_category(slug, name, name_he, icon, display_order) on true
+where parent.slug = 'transportation'
+  and category.slug = new_category.slug;
+
+-- Backfill existing rows that previously used Fuel as a top-level category.
+with transportation_ids as (
+    select
+        (select id from public.expense_categories where slug = 'transportation')
+            as transportation_id,
+        (select id from public.expense_categories where slug = 'transportation-fuel')
+            as fuel_id
+)
+update public.credit_card_transactions txn
+set
+    category_id = transportation_ids.transportation_id,
+    subcategory_id = transportation_ids.fuel_id
+from transportation_ids
+where txn.category_id = transportation_ids.fuel_id
+  and transportation_ids.transportation_id is not null
+  and transportation_ids.fuel_id is not null;
+
+with transportation_ids as (
+    select
+        (select id from public.expense_categories where slug = 'transportation')
+            as transportation_id,
+        (select id from public.expense_categories where slug = 'transportation-fuel')
+            as fuel_id
+)
+update public.merchant_category_mappings mapping
+set
+    category_id = transportation_ids.transportation_id,
+    subcategory_id = transportation_ids.fuel_id
+from transportation_ids
+where mapping.category_id = transportation_ids.fuel_id
+  and transportation_ids.transportation_id is not null
+  and transportation_ids.fuel_id is not null;
+
+-- Backfill existing rows that previously used Travel > Public Transit & Licensing.
+with transportation_ids as (
+    select
+        (select id from public.expense_categories where slug = 'transportation')
+            as transportation_id,
+        (select id from public.expense_categories where slug = 'transportation-public-transit')
+            as public_transit_id
+)
+update public.credit_card_transactions txn
+set
+    category_id = transportation_ids.transportation_id,
+    subcategory_id = transportation_ids.public_transit_id
+from transportation_ids
+where (
+        txn.category_id = transportation_ids.public_transit_id
+        or txn.subcategory_id = transportation_ids.public_transit_id
+    )
+  and transportation_ids.transportation_id is not null
+  and transportation_ids.public_transit_id is not null;
+
+with transportation_ids as (
+    select
+        (select id from public.expense_categories where slug = 'transportation')
+            as transportation_id,
+        (select id from public.expense_categories where slug = 'transportation-public-transit')
+            as public_transit_id
+)
+update public.merchant_category_mappings mapping
+set
+    category_id = transportation_ids.transportation_id,
+    subcategory_id = transportation_ids.public_transit_id
+from transportation_ids
+where (
+        mapping.category_id = transportation_ids.public_transit_id
+        or mapping.subcategory_id = transportation_ids.public_transit_id
+    )
+  and transportation_ids.transportation_id is not null
+  and transportation_ids.public_transit_id is not null;
+
+commit;


### PR DESCRIPTION
## Summary

Working as McManus (Data/Finance Developer).

Jony requested: “I'm missing a category for Transportation / תחבורה which includes fuel, car insurance, car maintenance, registrations, public transport. These are expenses around transportation to work, and daily commute. This is different from the \"Travel\" category which is around travels and vacations - flights, hotels etc.”

This PR splits daily commute / vehicle costs from vacation Travel by adding a top-level `transportation` category and reparenting existing rows instead of duplicating them.

| Before | After | UUID behavior |
| --- | --- | --- |
| `fuel` (top-level) | `transportation` > `transportation-fuel` | existing UUID preserved via `UPDATE` |
| `travel` > `travel-transit` | `transportation` > `transportation-public-transit` | existing UUID preserved via `UPDATE` |
| — | `transportation` > `transportation-insurance` | new |
| — | `transportation` > `transportation-maintenance` | new |
| — | `transportation` > `transportation-registration` | new |

## Changes

- Adds Supabase migration `20260530055800_add_transportation_category.sql`.
- Backfills existing `credit_card_transactions` and `merchant_category_mappings` so old Fuel / Public Transit categorizations now resolve under Transportation.
- Updates McManus YAML rules:
  - moves fuel station patterns under `transportation-fuel`
  - moves bus/train/Rav Kav patterns under `transportation-public-transit`
  - moves licensing/MOT/government-registration patterns under `transportation-registration`
  - adds starter car insurance and maintenance patterns with RTL annotations
- Updates deterministic sector mapping so issuer sector `קלד` resolves to `transportation` + `transportation-fuel`.
- Updates frontend static category tree and e2e fixtures for the renamed slugs.
- Adds regression coverage for Transportation fuel sector and commute-vs-travel rule split.
- Prior art: `supabase/migrations/20260529122501_seed_expense_categories.sql`.

## Migration notes

- No deletes; `fuel` and `travel-transit` are UUID-preserving `UPDATE`s.
- Row count becomes 39 locally: existing 35 + new `transportation` parent + 3 new subcategories.
- Commit includes `[apply-migrations]`, so Kujan's workflow should auto-apply on merge.

## Validation

- `supabase start` applied all migrations including `20260530055800_add_transportation_category.sql` successfully.
- Verified local taxonomy:
  - `expense_categories` count = 39
  - `fuel` and `travel-transit` no longer exist as slugs
  - `transportation` has 5 children: fuel, public transport, insurance, maintenance, registration
- Replayed migration statements locally to verify idempotence; count stayed 39.
- `cd apps/backend && uv run pytest tests/credit_card_pipeline -v` → 65 passed, 48 skipped, 1 xfailed.
- `cd apps/frontend && npx tsc --noEmit` still fails on pre-existing unrelated repo errors; no errors mention touched files (`src/types/expenses`, `e2e/fixtures/expenses`, `e2e/expenses/03-by-category`).

## Post-merge verification for Jony

Previously categorized Fuel transactions should now display as Transportation > Fuel, and prior Travel > Public Transit & Licensing rows should display as Transportation > Public Transport.